### PR TITLE
Remove an unused namespace

### DIFF
--- a/src/Http/HttpRequestContext.cs
+++ b/src/Http/HttpRequestContext.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using Google.Protobuf.Collections;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker
 {


### PR DESCRIPTION
Remove an unused namespace in `HttpRequestContext.cs`.