### PR TITLE
Bug fixes and code refactoring to get it ready for durable function support

### DIFF
--- a/src/PowerShell/PowerShellExtensions.cs
+++ b/src/PowerShell/PowerShellExtensions.cs
@@ -13,15 +13,29 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
     {
         public static void InvokeAndClearCommands(this PowerShell pwsh)
         {
-            pwsh.Invoke();
-            pwsh.Commands.Clear();
+            try
+            {
+                pwsh.Invoke();
+            }
+            finally
+            {
+                pwsh.Streams.ClearStreams();
+                pwsh.Commands.Clear();
+            }
         }
 
         public static Collection<T> InvokeAndClearCommands<T>(this PowerShell pwsh)
         {
-            var result = pwsh.Invoke<T>();
-            pwsh.Commands.Clear();
-            return result;
+            try
+            {
+                var result = pwsh.Invoke<T>();
+                return result;
+            }
+            finally
+            {
+                pwsh.Streams.ClearStreams();
+                pwsh.Commands.Clear();
+            }
         }
     }
 }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 // If an entry point is defined, we load the script as a module and invoke the function with that name.
                 // We also need to fetch the ParameterMetadata to know what to pass in as arguments.
                 var parameterMetadata = RetriveParameterMetadata(functionInfo, out moduleName);
-                _pwsh.AddCommand(String.IsNullOrEmpty(entryPoint) ? scriptPath : $@"{moduleName}\{entryPoint}");
+                _pwsh.AddCommand(String.IsNullOrEmpty(entryPoint) ? scriptPath : entryPoint);
 
                 // Set arguments for each input binding parameter
                 foreach (ParameterBinding binding in inputData)
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     moduleName = Path.GetFileNameWithoutExtension(scriptPath);
                     return _pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module").AddParameter("Name", scriptPath)
                                 .AddStatement()
