### PR TITLE
remove powershellget from worker

### DIFF
--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,9 +1,5 @@
 @{
     # Modules bundled with the PowerShell Language Worker
-    'PowerShellGet' = @{
-        Version = '1.6.7'
-        Target = 'src/Modules'
-    }
     'Microsoft.PowerShell.Archive' = @{
         Version = '1.1.0.0'
         Target = 'src/Modules'


### PR DESCRIPTION
Because we are unable to override where Install-Module goes, we are removing PowerShellGet for now until we get some feedback.

If a user wants to use it for `Save-*` or `Publish-*` they can bring it in just like any other module.