### PR TITLE
Durable functions - 'Function chaining' scenario support

### DIFF
--- a/src/Durable/Actions.cs
+++ b/src/Durable/Actions.cs
@@ -1,0 +1,139 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Action
+{
+    /// <summary>
+    /// Action types
+    /// </summary>
+    public enum ActionType
+    {
+        /// <summary>
+        /// Call an activity function.
+        /// </summary>
+        CallActivity = 0,
+
+        /// <summary>
+        /// Call an activity function with retry.
+        /// </summary>
+        CallActivityWithRetry = 1,
+
+        /// <summary>
+        /// Call a sub-orchestration function.
+        /// </summary>
+        CallSubOrchestrator = 2,
+
+        /// <summary>
+        /// Call a sub-orchestration function with retry.
+        /// </summary>
+        CallSubOrchestratorWithRetry = 3,
+
+        /// <summary>
+        /// Run the orchestration function as a loop.
+        /// </summary>
+        ContinueAsNew = 4,
+
+        /// <summary>
+        /// Create a timer.
+        /// </summary>
+        CreateTimer = 5,
+
+        /// <summary>
+        /// Wait for an external event.
+        /// </summary>
+        WaitForExternalEvent = 6,
+    }
+
+    /// <summary>
+    /// Base class that represents an orchestration action.
+    /// </summary>
+    public abstract class AzAction
+    {
+        /// <summary>
+        /// Base constructor for creating an action.
+        /// </summary>
+        protected AzAction(ActionType actionType)
+        {
+            ActionType = actionType;
+        }
+
+        /// <summary>
+        /// Action type.
+        /// </summary>
+        public readonly ActionType ActionType;
+    }
+
+    /// <summary>
+    /// An orchestration action that represents calling an activity function.
+    /// </summary>
+    public class CallActivityAction : AzAction
+    {
+        /// <summary>
+        /// The activity function name.
+        /// </summary>
+        public readonly string FunctionName;
+        
+        /// <summary>
+        /// The input to the activity function.
+        /// </summary>
+        public readonly object Input;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal CallActivityAction(string functionName, object input) : base(ActionType.CallActivity)
+        {
+            FunctionName = functionName;
+            Input = input;
+        }
+    }
+
+    /// <summary>
+    /// An orchestration action that represents creating a timer.
+    /// </summary>
+    public class CreateTimerAction : AzAction
+    {
+        /// <summary>
+        /// Time to fire the timer.
+        /// </summary>
+        public readonly DateTime FireAt;
+
+        /// <summary>
+        /// Indicate if the timer is cancelled.
+        /// </summary>
+        public readonly bool IsCanceled;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        internal CreateTimerAction(DateTime fireAt, bool isCanceled) : base(ActionType.CreateTimer)
+        {
+            FireAt = fireAt;
+            IsCanceled = isCanceled;
+        }
+    }
+
+    /// <summary>
+    /// An orchestration action that represents waiting for an external event.
+    /// </summary>
+    public class WaitForExternalEventAction : AzAction
+    {
+        /// <summary>
+        /// Name of the external event.
+        /// </summary>
+        public readonly string ExternalEventName;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        internal WaitForExternalEventAction(string externalEventName) : base(ActionType.WaitForExternalEvent)
+        {
+            ExternalEventName = externalEventName;
+        }
+    }
+}

