### PR TITLE
WIP: Remove the Az module from bundle and add auto-authentication if MSI is available

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -81,24 +81,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     .AddParameter("Uri", $"{msiEndpoint}?resource=https://management.azure.com&api-version=2017-09-01")
                     .InvokeAndClearCommands<PSObject>();
 
-<<<<<<< HEAD
                 using (ExecutionTimer.Start(_logger, "Authentication to Azure"))
-=======
-                using (ExecutionTimer.Start(_logger, "Authentication to Azure completed."))
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
                 {
                     _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")
                         .AddParameter("AccessToken", response[0].Properties["access_token"].Value)
                         .AddParameter("AccountId", accountId)
                         .InvokeAndClearCommands();
-<<<<<<< HEAD
 
                     if(_pwsh.HadErrors)
                     {
                         _logger.Log(LogLevel.Trace, "Failed to Authenticate to Azure. Check the logs for the errors generated.");
                     }
-=======
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
                 }
             }
             else
@@ -112,11 +105,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     string.IsNullOrEmpty(applicationSecret) ||
                     string.IsNullOrEmpty(tenantId))
                 {
-<<<<<<< HEAD
                     _logger.Log(LogLevel.Warning, "Skip authentication to Azure. Environment variables for authenticating to Azure are not present.");
-=======
-                    _logger.Log(LogLevel.Warning, "Required environment variables to authenticate to Azure were not present");
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
                     return;
                 }
 
@@ -127,25 +116,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     secureString.AppendChar(item);
                 }
                 
-<<<<<<< HEAD
                 using (ExecutionTimer.Start(_logger, "Authentication to Azure"))
-=======
-                using (ExecutionTimer.Start(_logger, "Authentication to Azure completed."))
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
                 {
                     _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")
                         .AddParameter("Credential", new PSCredential(applicationId, secureString))
                         .AddParameter("ServicePrincipal")
                         .AddParameter("TenantId", tenantId)
                         .InvokeAndClearCommands();
-<<<<<<< HEAD
 
                     if(_pwsh.HadErrors)
                     {
                         _logger.Log(LogLevel.Trace, "Failed to Authenticate to Azure. Check the logs for the errors generated.");
                     }
-=======
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
                 }
             }
         }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -50,34 +50,75 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
         internal void AuthenticateToAzure()
         {
-            // Try to authenticate to Azure
-            // TODO: The Azure Functions Host might supply these differently. This might change but works for the demo
-            string applicationId = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_APP_ID");
-            string applicationSecret = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_APP_PASSWORD");
-            string tenantId = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_TENANT_ID");
+            // Check if Az.Profile is available
+            Collection<PSModuleInfo> azprofile = _pwsh.AddCommand("Get-Module")
+                .AddParameter("ListAvailable")
+                .AddParameter("Name", "Az.Profile")
+                .InvokeAndClearCommands<PSModuleInfo>();
 
-            if (string.IsNullOrEmpty(applicationId) ||
-                string.IsNullOrEmpty(applicationSecret) ||
-                string.IsNullOrEmpty(tenantId))
+            if (azprofile.Count == 0)
             {
-                _logger.Log(LogLevel.Warning, "Required environment variables to authenticate to Azure were not present");
+                _logger.Log(LogLevel.Warning, "Required module to authenticate, Az.Profile, was not present on the PSModulePath");
                 return;
             }
 
-            // Build SecureString
-            var secureString = new SecureString();
-            foreach (char item in applicationSecret)
+            // Try to authenticate to Azure using MSI
+            string msiSecret = Environment.GetEnvironmentVariable("MSI_SECRET");
+            string msiEndpoint = Environment.GetEnvironmentVariable("MSI_ENDPOINT");
+            string accountId = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+
+            if (!string.IsNullOrEmpty(msiSecret) &&
+                !string.IsNullOrEmpty(msiEndpoint) &&
+                !string.IsNullOrEmpty(accountId))
             {
-                secureString.AppendChar(item);
+                // NOTE: There is a limitation in Azure PowerShell that prevents us from using the parameter set:
+                // Connect-AzAccount -MSI or Connect-AzAccount -Identity
+                // see this GitHub issue https://github.com/Azure/azure-powershell/issues/7876
+                // As a workaround, we can all an API endpoint on the MSI_ENDPOINT to get an AccessToken and use that to authenticate
+                Collection<PSObject> response = _pwsh.AddCommand("Microsoft.PowerShell.Utility\\Invoke-RestMethod")
+                    .AddParameter("Method", "Get")
+                    .AddParameter("Headers", new Hashtable {{ "Secret", msiSecret }})
+                    .AddParameter("Uri", $"{msiEndpoint}?resource=https://management.azure.com&api-version=2017-09-01")
+                    .InvokeAndClearCommands<PSObject>();
+
+                using (ExecutionTimer.Start(_logger, "Authentication to Azure completed."))
+                {
+                    _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")
+                        .AddParameter("AccessToken", response[0].Properties["access_token"].Value)
+                        .AddParameter("AccountId", accountId)
+                        .InvokeAndClearCommands();
+                }
             }
-            
-            using (ExecutionTimer.Start(_logger, "Authentication to Azure completed."))
+            else
             {
-                _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")
-                    .AddParameter("Credential", new PSCredential(applicationId, secureString))
-                    .AddParameter("ServicePrincipal")
-                    .AddParameter("TenantId", tenantId)
-                    .InvokeAndClearCommands();
+                // Try to authenticate to Azure using Service Principal
+                string applicationId = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_APP_ID");
+                string applicationSecret = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_APP_PASSWORD");
+                string tenantId = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_TENANT_ID");
+
+                if (string.IsNullOrEmpty(applicationId) ||
+                    string.IsNullOrEmpty(applicationSecret) ||
+                    string.IsNullOrEmpty(tenantId))
+                {
+                    _logger.Log(LogLevel.Warning, "Required environment variables to authenticate to Azure were not present");
+                    return;
+                }
+
+                // Build SecureString
+                var secureString = new SecureString();
+                foreach (char item in applicationSecret)
+                {
+                    secureString.AppendChar(item);
+                }
+                
+                using (ExecutionTimer.Start(_logger, "Authentication to Azure completed."))
+                {
+                    _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")
+                        .AddParameter("Credential", new PSCredential(applicationId, secureString))
+                        .AddParameter("ServicePrincipal")
+                        .AddParameter("TenantId", tenantId)
+                        .InvokeAndClearCommands();
+                }
             }
         }
 

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -130,8 +130,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
             // Set the PSModulePath
             Environment.SetEnvironmentVariable("PSModulePath", Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules"));
-
-            AuthenticateToAzure();
         }
 
         /// <summary>

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -81,6 +81,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     .AddParameter("Uri", $"{msiEndpoint}?resource=https://management.azure.com&api-version=2017-09-01")
                     .InvokeAndClearCommands<PSObject>();
 
