### PR TITLE
Update JSON conversion depth to 3 to get better responsiveness given a complex return object

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             return _pwsh.AddCommand("Microsoft.PowerShell.Utility\\ConvertTo-Json")
                         .AddParameter("InputObject", fromObj)
-                        .AddParameter("Depth", 10)
+                        .AddParameter("Depth", 3)
                         .AddParameter("Compress", true)
                         .InvokeAndClearCommands<string>()[0];
         }

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         }
 
         private static JsonSerializerSettings setting =
-            new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None, MaxDepth = 10 };
+            new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None, MaxDepth = 3 };
         private static object DeserializeJson(string json)
         {
             var obj = JsonConvert.DeserializeObject(json, setting);


### PR DESCRIPTION
When the return/output object is a complex one, the powershell worker will freeze when converting it to JSON due to `-Depth 10` in the call to `ConvertTo-Json`. Talked to @eamonoreilly and decided to change to 3, which should be deep enough for most real scenarios.