### PR TITLE
Log items added to the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Copy the result of the `publish` directory into a `powershell` folder under `wor
 Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.1/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
 ```
 
+> NOTE: if the powershell folder already exists, you should delete it or debugging won't work.
+
 Then `cd` into a Function App with PowerShell as the worker runtime 
 (NOTE: There's an example PowerShell Function App in the `examples` folder).
 

--- a/src/PowerShell/PowerShellExtensions.cs
+++ b/src/PowerShell/PowerShellExtensions.cs
@@ -37,5 +37,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 pwsh.Commands.Clear();
             }
         }
+
+        public static string FormatObjectToString(this PowerShell pwsh, object inputObject)
+        {
+            return pwsh.AddCommand("Write-Output")
+                .AddParameter("InputObject", inputObject)
+                .AddCommand("Out-String")
+                .InvokeAndClearCommands<string>()[0];
+        }
     }
 }

--- a/src/PowerShell/PowerShellExtensions.cs
+++ b/src/PowerShell/PowerShellExtensions.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
         public static string FormatObjectToString(this PowerShell pwsh, object inputObject)
         {
+            // PowerShell's `Out-String -InputObject` handles collections differently
+            // than when receiving InputObjects from the pipeline. (i.e. `$collection | Out-String`).
+            // That is why we need `Write-Output` here. See related GitHub issue here:
+            // https://github.com/PowerShell/PowerShell/issues/8246
             return pwsh.AddCommand("Write-Output")
                 .AddParameter("InputObject", inputObject)
                 .AddCommand("Out-String")

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     // Log everything we received from the pipeline
                     foreach (var item in pipelineItems)
                     {
-                        _logger.Log(LogLevel.Information, $"OUTPUT: {item.ToString()}");
+                        _logger.Log(LogLevel.Information, $"OUTPUT: {_pwsh.FormatObjectToString(item)}", isUserLog: true);
                     }
                     
                     // TODO: See GitHub issue #82. We are not settled on how to handle the Azure Functions concept of the $returns Output Binding

--- a/test/Unit/PowerShell/PowerShellExtensionsTests.cs
+++ b/test/Unit/PowerShell/PowerShellExtensionsTests.cs
@@ -10,7 +10,9 @@ using Xunit;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 {
+    using System;
     using System.Management.Automation;
+    using System.Runtime.InteropServices;
 
     public class PowerShellExtensionsTests
     {
@@ -40,16 +42,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         [Fact]
         public void CanFormatObjectsToString()
         {
-            string expectedResult = @"
-Name                           Value
-----                           -----
-Foo                            bar
-
-
-";
+            string[] expectedResult = {
+                "",
+                "Name                           Value",
+                "----                           -----",
+                "Foo                            bar",
+                "",
+                "",
+                ""
+            };
 
             Hashtable data = new Hashtable {{ "Foo", "bar"}};   
-            Assert.Equal(expectedResult, 
+            Assert.Equal(
+                string.Join(Environment.NewLine, expectedResult), 
                 PowerShell.Create().FormatObjectToString(data));
         }
     }

--- a/test/Unit/PowerShell/PowerShellExtensionsTests.cs
+++ b/test/Unit/PowerShell/PowerShellExtensionsTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-
+using System.Collections;
 using System.Collections.ObjectModel;
 
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
@@ -35,6 +35,22 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Empty(pwsh.Commands.Commands);
 
             Assert.Single(results, data);
+        }
+
+        [Fact]
+        public void CanFormatObjectsToString()
+        {
+            string expectedResult = @"
+Name                           Value
+----                           -----
+Foo                            bar
+
+
+";
+
+            Hashtable data = new Hashtable {{ "Foo", "bar"}};   
+            Assert.Equal(expectedResult, 
+                PowerShell.Create().FormatObjectToString(data));
         }
     }
 }


### PR DESCRIPTION
Before, we didn't have the `isUserLog: true` property when we were logging things from the pipeline which means they only showed up as system logs. This is fixed in this PR.

However, we were also using a naive `ToString()` this has been replaced with a similar script:

```powershell
Write-Output $obj | Out-String
```