-                                .AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", $"{moduleName}\\{entryPoint}")
+                                .AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", entryPoint)
                                 .InvokeAndClearCommands<FunctionInfo>()[0].Parameters;
                 }
             }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -21,10 +21,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
     internal class PowerShellManager
     {
-        private const string _TriggerMetadataParameterName = "TriggerMetadata";
-
-        private ILogger _logger;
-        private PowerShell _pwsh;
+        private readonly ILogger _logger;
+        private readonly PowerShell _pwsh;
 
         internal PowerShellManager(ILogger logger)
         {
@@ -88,104 +86,128 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             // Add HttpResponseContext namespace so users can reference
             // HttpResponseContext without needing to specify the full namespace
             _pwsh.AddScript($"using namespace {typeof(HttpResponseContext).Namespace}").InvokeAndClearCommands();
-            
+
             // Set the PSModulePath
             Environment.SetEnvironmentVariable("PSModulePath", Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules"));
 
             AuthenticateToAzure();
         }
 
+        /// <summary>
+        /// Execution a function fired by a trigger or an activity function scheduled by an orchestration.
+        /// </summary>
         internal Hashtable InvokeFunction(
-            string scriptPath,
-            string entryPoint,
+            AzFunctionInfo functionInfo,
             Hashtable triggerMetadata,
             IList<ParameterBinding> inputData)
         {
+            string scriptPath = functionInfo.ScriptPath;
+            string entryPoint = functionInfo.EntryPoint;
+            string moduleName = null;
+
             try
             {
-                Dictionary<string, ParameterMetadata> parameterMetadata;
+                // If an entry point is defined, we load the script as a module and invoke the function with that name.
+                // We also need to fetch the ParameterMetadata to know what to pass in as arguments.
+                var parameterMetadata = RetriveParameterMetadata(functionInfo, out moduleName);
+                _pwsh.AddCommand(String.IsNullOrEmpty(entryPoint) ? scriptPath : $@"{moduleName}\{entryPoint}");
 
-                // We need to take into account if the user has an entry point.
-                // If it does, we invoke the command of that name. We also need to fetch
-                // the ParameterMetadata so that we can tell whether or not the user is asking
-                // for the $TriggerMetadata
-                using (ExecutionTimer.Start(_logger, "Parameter metadata retrieved."))
-                {
-                    if (entryPoint != "")
-                    {
-                        parameterMetadata = _pwsh
-                            .AddCommand("Microsoft.PowerShell.Core\\Import-Module").AddParameter("Name", scriptPath)
-                            .AddStatement()
-                            .AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", entryPoint)
-                            .InvokeAndClearCommands<FunctionInfo>()[0].Parameters;
-
-                        _pwsh.AddCommand(entryPoint);
-
-                    }
-                    else
-                    {
-                        parameterMetadata = _pwsh.AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", scriptPath)
-                            .InvokeAndClearCommands<ExternalScriptInfo>()[0].Parameters;
-
-                        _pwsh.AddCommand(scriptPath);
-                    }
-                }
-
-                // Sets the variables for each input binding
+                // Set arguments for each input binding parameter
                 foreach (ParameterBinding binding in inputData)
                 {
-                    _pwsh.AddParameter(binding.Name, binding.Data.ToObject());
+                    if (parameterMetadata.ContainsKey(binding.Name))
+                    {
+                        _pwsh.AddParameter(binding.Name, binding.Data.ToObject());
+                    }
                 }
 
                 // Gives access to additional Trigger Metadata if the user specifies TriggerMetadata
-                if(parameterMetadata.ContainsKey(_TriggerMetadataParameterName))
+                if(parameterMetadata.ContainsKey(AzFunctionInfo.TriggerMetadata))
                 {
-                    _pwsh.AddParameter(_TriggerMetadataParameterName, triggerMetadata);
-                    _logger.Log(LogLevel.Debug, $"TriggerMetadata found. Value:{Environment.NewLine}{triggerMetadata.ToString()}");
+                    _logger.Log(LogLevel.Debug, "Parameter '-TriggerMetadata' found.");
+                    _pwsh.AddParameter(AzFunctionInfo.TriggerMetadata, triggerMetadata);
                 }
 
-                PSObject returnObject = null;
+                Collection<object> pipelineItems = null;
                 using (ExecutionTimer.Start(_logger, "Execution of the user's function completed."))
                 {
-                    // Log everything we received from the pipeline and set the last one to be the ReturnObject
-                    Collection<PSObject> pipelineItems = _pwsh.InvokeAndClearCommands<PSObject>();
-                    if (pipelineItems.Count > 0)
-                    {
-                        foreach (var psobject in pipelineItems)
-                        {
-                            _logger.Log(LogLevel.Information, $"OUTPUT: {psobject.ToString()}");
-                        }
-                        returnObject =  pipelineItems[pipelineItems.Count - 1];
-                    }
+                    pipelineItems = _pwsh.InvokeAndClearCommands<object>();
                 }
-                
-                var result = _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Get-OutputBinding")
-                    .AddParameter("Purge")
-                    .InvokeAndClearCommands<Hashtable>()[0];
 
-                if(returnObject != null)
+                var result = _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Get-OutputBinding")
+                                  .AddParameter("Purge")
+                                  .InvokeAndClearCommands<Hashtable>()[0];
+
+                if (pipelineItems != null && pipelineItems.Count > 0)
                 {
-                    result.Add("$return", returnObject);
+                    // Log everything we received from the pipeline and set the last one to be the ReturnObject
+                    foreach (var item in pipelineItems)
+                    {
+                        _logger.Log(LogLevel.Information, $"OUTPUT: {item.ToString()}");
+                    }
+                    result.Add(AzFunctionInfo.DollarReturn, pipelineItems[pipelineItems.Count - 1]);
                 }
+
                 return result;
             }
             finally
             {
-                ResetRunspace(scriptPath);
+                ResetRunspace(moduleName);
             }
         }
 
-        private void ResetRunspace(string scriptPath)
+        /// <summary>
+        /// Helper method to convert the result returned from a function to JSON.
+        /// </summary>
+        internal string ConvertToJson(object fromObj)
+        {
+            return _pwsh.AddCommand("Microsoft.PowerShell.Utility\\ConvertTo-Json")
+                        .AddParameter("InputObject", fromObj)
+                        .AddParameter("Depth", 10)
+                        .AddParameter("Compress", true)
+                        .InvokeAndClearCommands<string>()[0];
+        }
+
+        private Dictionary<string, ParameterMetadata> RetriveParameterMetadata(
+            AzFunctionInfo functionInfo,
+            out string moduleName)
+        {
+            moduleName = null;
+            string scriptPath = functionInfo.ScriptPath;
+            string entryPoint = functionInfo.EntryPoint;
+
+            using (ExecutionTimer.Start(_logger, "Parameter metadata retrieved."))
+            {
+                if (String.IsNullOrEmpty(entryPoint))
+                {
+                    return _pwsh.AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", scriptPath)
+                                .InvokeAndClearCommands<ExternalScriptInfo>()[0].Parameters;
+                }
+                else
+                {
+                    moduleName = Path.GetFileNameWithoutExtension(scriptPath);
+                    return _pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module").AddParameter("Name", scriptPath)
+                                .AddStatement()
+                                .AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddParameter("Name", $"{moduleName}\\{entryPoint}")
+                                .InvokeAndClearCommands<FunctionInfo>()[0].Parameters;
+                }
+            }
+        }
+
+        private void ResetRunspace(string moduleName)
         {
             // Reset the runspace to the Initial Session State
             _pwsh.Runspace.ResetRunspaceState();
 
-            // If the function had an entry point, this will remove the module that was loaded
-            var moduleName = Path.GetFileNameWithoutExtension(scriptPath);
-            _pwsh.AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
-                .AddParameter("Name", moduleName)
-                .AddParameter("ErrorAction", "SilentlyContinue")
-                .InvokeAndClearCommands();
+            if (!String.IsNullOrEmpty(moduleName))
+            {
+                // If the function had an entry point, this will remove the module that was loaded
+                _pwsh.AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
+                    .AddParameter("Name", moduleName)
+                    .AddParameter("Force", true)
+                    .AddParameter("ErrorAction", "SilentlyContinue")
+                    .InvokeAndClearCommands();
+            }
         }
     }
 }

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     if (IsValidJson(str)) { typedData.Json = str; } else { typedData.String = str; }
                     break;
                 default:
