### PR TITLE
Make 'StatusCode' accept status code in the form of integer, string, and enum

### DIFF
--- a/src/Http/HttpResponseContext.cs
+++ b/src/Http/HttpResponseContext.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Net;
 using System.Collections.Generic;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker
@@ -36,6 +37,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// <summary>
         /// Gets or sets the StatusCode of the Http response.
         /// </summary>
-        public int StatusCode { get; set; } = 200;
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
     }
 }

--- a/src/Http/HttpResponseContext.cs
+++ b/src/Http/HttpResponseContext.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// <summary>
         /// Gets or sets the StatusCode of the Http response.
         /// </summary>
-        public string StatusCode { get; set; } = "200";
+        public int StatusCode { get; set; } = 200;
     }
 }

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         {
             var rpcHttp = new RpcHttp
             {
-                StatusCode = httpResponseContext.StatusCode
+                StatusCode = httpResponseContext.StatusCode.ToString()
             };
 
             if (httpResponseContext.Body != null)

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         {
             var rpcHttp = new RpcHttp
             {
-                StatusCode = httpResponseContext.StatusCode.ToString()
+                StatusCode = httpResponseContext.StatusCode.ToString("d")
             };
 
             if (httpResponseContext.Body != null)

--- a/test/E2E/HttpTrigger.Tests.ps1
+++ b/test/E2E/HttpTrigger.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'HttpTrigger Tests' {
 
         $res = Invoke-WebRequest "$FUNCTIONS_BASE_URL/api/TestBasicHttpTrigger?Name=Atlas"
         
-        $res.StatusCode | Should -Be ([HttpStatusCode]::OK)
+        $res.StatusCode | Should -Be ([HttpStatusCode]::Accepted)
         $res.Content | Should -Be $ExpectedContent
     }
 

--- a/test/E2E/TestFunctionApp/TestBasicHttpTrigger/run.ps1
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTrigger/run.ps1
@@ -18,7 +18,7 @@ if($name) {
     $body = "Hello " + $name
 }
 else {
-    $status = 400
+    $status = "400"
     $body = "Please pass a name on the query string or in the request body."
 }
 

--- a/test/E2E/TestFunctionApp/TestBasicHttpTrigger/run.ps1
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTrigger/run.ps1
@@ -14,7 +14,7 @@ $name = $req.Query.Name
 if (-not $name) { $name = $req.Body.Name }
 
 if($name) {
-    $status = 200
+    $status = 202
     $body = "Hello " + $name
 }
 else {

--- a/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithTriggerMetadata/run.ps1
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithTriggerMetadata/run.ps1
@@ -14,7 +14,7 @@ $name = $TriggerMetadata.req.Query.Name
 if (-not $name) { $name = $TriggerMetadata.req.Body.Name }
 
 if($name) {
-    $status = [System.Net.HttpStatusCode]::OK
+    $status = [System.Net.HttpStatusCode]::Accepted
     $body = "Hello " + $name
 }
 else {

--- a/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithTriggerMetadata/run.ps1
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithTriggerMetadata/run.ps1
@@ -14,7 +14,7 @@ $name = $TriggerMetadata.req.Query.Name
 if (-not $name) { $name = $TriggerMetadata.req.Body.Name }
 
 if($name) {
-    $status = 200
+    $status = [System.Net.HttpStatusCode]::OK
     $body = "Hello " + $name
 }
 else {

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = "200",
+                    StatusCode = 200,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }
@@ -350,7 +350,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = "200",
+                    StatusCode = 200,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = "200",
+                    StatusCode = 200,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -390,13 +390,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var input = new HttpResponseContext
             {
                 Body = data,
-                StatusCode = "201"
+                StatusCode = 201
             };
             var expected = new TypedData
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = "201",
+                    StatusCode = 201,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = HttpStatusCode.OK,
+                    StatusCode = "200",
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = HttpStatusCode.OK,
+                    StatusCode = "200",
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = HttpStatusCode.OK,
+                    StatusCode = "200",
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = HttpStatusCode.Created,
+                    StatusCode = "201",
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Net;
 using System.Management.Automation;
 
 using Google.Protobuf;
@@ -327,7 +328,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = 200,
+                    StatusCode = HttpStatusCode.OK,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }
@@ -350,7 +351,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = 200,
+                    StatusCode = HttpStatusCode.OK,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -373,7 +374,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = 200,
+                    StatusCode = HttpStatusCode.OK,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/html" } }
                 }
@@ -390,13 +391,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var input = new HttpResponseContext
             {
                 Body = data,
-                StatusCode = 201
+                StatusCode = HttpStatusCode.Created
             };
             var expected = new TypedData
             {
                 Http = new RpcHttp
                 {
-                    StatusCode = 201,
+                    StatusCode = HttpStatusCode.Created,
                     Body = new TypedData { String = data },
                     Headers = { { "content-type", "text/plain" } }
                 }


### PR DESCRIPTION
Change the type of 'StatusCode' to 'System.Net.HttpStatusCode', so that it can accept status code in the form of integer, string, and enum 'HttpStatusCode'.