### PR TITLE
set build number in CI

### DIFF
--- a/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
@@ -10,7 +10,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5100;NU5123</NoWarn>
 
+    <BuildNumber Condition="$(APPVEYOR) != ''">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
+    <BuildNumber Condition="$(APPVEYOR) == ''">9999</BuildNumber>
+
     <NuspecFile>Microsoft.Azure.Functions.PowerShellWorker.nuspec</NuspecFile>
-    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework)</NuspecProperties>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);BuildNumber=$(BuildNumber)</NuspecProperties>
   </PropertyGroup>
 </Project>

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Microsoft.Azure.Functions.PowerShellWorker</id>
-    <version>0.1.0</version>
+    <version>0.1.$BuildNumber$-alpha</version>
     <title>Azure Function PowerShell Language Worker</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
For the Deploy to work in AppVeyor, we need to set the build number to the patch version.

@pragnagopa has asked that the version generated be in the following format:

0.1.BUILD_NUMBER-alpha