+                    if (psHelper == null) { throw new ArgumentNullException(nameof(psHelper)); }
                     typedData.Json = psHelper.ConvertToJson(value);   
                     break;             
             }

--- a/test/PowerShell/PowerShellManagerTests.cs
+++ b/test/PowerShell/PowerShellManagerTests.cs
@@ -26,7 +26,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             }
         };
+        public readonly RpcFunctionMetadata rpcFunctionMetadata = new RpcFunctionMetadata();
 
+        private AzFunctionInfo GetAzFunctionInfo(string scriptFile, string entryPoint)
+        {
+            rpcFunctionMetadata.ScriptFile = scriptFile;
+            rpcFunctionMetadata.EntryPoint = entryPoint;
+            return new AzFunctionInfo(rpcFunctionMetadata);
+        }
 
         [Fact]
         public void InitializeRunspaceSuccess()
@@ -50,7 +57,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             string path = System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
                 "PowerShell/TestScripts/testBasicFunction.ps1");
-            Hashtable result = manager.InvokeFunction(path, "", null, TestInputData);
+
+            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            Hashtable result = manager.InvokeFunction(functionInfo, null, TestInputData);
 
             Assert.Equal(TestStringData, result[TestOutputBindingName]);
         }
@@ -71,7 +80,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 { TestInputBindingName, TestStringData }
             };
 