+                if(_pwsh.HadErrors) 
+                {
+                    _logger.Log(LogLevel.Trace, "Failed to Authenticate to Azure. Check the logs for the errors generated.");
+                    return;
+                }
+
                 using (ExecutionTimer.Start(_logger, "Authentication to Azure"))
                 {
                     _pwsh.AddCommand("Az.Profile\\Connect-AzAccount")

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
             if (azprofile.Count == 0)
             {
-                _logger.Log(LogLevel.Warning, "Required module to authenticate, Az.Profile, was not present on the PSModulePath");
+                _logger.Log(LogLevel.Warning, "Required module to automatically authenticate with Azure `Az.Profile` was not found in the PSModulePath.");
                 return;
             }
 

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -111,6 +111,11 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                     string functionAppModulesPath = Path.GetFullPath(
                         Path.Combine(functionLoadRequest.Metadata.Directory, "..", "Modules"));
                     _powerShellManager.PrependToPSModulePath(functionAppModulesPath);
+
+                    // Since this is the first time we know where the location of the FunctionApp is,
+                    // we can attempt to authenticate to Azure at this time.
+                    _powerShellManager.AuthenticateToAzure();
+
                     _prependedPath = true;
                 }
             }

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -4,8 +4,4 @@
         Version = '1.1.0.0'
         Target = 'src/Modules'
     }
-    'Az' = @{
-        Version = '0.2.2'
-        Target = 'src/Modules'
-    }
 }

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var manager = new PowerShellManager(logger);
             manager.InitializeRunspace();
 
-            Assert.Single(logger.FullLog);
-            Assert.Equal("Warning: Required module to authenticate, Az.Profile, was not present on the PSModulePath", logger.FullLog[0]);
+            Assert.Empty(logger.FullLog);
         }
 
         [Fact]

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             manager.InitializeRunspace();
 
             Assert.Single(logger.FullLog);
-            Assert.Equal("Warning: Required environment variables to authenticate to Azure were not present", logger.FullLog[0]);
+            Assert.Equal("Warning: Required module to authenticate, Az.Profile, was not present on the PSModulePath", logger.FullLog[0]);
         }
 
         [Fact]

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -42,12 +42,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var manager = new PowerShellManager(logger);
             manager.InitializeRunspace();
 
-<<<<<<< HEAD
             Assert.Empty(logger.FullLog);
-=======
-            Assert.Single(logger.FullLog);
-            Assert.Equal("Warning: Required module to authenticate, Az.Profile, was not present on the PSModulePath", logger.FullLog[0]);
->>>>>>> ca97b495ff7b3c41cc744f3e3023924f7f36fc37
         }
 
         [Fact]


### PR DESCRIPTION
This PR:
* Removes the Az module from the worker - if the user wants to interact with Azure, they should do:

```powershell
Save-Module Az.Profile ./Modules
Save-Module Az.KeyVault ./Modules
```
from their Function App root.

Also... if the user has enabled MSI and Az.Profile is available, we auto-authenticate to Azure.