### PR TITLE
Remove `powershell-core` feed from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" /> 
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
     <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" /> 
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
     <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
     <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />


### PR DESCRIPTION
Remove `powershell-core` feed from NuGet.config.
I think it's OK to remove it, but will wait on the CIs.