-            Hashtable result = manager.InvokeFunction(path, "", triggerMetadata, TestInputData);
+            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            Hashtable result = manager.InvokeFunction(functionInfo, triggerMetadata, TestInputData);
 
             Assert.Equal(TestStringData, result[TestOutputBindingName]);
         }
@@ -85,9 +95,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             manager.InitializeRunspace();
 
             string path = System.IO.Path.Join(
-            AppDomain.CurrentDomain.BaseDirectory,
-            "PowerShell/TestScripts/testFunctionWithEntryPoint.ps1");
-            Hashtable result = manager.InvokeFunction(path, "Run", null, TestInputData);
+                AppDomain.CurrentDomain.BaseDirectory,
+                "PowerShell/TestScripts/testFunctionWithEntryPoint.ps1");
+
+            var functionInfo = GetAzFunctionInfo(path, "Run");
+            Hashtable result = manager.InvokeFunction(functionInfo, null, TestInputData);
 
             Assert.Equal(TestStringData, result[TestOutputBindingName]);
         }
@@ -101,14 +113,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             manager.InitializeRunspace();
 
             string path = System.IO.Path.Join(
-            AppDomain.CurrentDomain.BaseDirectory,
-            "PowerShell/TestScripts/testFunctionCleanup.ps1");
+                AppDomain.CurrentDomain.BaseDirectory,
+                "PowerShell/TestScripts/testFunctionCleanup.ps1");
 
-            Hashtable result1 = manager.InvokeFunction(path, "", null, TestInputData);
+            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            Hashtable result1 = manager.InvokeFunction(functionInfo, null, TestInputData);
             Assert.Equal("is not set", result1[TestOutputBindingName]);
 
             // the value shoould not change if the variable table is properly cleaned up.
-            Hashtable result2 = manager.InvokeFunction(path, "", null, TestInputData);
+            Hashtable result2 = manager.InvokeFunction(functionInfo, null, TestInputData);
             Assert.Equal("is not set", result2[TestOutputBindingName]);
         }
     }

--- a/test/Utility/TypeExtensionsTests.cs
+++ b/test/Utility/TypeExtensionsTests.cs
@@ -10,6 +10,7 @@ using System.IO;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Microsoft.Azure.Functions.PowerShellWorker;
+using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Newtonsoft.Json;
@@ -243,7 +244,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -266,7 +267,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -289,7 +290,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -312,7 +313,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -326,7 +327,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Int = data
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -340,7 +341,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Double = data
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -354,7 +355,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 String = data
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -368,7 +369,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Bytes = ByteString.CopyFrom(data)
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
@@ -383,7 +384,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                     Stream = ByteString.FromStream(data)
                 };
 
-                Assert.Equal(expected, input.ToTypedData());
+                Assert.Equal(expected, input.ToTypedData(null));
             }
         }
 
@@ -398,21 +399,25 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Json = data
             };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(null));
         }
 
         [Fact]
         public void TestObjectToTypedDataJsonHashtable()
         {
+            var logger = new ConsoleLogger();
+            var manager = new PowerShellManager(logger);
+            manager.InitializeRunspace();
+
             var data = new Hashtable { { "foo", "bar" } };
 
             var input = (object)data;
             var expected = new TypedData
             {
                 Json = "{\"foo\":\"bar\"}"
-        };
+            };
 
-            Assert.Equal(expected, input.ToTypedData());
+            Assert.Equal(expected, input.ToTypedData(manager));
         }
         #endregion
     }


### PR DESCRIPTION
Fix #71 

- Use `ConvertTo-Json` for converting the results returned from the function to JSON. So objects that are wrapped in `PSObject` won't be a problem anymore.
- Refactor the code to make it ready for durable function implementation.

The implementation of invoking an orchestration function is made a placeholder in this PR, where it throws `NotImplementedException` when an orchestration function is triggered.
See `RequestProcessor.InvokeOrchestrationFunction`.