### PR TITLE
Use 'JsonObject.ConvertFromJson' to serialize JSON binding input

### DIFF
--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -6,12 +6,13 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
+using System.Reflection;
 
 using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
@@ -73,7 +74,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             switch (data.DataCase)
             {
                 case TypedData.DataOneofCase.Json:
-                    return DeserializeJson(data.Json);
+                    return ConvertFromJson(data.Json);
                 case TypedData.DataOneofCase.Bytes:
                     return data.Bytes.ToByteArray();
                 case TypedData.DataOneofCase.Double:
@@ -89,24 +90,34 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 case TypedData.DataOneofCase.None:
                     return null;
                 default:
-                    return new InvalidOperationException("Data Case was not set.");
+                    return new InvalidOperationException("DataCase was not set.");
             }
         }
 
-        private static JsonSerializerSettings setting =
-            new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None, MaxDepth = 3 };
-        private static object DeserializeJson(string json)
+        // PowerShell NuGet packages only have 'System.Management.Automation.dll' as the ref assembly, and thus types from other powershell assemblies
+        // cannot be used directly in an application that reference the PowerShell NuGet packages.
+        // Here we need to use 'Microsoft.PowerShell.Commands.JsonObject' from 'Microsoft.PowerShell.Commands.Utility'. Due the above issue, we have to
+        // use reflection to call 'JsonObject.ConvertFromJson(...)'.
+        private const string UtilityAssemblyFullName = "Microsoft.PowerShell.Commands.Utility, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
+        private static MethodInfo s_ConvertFromJson = null;
+        private static object ConvertFromJson(string json)
         {
-            var obj = JsonConvert.DeserializeObject(json, setting);
-            switch (obj)
+            if (s_ConvertFromJson == null)
             {
-                case JObject dict:
-                    return new Hashtable(dict.ToObject<Hashtable>(), StringComparer.OrdinalIgnoreCase);
-                case JArray list:
-                    return list.ToObject<object[]>();
-                default:
-                    return obj;
+                Assembly utilityAssembly = AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.FullName == UtilityAssemblyFullName);
+                Type jsonObjectType = utilityAssembly.GetType("Microsoft.PowerShell.Commands.JsonObject");
+                s_ConvertFromJson = jsonObjectType.GetMethod(
+                    name: "ConvertFromJson",
+                    types: new Type[] { typeof(string), typeof(bool), typeof(ErrorRecord).MakeByRefType() },
+                    modifiers: null);
             }
+
+            object retObj = s_ConvertFromJson.Invoke(null, new object[] { json, true, null });
+            if (retObj is PSObject psObj)
+            {
+                retObj = psObj.BaseObject;
+            }
+            return retObj;
         }
 
         internal static RpcException ToRpcException(this Exception exception)
@@ -160,6 +171,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 return typedData;
             }
 
+            // Save the original value.
+            // We will use the original value when converting to JSON, so members added by ETS can be captured in the serialization. 
+            var originalValue = value;
+            if (value is PSObject psObj && psObj.BaseObject != null)
+            {
+                value = psObj.BaseObject;
+            }
+
             switch (value)
             {
                 case double d:
@@ -185,8 +204,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     break;
                 default:
                     if (psHelper == null) { throw new ArgumentNullException(nameof(psHelper)); }
-                    typedData.Json = psHelper.ConvertToJson(value);   
-                    break;             
+                    typedData.Json = psHelper.ConvertToJson(originalValue);
+                    break;
             }
             return typedData;
         }

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         }
 
         // PowerShell NuGet packages only have 'System.Management.Automation.dll' as the ref assembly, and thus types from other powershell assemblies
-        // cannot be used directly in an application that reference the PowerShell NuGet packages.
+        // cannot be used directly in an application that reference the PowerShell NuGet packages. This is tracked by PowerShell#8121.
         // Here we need to use 'Microsoft.PowerShell.Commands.JsonObject' from 'Microsoft.PowerShell.Commands.Utility'. Due the above issue, we have to
         // use reflection to call 'JsonObject.ConvertFromJson(...)'.
         private const string UtilityAssemblyFullName = "Microsoft.PowerShell.Commands.Utility, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -98,10 +98,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         // cannot be used directly in an application that reference the PowerShell NuGet packages. This is tracked by PowerShell#8121.
         // Here we need to use 'Microsoft.PowerShell.Commands.JsonObject' from 'Microsoft.PowerShell.Commands.Utility'. Due the above issue, we have to
         // use reflection to call 'JsonObject.ConvertFromJson(...)'.