--- a/src/Durable/HistoryEvent.cs
+++ b/src/Durable/HistoryEvent.cs
@@ -1,0 +1,145 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.History
+{
+    [DataContract]
+    internal class HistoryEvent
+    {
+        #region Common_Fields
+
+        [DataMember]
+        internal int EventId { get; set; }
+        [DataMember]
+        internal bool IsPlayed { get; set; }
+        [DataMember]
+        internal DateTime Timestamp { get; set; }
+        [DataMember]
+        internal EventType EventType { get; set; }
+
+        #endregion
+
+        #region Timer_Event_Fields
+
+        [DataMember]
+        internal DateTime FireAt { get; set; }
+        [DataMember]
+        internal int TimerId { get; set; }
+
+        #endregion
+
+        #region Overloaded_Fields
+
+        [DataMember]
+        internal int TaskScheduledId { get; set; }
+        [DataMember]
+        internal string Input { get; set; }
+        [DataMember]
+        internal string Name { get; set; }
+        [DataMember]
+        internal string Result { get; set; }
+
+        #endregion
+
+        // Internal used only
+        internal bool IsProcessed { get; set; }
+    }
+
+    internal enum EventType
+    {
+        /// <summary>
+        /// Orchestration execution has started event
+        /// </summary>
+        ExecutionStarted,
+
+        /// <summary>
+        /// Orchestration execution has completed event
+        /// </summary>
+        ExecutionCompleted,
+
+        /// <summary>
+        /// Orchestration execution has failed event
+        /// </summary>
+        ExecutionFailed,
+
+        /// <summary>
+        /// Orchestration was terminated event
+        /// </summary>
+        ExecutionTerminated,
+
+        /// <summary>
+        /// Task Activity scheduled event 
+        /// </summary>
+        TaskScheduled,
+
+        /// <summary>
+        /// Task Activity completed event
+        /// </summary>
+        TaskCompleted,
+
+        /// <summary>
+        /// Task Activity failed event
+        /// </summary>
+        TaskFailed,
+
+        /// <summary>
+        /// Sub Orchestration instance created event
+        /// </summary>
+        SubOrchestrationInstanceCreated,
+
+        /// <summary>
+        /// Sub Orchestration instance completed event
+        /// </summary>
+        SubOrchestrationInstanceCompleted,
+
+        /// <summary>
+        /// Sub Orchestration instance failed event
+        /// </summary>
+        SubOrchestrationInstanceFailed,
+
+        /// <summary>
+        /// Timer created event
+        /// </summary>
+        TimerCreated,
+
+        /// <summary>
+        /// Timer fired event
+        /// </summary>
+        TimerFired,
+
+        /// <summary>
+        /// Orchestration has started event
+        /// </summary>
+        OrchestratorStarted,
+
+        /// <summary>
+        /// Orchestration has completed event
+        /// </summary>
+        OrchestratorCompleted,
+
+        /// <summary>
+        /// External Event raised to orchestration event
+        /// </summary>
+        EventRaised,
+
+        /// <summary>
+        /// Orchestration Continued as new event
+        /// </summary>
+        ContinueAsNew,
+
+        /// <summary>
+        /// Generic event for tracking event existence
+        /// </summary>
+        GenericEvent,
+
+        /// <summary>
+        /// Orchestration state history event
+        /// </summary>
+        HistoryState,
+    }
+}

--- a/src/Durable/InvokeActivityFunctionCommand.cs
+++ b/src/Durable/InvokeActivityFunctionCommand.cs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Threading;
+
+using Newtonsoft.Json;
+using Microsoft.Azure.Functions.PowerShellWorker.Action;
+using Microsoft.Azure.Functions.PowerShellWorker.History;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Commands
+{
+    /// <summary>
+    /// Invoke a function asynchronously.
+    /// </summary>
+    [Cmdlet("Invoke", "ActivityFunctionAsync")]
+    public class InvokeActivityFunctionCommand : PSCmdlet
+    {
+        /// <summary>
+        /// Gets and sets the activity function name.
+        /// </summary>
+        [Parameter(Mandatory = true)]
+        public string FunctionName { get; set; }
+
+        /// <summary>
+        /// Gets and sets the input for an activity function.
+        /// </summary>
+        /// <remarks>
+        /// Copy the default value from durable-js, in case that it's a magic value for specifying no input value.
+        /// </remarks>
+        [Parameter]
+        [ValidateNotNull]
+        public object Input { get; set; } = "__activity__default";
+
+        // Used for waiting on the pipeline to be stopped.
+        private ManualResetEvent waitForStop = new ManualResetEvent(initialState: false);
+        private OrchestrationContext context;
+
+        /// <summary>
+        /// Implement the EndProcessing method.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            var privateData = (Hashtable)this.MyInvocation.MyCommand.Module.PrivateData;
+            context = (OrchestrationContext)privateData[SetFunctionInvocationContextCommand.ContextKey];
+
+            context.Actions.Add(new List<AzAction>() { new CallActivityAction(FunctionName, Input) });
+
+            HistoryEvent taskScheduled = context.History
+                .FirstOrDefault(e => e.EventType == EventType.TaskScheduled &&
+                                e.Name == FunctionName &&
+                                !e.IsProcessed);
+
+            HistoryEvent taskCompleted = taskScheduled == null ? null : context.History
+                .FirstOrDefault(e => e.EventType == EventType.TaskCompleted &&
+                                e.TaskScheduledId == taskScheduled.EventId);
+
+            if (taskCompleted != null)
+            {
+                taskScheduled.IsProcessed = true;
+                taskCompleted.IsProcessed = true;
+                WriteObject(taskCompleted.Result);
+            }
+            else
+            {
+                context.ActionEvent.Set();
+                waitForStop.WaitOne();
+            }
+        }
+
+        /// <summary>
+        /// Implement the StopProcessing method.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            waitForStop.Set();
+        }
+    }
+}

