### PR TITLE
initial refactor of logger

### DIFF
--- a/src/Logging/ILogger.cs
+++ b/src/Logging/ILogger.cs
@@ -1,0 +1,15 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
+{
+    internal abstract class ILogger
+    {
+        public abstract void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false);
+    }
+}

--- a/src/Messaging/RpcLogger.cs
+++ b/src/Messaging/RpcLogger.cs
@@ -11,7 +11,7 @@ using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
-    internal class RpcLogger : IDisposable
+    internal class RpcLogger : ILogger, IDisposable
     {
         private const string SystemLogPrefix = "LanguageWorkerConsoleLog";
         private MessagingStream _msgStream;
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             _invocationId = null;
         }
 
-        public async void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false)
+        public override async void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false)
         {
             var invocationId = _invocationId ?? "N/A";
             if (isUserLog)

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
     {
         private const string _TriggerMetadataParameterName = "TriggerMetadata";
 
-        private RpcLogger _logger;
+        private ILogger _logger;
         private PowerShell _pwsh;
 
-        internal PowerShellManager(RpcLogger logger)
+        internal PowerShellManager(ILogger logger)
         {
             var initialSessionState = InitialSessionState.CreateDefault();
             

--- a/src/PowerShell/StreamHandler.cs
+++ b/src/PowerShell/StreamHandler.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
     internal class StreamHandler
     {
-        RpcLogger _logger;
+        ILogger _logger;
 
-        public StreamHandler(RpcLogger logger)
+        public StreamHandler(ILogger logger)
         {
             _logger = logger;
         }

--- a/src/Utility/ExecutionTimer.cs
+++ b/src/Utility/ExecutionTimer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         [ThreadStatic]
         static Stopwatch s_threadStaticStopwatch;
 
-        readonly RpcLogger _logger;
+        readonly ILogger _logger;
         readonly string _message;
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         /// <param name="message">The message to prefix the execution time with.</param>
         /// <returns>A new, started execution timer.</returns>
         public static ExecutionTimer Start(
-            RpcLogger logger,
+            ILogger logger,
             string message)
         {
             var timer = new ExecutionTimer(logger, message);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         }
 
         internal ExecutionTimer(
-            RpcLogger logger,
+            ILogger logger,
             string message)
         {
             _logger = logger;

--- a/test/Logging/ConsoleLogger.cs
+++ b/test/Logging/ConsoleLogger.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Azure.Functions.PowerShellWorker.Utility;
+using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test
+{
+    internal class ConsoleLogger : ILogger
+    {
+        public List<string> FullLog = new List<string>();
+
+        public override void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false)
+        {
+            var log = $"{logLevel}: {message}";
+            Console.WriteLine(log);
+            FullLog.Add(log);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -18,4 +18,12 @@
     <ProjectReference Include="..\src\Microsoft.Azure.Functions.PowerShellWorker.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="Requests\ProcessFunctionLoadRequestTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="PowerShell\testFunction.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/PowerShell/PowerShellExtensionsTests.cs
+++ b/test/PowerShell/PowerShellExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.ObjectModel;
+
+using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test
+{
+    using System.Management.Automation;
+
+    public class PowerShellExtensionsTests
+    {
+        [Fact]
+        public void CanInvokeAndClearCommands()
+        {
+            var pwsh = PowerShell.Create().AddCommand("Get-Process");
+            Assert.Single(pwsh.Commands.Commands);
+
+            pwsh.InvokeAndClearCommands();
+            Assert.Empty(pwsh.Commands.Commands);
+        }
+
+        [Fact]
+        public void CanInvokeAndClearCommandsWithReturnValue()
+        {
+            var data = 5;
+            var pwsh = PowerShell.Create().AddScript($"function Get-Value() {{ {data} }}; Get-Value");
+            Assert.Single(pwsh.Commands.Commands);
+
+            Collection<int> results = pwsh.InvokeAndClearCommands<int>();
+            Assert.Empty(pwsh.Commands.Commands);
+
+            Assert.Single(results, data);
+        }
+    }
+}

--- a/test/PowerShell/PowerShellManagerTests.cs
+++ b/test/PowerShell/PowerShellManagerTests.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test
+{
+    public class PowerShellManagerTests
+    {
+        [Fact]
+        public void InitializeRunspaceSuccess()
+        {
+            var logger = new ConsoleLogger();
+            var manager = new PowerShellManager(logger);
+            manager.InitializeRunspace();
+
+            Assert.Single(logger.FullLog);
+            Assert.Equal("Warning: Required environment variables to authenticate to Azure were not present", logger.FullLog[0]);
+        }
+    }
+}

--- a/test/PowerShell/testFunction.ps1
+++ b/test/PowerShell/testFunction.ps1
@@ -1,0 +1,3 @@
+﻿param ($Req, $TriggerMetadata)
+
+Push-OutputBinding -Name res -Value foo

--- a/test/Requests/ProcessWorkerInitRequestTests.cs
+++ b/test/Requests/ProcessWorkerInitRequestTests.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.Azure.Functions.PowerShellWorker;
-using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Xunit;
 


### PR DESCRIPTION
@daxian-dbw here are a few more tests... I've refactored the logger a bit so that we can test the worker using a `ConsoleLogger` that doesn't rely on gRPC.

Let me know what you think of this initial refactor.