### PR TITLE
switch to pattern matching and support all other TypedData types

### DIFF
--- a/test/Utility/TypeExtensionsTests.cs
+++ b/test/Utility/TypeExtensionsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 
 using Google.Protobuf;
 using Google.Protobuf.Collections;
@@ -314,10 +315,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(expected, input.ToTypedData());
         }
 
-        [Fact(Skip = "Int gets interpreted as byte[]")]
+        [Fact]
         public void TestObjectToTypedDataInt()
         {
-            var data = (long)1;
+            var data = 1;
 
             var input = (object)data;
             var expected = new TypedData
@@ -328,7 +329,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(expected, input.ToTypedData());
         }
 
-        [Fact(Skip = "Double gets interpreted as byte[]")]
+        [Fact]
         public void TestObjectToTypedDataDouble()
         {
             var data = 1.1;
@@ -370,18 +371,20 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(expected, input.ToTypedData());
         }
 
-        [Fact(Skip = "Stream gets interpreted as Bytes")]
+        [Fact]
         public void TestObjectToTypedDataStream()
         {
-            var data = ByteString.CopyFromUtf8("Hello World!").ToByteArray();
-
-            var input = (object)data;
-            var expected = new TypedData
+            using(MemoryStream data = new MemoryStream(100))
             {
-                Stream = ByteString.CopyFrom(data)
-            };
 
-            Assert.Equal(expected, input.ToTypedData());
+                var input = (object)data;
+                var expected = new TypedData
+                {
+                    Stream = ByteString.FromStream(data)
+                };
+
+                Assert.Equal(expected, input.ToTypedData());
+            }
         }
 
         [Fact]


### PR DESCRIPTION
fixes #30 

This switches from using `LanguagePrimatives.TryConvertTo` to a pattern matching `switch` statement.

If we can't guess what it is, just turn it into a string and go with that.

This also reenables all tests 😄 they all pass!