--- a/src/Durable/InvokeActivityFunctionCommand.cs
+++ b/src/Durable/InvokeActivityFunctionCommand.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Newtonsoft.Json;
 using Microsoft.Azure.Functions.PowerShellWorker.Action;
 using Microsoft.Azure.Functions.PowerShellWorker.History;
+using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Commands
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Commands
             {
                 taskScheduled.IsProcessed = true;
                 taskCompleted.IsProcessed = true;
-                WriteObject(taskCompleted.Result);
+                WriteObject(TypeExtensions.DeserializeJson(taskCompleted.Result));
             }
             else
             {

--- a/src/Durable/Orchestration.cs
+++ b/src/Durable/Orchestration.cs
@@ -1,0 +1,88 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading;
+
+using Microsoft.Azure.Functions.PowerShellWorker.History;
+using Microsoft.Azure.Functions.PowerShellWorker.Action;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker
+{
+    /// <summary>
+    /// Represent the context of an execution of an orchestration function.
+    /// </summary>
+    [DataContract]
+    public class OrchestrationContext
+    {
+        [DataMember]
+        internal object Input { get; set; }
+
+        [DataMember]
+        internal string InstanceId { get; set; }
+
+        [DataMember]
+        internal string ParentInstanceId { get; set; }
+
+        [DataMember]
+        internal bool IsReplaying { get; set; }
+
+        [DataMember]
+        internal HistoryEvent[] History { get; set; }
+
+        internal AutoResetEvent ActionEvent { get; set; }
+
+        internal List<List<AzAction>> Actions { get; } = new List<List<AzAction>>();
+
+        /// <summary>
+        /// Gets the input of the current orchestrator function as a deserialized value.
+        /// </summary>
+        /// <returns>The deserialized input value.</returns>
+        public object GetInput()
+        {
+            return Input;
+        }
+
+        /// <summary>
+        /// Gets the current date/time in a way that is safe for use by orchestrator functions.
+        /// </summary>
+        /// <remarks>
+        /// This date/time value is derived from the orchestration history. It always returns the same value
+        /// at specific points in the orchestrator function code, making it deterministic and safe for replay.
+        /// </remarks>
+        /// <value>The orchestration's current date/time in UTC.</value>
+        public DateTime CurrentUtcDateTime { get; internal set; }
+    }
+
+    /// <summary>
+    /// Represent an orchestration message to be sent to the host.
+    /// </summary>
+    public class OrchestrationMessage
+    {
+        internal OrchestrationMessage(bool isDone, List<List<AzAction>> actions, object output)
+        {
+            IsDone = isDone;
+            Actions = actions;
+            Output = output;
+        }
+
+        /// <summary>
+        /// Indicate whether the orchestration is done.
+        /// </summary>
+        public readonly bool IsDone;
+
+        /// <summary>
+        /// Orchestration actions to be taken.
+        /// </summary>
+        public readonly List<List<AzAction>> Actions;
+
+        /// <summary>
+        /// The output result of the orchestration function run.
+        /// </summary>
+        public readonly object Output;
+    }
+}

--- a/src/Durable/SetFunctionInvocationContext.cs
+++ b/src/Durable/SetFunctionInvocationContext.cs
@@ -1,0 +1,60 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections;
+using System.Management.Automation;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Commands
+{
+    /// <summary>
+    /// Set the orchestration context.
+    /// </summary>
+    [Cmdlet("Set", "FunctionInvocationContext")]
+    public class SetFunctionInvocationContextCommand : PSCmdlet
+    {
+        internal const string ContextKey = "OrchestrationContext";
+        internal const string StarterKey = "OrchestrationStarter";
+
+        /// <summary>
+        /// Gets and sets the orchestration context.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = ContextKey)]
+        public OrchestrationContext OrchestrationContext { get; set; }
+
+        /// <summary>
+        /// Gets and sets the orchestration client output binding name.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = StarterKey)]
+        public string OrchestrationStarter { get; set; }
+
+        /// <summary>
+        /// Gets and sets the orchestration context.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "Clear")]
+        public SwitchParameter Clear { get; set; }
+
+        /// <summary>
+        /// EndProcessing
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            var privateData = (Hashtable)this.MyInvocation.MyCommand.Module.PrivateData;
+            switch (this.ParameterSetName)
+            {
+                case ContextKey:
+                    privateData[ContextKey] = OrchestrationContext; break;
+                case StarterKey:
+                    privateData[StarterKey] = OrchestrationStarter; break;
+                default:
+                    if (Clear.IsPresent)
+                    {
+                        privateData.Remove(ContextKey);
+                        privateData.Remove(StarterKey);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
     internal class AzFunctionInfo
     {
+        private const string OrchestrationClient = "orchestrationClient";
         private const string OrchestrationTrigger = "orchestrationTrigger";
         private const string ActivityTrigger = "activityTrigger";
 
@@ -51,6 +52,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         internal readonly string EntryPoint;
         internal readonly string FunctionName;
         internal readonly string ScriptPath;
+        internal readonly string OrchestrationClientBindingName;
         internal readonly AzFunctionType Type;
         internal readonly MapField<string, BindingInfo> AllBindings;
         internal readonly MapField<string, BindingInfo> OutputBindings;
@@ -92,6 +94,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
                 if (bindingInfo.Direction == BindingInfo.Types.Direction.Out)
                 {
+                    if (bindingInfo.Type == OrchestrationClient)
+                    {
+                        OrchestrationClientBindingName = bindingName;
+                    }
                     OutputBindings.Add(bindingName, bindingInfo);
                 }
             }

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -1,8 +1,5 @@
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'Microsoft.Azure.Functions.PowerShellWorker.psm1'
-
 # Version number of this module.
 ModuleVersion = '0.1.0'
 
@@ -43,13 +40,13 @@ TypesToProcess = @()
 FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-NestedModules = @()
+NestedModules = @('Microsoft.Azure.Functions.PowerShellWorker.psm1', 'Microsoft.Azure.Functions.PowerShellWorker.dll')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('Push-OutputBinding', 'Get-OutputBinding')
+FunctionsToExport = @('Push-OutputBinding', 'Get-OutputBinding', 'Start-NewOrchestration')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @()
+CmdletsToExport = @('Set-FunctionInvocationContext', 'Invoke-ActivityFunctionAsync')
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -130,3 +130,62 @@ function Push-OutputBinding {
         }
     }
 }
+
+<#
+.SYNOPSIS
+    Start an orchestration Azure Function.
+.DESCRIPTION
+    Start an orchestration Azure Function with the given function name and input value.
+    It requires an output binding of the type 'orchestrationClient' is defined for the caller Azure Function.
+    If no such output binding is defined, this function throws an exception.
+.EXAMPLE
+    PS > Start-NewOrchestration -Name starter -InputObject "input value for the orchestration function"
+    Return the instance id of the new orchestration.
+.PARAMETER FunctionName
+    The name of the orchestration Azure Function you want to start.
+.PARAMETER InputObject
+    The input value that will be passed to the orchestration Azure Function.
+.PARAMETER Force
+    (Optional) If specified, will force the metadata to be updated for the orchestration Azure Function.
+#>
+function Start-NewOrchestration {
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Mandatory=$true,
+            Position=0,
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $FunctionName,
+
+        [Parameter(
+            Position=2,
+            ValueFromPipelineByPropertyName=$true)]
+        [object] $InputObject,
+
+        [switch] $Force
+    )
+
+    $privateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData
+    if ($privateData -is [hashtable])
+    {
+        $starterName = $privateData["OrchestrationStarter"]
+    }
+
+    if ($null -ne $starterName)
+    {
+        $instanceId = (New-Guid).Guid
+        $value = ,@{
+            FunctionName = $FunctionName
+            Input = $InputObject
+            InstanceId = $instanceId
+        }
+
+        $value = ConvertTo-Json -InputObject $value -Depth 10 -Compress
+        Push-KeyValueOutputBinding -Name $starterName -Value $value -Force:$Force.IsPresent
+        return $instanceId
+    }
+    else
+    {
+        throw "Cannot start an orchestration function. No output binding of the type 'orchestrationClient' was defined."
+    }
+}

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
         private static JsonSerializerSettings setting =
             new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None, MaxDepth = 10 };
-        private static object DeserializeJson(string json)
+        internal static object DeserializeJson(string json)
         {
             var obj = JsonConvert.DeserializeObject(json, setting);
             switch (obj)

--- a/test/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -11,7 +11,10 @@ Describe 'Azure Functions PowerShell Langauge Worker Helper Module Tests' {
         $workerDll = Get-ChildItem -Path $binFolder -Filter "Microsoft.Azure.Functions.PowerShellWorker.dll" -Recurse | Select-Object -First 1
 
         $moduleFolder = Join-Path -Path $workerDll.Directory.FullName -ChildPath "Modules\Microsoft.Azure.Functions.PowerShellWorker"
-        $modulePath = Join-Path -Path $moduleFolder -ChildPath "Microsoft.Azure.Functions.PowerShellWorker.psd1"
+        $pubFolder = Join-Path -Path $workerDll.Directory.FullName -ChildPath "publish"
+        Copy-Item -Path $moduleFolder/* -Destination $pubFolder -ErrorAction SilentlyContinue
+
+        $modulePath = Join-Path -Path $pubFolder -ChildPath "Microsoft.Azure.Functions.PowerShellWorker.psd1"
         Import-Module $modulePath
 
         # Helper function that tests hashtable equality


### PR DESCRIPTION
### Purpose of the PR

The purpose is to seek feedback and also transfer my learnings to @tylerl0706 
Not seeking to merge to `/dev` branch, as the durable function is not in scope for the private preview (maybe not even in the scope of the public preview).

But since I started the investigation, it's a better use of my time to finish it, to some extent, so that we don't lose the learnings and related knowledge.

### Summary

This is the initial changes to support the ["Function Chaining"](https://docs.microsoft.com/en-us/azure/azure-functions/durable-functions-overview#pattern-1-function-chaining) pattern of the durable function.

The main work involved are from two aspects:
1. Figure out a mechanism for powershell worker to be able to stop in the middle of an execution, discard the current execution, and replay the execution when needed.
2. Figure out the [out-of-proc execution protocol](https://github.com/Azure/azure-functions-durable-extension/wiki/Out-of-Proc-Orchestrator-Execution-Schema-Reference) used by [durable-js](https://github.com/Azure/azure-functions-durable-js).

For **(1)**, the solution is to take advantage of the async invocation APIs `BeginInvoke`, `EndInvoke` and `Stop`. An `AutoResetEvent` named `actionEvent` is added to `PowerShellManager`, which will be passed to `Invoke-ActivityFunctionAsync` along with the history events. Once `PowerShellManager` starts the execution of an orchestration function by `BeginInvoke`, it will get an `AsyncResult` object back, then it will wait on either `actionEvent` or `asyncResult.AsyncWaitHandle` to be set. 
- If the former is set, that means the `Invoke-ActivityFunctionAsync` is requesting for scheduling a new activity, and `PowerShellManager` will stop the execution by calling `Stop()` and handle the requested actions.
- If the latter is set, that means the orchestration function has run to completion.

Inside the `Invoke-ActivityFunction`, based on the history events, if it needs to schedule an activity function, then it creates actions and attaches them to the context object; if the activity function already completes, then it's a replay, and it just writes the result to the pipeline.

For **(2)**, I mimic the implementation of `durable-js` on how to handle messages related to durable function execution.