### PR TITLE
add psm1 support

### DIFF
--- a/src/worker.config.json
+++ b/src/worker.config.json
@@ -1,7 +1,7 @@
 {
     "description":{
         "language":"powershell",
-        "extensions":[".ps1"],
+        "extensions":[".ps1", ".psm1"],
         "defaultExecutablePath":"dotnet",
         "defaultWorkerPath":"Microsoft.Azure.Functions.PowerShellWorker.dll"
     }


### PR DESCRIPTION
I'm going to defer any fancy entry point checking for #15 

This allows a user to use a psm1 - they just need to make sure they specify an entrypoint and export that module member.

fixes #46 