-        private const string UtilityAssemblyFullName = "Microsoft.PowerShell.Commands.Utility, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
         private static MethodInfo s_ConvertFromJson = null;
         private static object ConvertFromJson(string json)
         {
+            const string UtilityAssemblyFullName = "Microsoft.PowerShell.Commands.Utility, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
+
             if (s_ConvertFromJson == null)
             {
                 Assembly utilityAssembly = AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.FullName == UtilityAssemblyFullName);

--- a/test/Utility/TypeExtensionsTests.cs
+++ b/test/Utility/TypeExtensionsTests.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         }
 
         [Fact]
-        public void TestObjectToTypedDataJsonPSObject1()
+        public void TestObjectToTypedData_PSObjectToJson_1()
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
@@ -528,54 +528,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         }
 
         [Fact]
-        public void TestObjectToTypedDataJsonPSObject2()
-        {
-            var logger = new ConsoleLogger();
-            var manager = new PowerShellManager(logger);
-            manager.InitializeRunspace();
-
-            var data = new byte[] { 12,23,34 };
-            object input = PSObject.AsPSObject(data);
-
-            TypedData output = input.ToTypedData(manager);
-
-            Assert.Equal(TypedData.DataOneofCase.Bytes, output.DataCase);
-            Assert.Equal(3, output.Bytes.Length);
-        }
-
-        [Fact]
-        public void TestObjectToTypedDataJsonPSObject3()
-        {
-            var logger = new ConsoleLogger();
-            var manager = new PowerShellManager(logger);
-            manager.InitializeRunspace();
-
-            using (var data = new MemoryStream(new byte[] { 12,23,34 }))
-            {
-                object input = PSObject.AsPSObject(data);
-                TypedData output = input.ToTypedData(manager);
-
-                Assert.Equal(TypedData.DataOneofCase.Stream, output.DataCase);
-                Assert.Equal(3, output.Stream.Length);
-            }
-        }
-
-        [Fact]
-        public void TestObjectToTypedDataJsonPSObject4()
-        {
-            var logger = new ConsoleLogger();
-            var manager = new PowerShellManager(logger);
-            manager.InitializeRunspace();
-
-            object input = PSObject.AsPSObject("Hello World");
-            TypedData output = input.ToTypedData(manager);
-
-            Assert.Equal(TypedData.DataOneofCase.String, output.DataCase);
-            Assert.Equal("Hello World", output.String);
-        }
-
-        [Fact]
-        public void TestObjectToTypedDataJsonPSObject5()
+        public void TestObjectToTypedData_PSObjectToJson_2()
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
@@ -592,6 +545,53 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
                 Assert.Equal(expected, input.ToTypedData(manager));
             }
+        }
+
+        [Fact]
+        public void TestObjectToTypedData_PSObjectToBytes()
+        {
+            var logger = new ConsoleLogger();
+            var manager = new PowerShellManager(logger);
+            manager.InitializeRunspace();
+
+            var data = new byte[] { 12,23,34 };
+            object input = PSObject.AsPSObject(data);
+
+            TypedData output = input.ToTypedData(manager);
+
+            Assert.Equal(TypedData.DataOneofCase.Bytes, output.DataCase);
+            Assert.Equal(3, output.Bytes.Length);
+        }
+
+        [Fact]
+        public void TestObjectToTypedData_PSObjectToStream()
+        {
+            var logger = new ConsoleLogger();
+            var manager = new PowerShellManager(logger);
+            manager.InitializeRunspace();
+
+            using (var data = new MemoryStream(new byte[] { 12,23,34 }))
+            {
+                object input = PSObject.AsPSObject(data);
+                TypedData output = input.ToTypedData(manager);
+
+                Assert.Equal(TypedData.DataOneofCase.Stream, output.DataCase);
+                Assert.Equal(3, output.Stream.Length);
+            }
+        }
+
+        [Fact]
+        public void TestObjectToTypedData_PSObjectToString()
+        {
+            var logger = new ConsoleLogger();
+            var manager = new PowerShellManager(logger);
+            manager.InitializeRunspace();
+
+            object input = PSObject.AsPSObject("Hello World");
+            TypedData output = input.ToTypedData(manager);
+
+            Assert.Equal(TypedData.DataOneofCase.String, output.DataCase);
+            Assert.Equal("Hello World", output.String);
         }
 
         #endregion


### PR DESCRIPTION
There are 2 changes here:
1. Use 'JsonObject.ConvertFromJson' to serialize JSON binding input. We have to use reflection because the reference assemblies are missing in our SDK NuGet packages.
2. Check for `PSObject` in our `ToTypedData` method, so that it handles wrapped objects properly.