### PR TITLE
Profile.ps1 support and removal of auto-auth to azure

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,13 +3,32 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet",
+            "command": "pwsh",
             "type": "process",
             "args": [
-                "build",
-                "${workspaceFolder}/psworker.csproj"
+                "-c",
+                "${workspaceFolder}/build.ps1"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "test",
+            "command": "pwsh",
+            "type": "process",
+            "args": [
+                "-c",
+                "${workspaceFolder}/build.ps1",
+                "-Test"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/examples/PSCoreApp/Profile.ps1
+++ b/examples/PSCoreApp/Profile.ps1
@@ -1,0 +1,20 @@
+# This script will be run on every COLD START of the Function App
+# You can define helper functions, run commands, or specify environment variables
+# NOTE: any variables defined that are not environment variables will get reset after the first execution
+
+# Example usecases for a Profile.ps1:
+
+# Authenticating with Azure PowerShell using MSI
+# $tokenAuthURI = $env:MSI_ENDPOINT + "?resource=https://management.azure.com&api-version=2017-09-01"
+# $tokenResponse = Invoke-RestMethod -Method Get -Headers @{"Secret"="$env:MSI_SECRET"} -Uri $tokenAuthURI
+# Connect-AzAccount -AccessToken $tokenResponse.access_token -AccountId $env:WEBSITE_SITE_NAME
+
+# Enabling legacy AzureRm alias in Azure PowerShell
+# Enable-AzureRmAlias
+
+# Defining a function that you can refernce in any of your PowerShell functions:
+# function Get-MyData {
+#     @{
+#         Foo = 5
+#     }
+# }

--- a/examples/PSCoreApp/Profile.ps1
+++ b/examples/PSCoreApp/Profile.ps1
@@ -2,7 +2,7 @@
 # You can define helper functions, run commands, or specify environment variables
 # NOTE: any variables defined that are not environment variables will get reset after the first execution
 
-# Example usecases for a Profile.ps1:
+# Example usecases for a profile.ps1:
 
 # Authenticating with Azure PowerShell using MSI
 # $tokenAuthURI = $env:MSI_ENDPOINT + "?resource=https://management.azure.com&api-version=2017-09-01"

--- a/examples/PSCoreApp/Profile.ps1
+++ b/examples/PSCoreApp/Profile.ps1
@@ -4,17 +4,14 @@
 
 # Example usecases for a profile.ps1:
 
-# Authenticating with Azure PowerShell using MSI
-# $tokenAuthURI = $env:MSI_ENDPOINT + "?resource=https://management.azure.com&api-version=2017-09-01"
-# $tokenResponse = Invoke-RestMethod -Method Get -Headers @{"Secret"="$env:MSI_SECRET"} -Uri $tokenAuthURI
-# Connect-AzAccount -AccessToken $tokenResponse.access_token -AccountId $env:WEBSITE_SITE_NAME
+<#
+# Authenticate with Azure PowerShell using MSI.
+$tokenAuthURI = $env:MSI_ENDPOINT + "?resource=https://management.azure.com&api-version=2017-09-01"
+$tokenResponse = Invoke-RestMethod -Method Get -Headers @{"Secret"="$env:MSI_SECRET"} -Uri $tokenAuthURI
+Connect-AzAccount -AccessToken $tokenResponse.access_token -AccountId $env:WEBSITE_SITE_NAME
 
-# Enabling legacy AzureRm alias in Azure PowerShell
-# Enable-AzureRmAlias
+# Enable legacy AzureRm alias in Azure PowerShell.
+Enable-AzureRmAlias
+#>
 
-# Defining a function that you can refernce in any of your PowerShell functions:
-# function Get-MyData {
-#     @{
-#         Foo = 5
-#     }
-# }
+# You can also define functions or aliases that can be referenced in any of your PowerShell functions.

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
     {
         private readonly MapField<string, AzFunctionInfo> _loadedFunctions = new MapField<string, AzFunctionInfo>();
 
+        internal static string FunctionAppRootLocation { get; set; }
+
         internal AzFunctionInfo GetFunctionInfo(string functionId)
         {
             if (_loadedFunctions.TryGetValue(functionId, out AzFunctionInfo funcInfo))
@@ -28,6 +30,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // TODO: catch "load" issues at "func start" time.
             // ex. Script doesn't exist, entry point doesn't exist
             _loadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
+
         }
     }
 

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -4,6 +4,10 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
 using Google.Protobuf.Collections;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 
@@ -14,6 +18,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         private readonly MapField<string, AzFunctionInfo> _loadedFunctions = new MapField<string, AzFunctionInfo>();
 
         internal static string FunctionAppRootLocation { get; set; }
+        internal static string FunctionAppProfileLocation { get; set; } = null;
+        internal static string FunctionAppModulesLocation { get; set; } = null;
 
         internal AzFunctionInfo GetFunctionInfo(string functionId)
         {
@@ -25,12 +31,41 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             throw new InvalidOperationException($"Function with the ID '{functionId}' was not loaded.");
         }
 
-        internal void Load(FunctionLoadRequest request)
+        /// <summary>
+        /// Runs once per Function in a Function App. Loads the Function info into the Function Loader
+        /// </summary>
+        internal void LoadFunction(FunctionLoadRequest request)
         {
             // TODO: catch "load" issues at "func start" time.
             // ex. Script doesn't exist, entry point doesn't exist
             _loadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
+        }
 
+        /// <summary>
+        /// Sets up well-known paths like the Function App root,
+        /// the Function App 'Modules' folder,
+        /// and the Function App's profile.ps1
+        /// </summary>
+        internal static void SetupWellKnownPaths(string functionAppRootLocation)
+        {
+            FunctionLoader.FunctionAppRootLocation = functionAppRootLocation;
+
+            var enumerationOptions = new EnumerationOptions {
+                MatchCasing = MatchCasing.CaseInsensitive
+            };
+            // Find the profile.ps1 in the Function App root if it exists
+            List<string> profiles = Directory.EnumerateFiles(functionAppRootLocation, "profile.ps1", enumerationOptions).ToList();
+            if (profiles.Count() > 0)
+            {
+                FunctionLoader.FunctionAppProfileLocation = profiles[0];
+            }
+
+            // Find the Modules directory in the Function App root if it exists
+            List<string> modulePaths = Directory.EnumerateFiles(functionAppRootLocation, "Modules", enumerationOptions).ToList();
+            if (modulePaths.Count() > 0)
+            {
+                FunctionLoader.FunctionAppModulesLocation = modulePaths[0];
+            }
         }
     }
 

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
     {
         private readonly MapField<string, AzFunctionInfo> _loadedFunctions = new MapField<string, AzFunctionInfo>();
 
-        internal static string FunctionAppRootLocation { get; set; }
-        internal static string FunctionAppProfileLocation { get; set; } = null;
-        internal static string FunctionAppModulesLocation { get; set; } = null;
+        internal static string FunctionAppRootPath { get; set; }
+        internal static string FunctionAppProfilePath { get; set; } = null;
+        internal static string FunctionAppModulesPath { get; set; } = null;
 
         internal AzFunctionInfo GetFunctionInfo(string functionId)
         {
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         internal static void SetupWellKnownPaths(string functionAppRootLocation)
         {
-            FunctionLoader.FunctionAppRootLocation = functionAppRootLocation;
-            FunctionLoader.FunctionAppModulesLocation = Path.Combine(functionAppRootLocation, "Modules");
+            FunctionLoader.FunctionAppRootPath = functionAppRootLocation;
+            FunctionLoader.FunctionAppModulesPath = Path.Combine(functionAppRootLocation, "Modules");
 
             // Find the profile.ps1 in the Function App root if it exists
             List<string> profiles = Directory.EnumerateFiles(functionAppRootLocation, "profile.ps1", new EnumerationOptions {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             }).ToList();
             if (profiles.Count() > 0)
             {
-                FunctionLoader.FunctionAppProfileLocation = profiles[0];
+                FunctionLoader.FunctionAppProfilePath = profiles[0];
             }
         }
     }

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -49,22 +49,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         internal static void SetupWellKnownPaths(string functionAppRootLocation)
         {
             FunctionLoader.FunctionAppRootLocation = functionAppRootLocation;
+            FunctionLoader.FunctionAppModulesLocation = Path.Combine(functionAppRootLocation, "Modules");
 
-            var enumerationOptions = new EnumerationOptions {
-                MatchCasing = MatchCasing.CaseInsensitive
-            };
             // Find the profile.ps1 in the Function App root if it exists
-            List<string> profiles = Directory.EnumerateFiles(functionAppRootLocation, "profile.ps1", enumerationOptions).ToList();
+            List<string> profiles = Directory.EnumerateFiles(functionAppRootLocation, "profile.ps1", new EnumerationOptions {
+                MatchCasing = MatchCasing.CaseInsensitive
+            }).ToList();
             if (profiles.Count() > 0)
             {
                 FunctionLoader.FunctionAppProfileLocation = profiles[0];
-            }
-
-            // Find the Modules directory in the Function App root if it exists
-            List<string> modulePaths = Directory.EnumerateFiles(functionAppRootLocation, "Modules", enumerationOptions).ToList();
-            if (modulePaths.Count() > 0)
-            {
-                FunctionLoader.FunctionAppModulesLocation = modulePaths[0];
             }
         }
     }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -8,7 +8,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Security;
+using System.Text;
 
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -17,9 +19,7 @@ using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 {
-    using System.Linq;
     using System.Management.Automation;
-    using System.Text;
 
     internal class PowerShellManager
     {

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -105,36 +105,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
-        /// Wrap a string in quotes to make it safe to use in scripts.
-        /// </summary>
-        /// <param name="path">The path to wrap in quotes.</param>
-        /// <returns>The given path wrapped in quotes appropriately.</returns>
-        private static StringBuilder QuoteEscapeString(string path)
-        {
-            var sb = new StringBuilder(path.Length + 2); // Length of string plus two quotes
-            sb.Append('\'');
-            if (!path.Contains('\''))
-            {
-                sb.Append(path);
-            }
-            else
-            {
-                foreach (char c in path)
-                {
-                    if (c == '\'')
-                    {
-                        sb.Append("''");
-                        continue;
-                    }
-
-                    sb.Append(c);
-                }
-            }
-            sb.Append('\'');
-            return sb;
-        }
-
-        /// <summary>
         /// Execution a function fired by a trigger or an activity function scheduled by an orchestration.
         /// </summary>
         internal Hashtable InvokeFunction(

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
         internal void InvokeProfile()
         {
-            string functionAppProfileLocation = FunctionLoader.FunctionAppProfileLocation;
+            string functionAppProfileLocation = FunctionLoader.FunctionAppProfilePath;
             if (functionAppProfileLocation == null)
             {
-                _logger.Log(LogLevel.Trace, $"No 'Profile.ps1' found at: {FunctionLoader.FunctionAppRootLocation}");
+                _logger.Log(LogLevel.Trace, $"No 'profile.ps1' is found at the FunctionApp root folder: {FunctionLoader.FunctionAppRootPath}");
                 return;
             }
             
@@ -71,14 +71,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 // Import-Module on a .ps1 file will evaluate the script in the global scope.
                 _pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module")
                     .AddParameter("Name", functionAppProfileLocation).AddParameter("PassThru", true)
-                    .AddCommand("Remove-Module")
+                    .AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
+                    .AddParameter("Force", true).AddParameter("ErrorAction", "SilentlyContinue")
                     .InvokeAndClearCommands();
             }
-            catch (CmdletInvocationException e)
+            catch (Exception e)
             {
                 _logger.Log(
                     LogLevel.Error,
-                    $"Invoking the Profile had errors. See logs for details. Profile location: {functionAppProfileLocation}",
+                    $"Fail to run profile.ps1. See logs for detailed errors. Profile location: {functionAppProfileLocation}",
                     e,
                     isUserLog: true);
                 throw;
@@ -88,7 +89,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             {
                 _logger.Log(
                     LogLevel.Error,
-                    $"Invoking the Profile had errors. See logs for details. Profile location: {functionAppProfileLocation}",
+                    $"Fail to run profile.ps1. See logs for detailed errors. Profile location: {functionAppProfileLocation}",
                     isUserLog: true);
             }
         }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -102,24 +102,30 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
             try
             {
-                // Try loading the metadata of the function
-                _functionLoader.Load(functionLoadRequest);
-
-                // if we haven't yet, add the well-known Function App module path to the PSModulePath
-                // The location of this module path is in a folder called "Modules" in the root of the Function App.
+                // This is the first opportunity we have to obtain the location of the Function App on the file system
+                // so we run some additional setup including:
+                // * Storing some well-known paths in the Function Loader
+                // * Prepending the Function App 'Modules' path
+                // * Invoking the Function App's profile.ps1
                 if (!_initializedFunctionApp)
                 {
-                    FunctionLoader.FunctionAppRootLocation = Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, ".."));
+                    // We obtain the Function App root path by navigating up 
+                    // one directory from the _Function_ directory we are given
+                    FunctionLoader.SetupWellKnownPaths(Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, "..")));
 
-                    // Prepend the Function App's 'Modules' folder to the PSModulePath
-                    _powerShellManager.PrependToPSModulePath(Path.Combine(FunctionLoader.FunctionAppRootLocation, "Modules"));
+                    if (FunctionLoader.FunctionAppModulesLocation != null)
+                    {
+                        // Prepend the Function App's 'Modules' folder to the PSModulePath
+                        _powerShellManager.PrependToPSModulePath(FunctionLoader.FunctionAppModulesLocation);
+                    }
 
-                    // Since this is the first time we know where the location of the FunctionApp is,
-                    // we can attempt to execute the Profile.
                     _powerShellManager.InvokeProfile();
 
                     _initializedFunctionApp = true;
                 }
+
+                // Try loading the metadata of the function
+                _functionLoader.LoadFunction(functionLoadRequest);
             }
             catch (Exception e)
             {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -109,11 +109,10 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 // The location of this module path is in a folder called "Modules" in the root of the Function App.
                 if (!_initializedFunctionApp)
                 {
-                    string functionAppRoot = Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, ".."));
-                    _powerShellManager.FunctionAppRootLocation = functionAppRoot;
+                    FunctionLoader.FunctionAppRootLocation = Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, ".."));
 
                     // Prepend the Function App's 'Modules' folder to the PSModulePath
-                    _powerShellManager.PrependToPSModulePath(Path.Combine(functionAppRoot, "Modules"));
+                    _powerShellManager.PrependToPSModulePath(Path.Combine(FunctionLoader.FunctionAppRootLocation, "Modules"));
 
                     // Since this is the first time we know where the location of the FunctionApp is,
                     // we can attempt to execute the Profile.

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -113,11 +113,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                     // one directory from the _Function_ directory we are given
                     FunctionLoader.SetupWellKnownPaths(Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, "..")));
 
-                    if (FunctionLoader.FunctionAppModulesLocation != null)
-                    {
-                        // Prepend the Function App's 'Modules' folder to the PSModulePath
-                        _powerShellManager.PrependToPSModulePath(FunctionLoader.FunctionAppModulesLocation);
-                    }
+                    _powerShellManager.PrependToPSModulePath(FunctionLoader.FunctionAppModulesLocation);
 
                     _powerShellManager.InvokeProfile();
 

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -113,7 +113,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                     // one directory from the _Function_ directory we are given
                     FunctionLoader.SetupWellKnownPaths(Path.GetFullPath(Path.Combine(functionLoadRequest.Metadata.Directory, "..")));
 
-                    _powerShellManager.PrependToPSModulePath(FunctionLoader.FunctionAppModulesLocation);
+                    _powerShellManager.PrependToPSModulePath(FunctionLoader.FunctionAppModulesPath);
 
                     _powerShellManager.InvokeProfile();
 

--- a/test/E2E/HttpTrigger.Tests.ps1
+++ b/test/E2E/HttpTrigger.Tests.ps1
@@ -24,11 +24,15 @@ Describe 'HttpTrigger Tests' {
         @{ 
             FunctionName = 'TestBasicHttpTriggerWithTriggerMetadata'
             ExpectedContent = 'Hello Atlas'
+        },
+        @{
+            FunctionName = 'TestBasicHttpTriggerWithProfile'
+            ExpectedContent = 'PROFILE'
         }
     ) {
-        param ($ExpectedContent)
+        param ($FunctionName, $ExpectedContent)
 
-        $res = Invoke-WebRequest "$FUNCTIONS_BASE_URL/api/TestBasicHttpTrigger?Name=Atlas"
+        $res = Invoke-WebRequest "$FUNCTIONS_BASE_URL/api/$($FunctionName)?Name=Atlas"
         
         $res.StatusCode | Should -Be ([HttpStatusCode]::Accepted)
         $res.Content | Should -Be $ExpectedContent
@@ -50,12 +54,12 @@ Describe 'HttpTrigger Tests' {
             FunctionName = 'TestBasicHttpTriggerWithTriggerMetadata'
         }
     ) {
-        param ($InputNameData)
+        param ($FunctionName, $InputNameData)
 
         if (Test-Path 'variable:InputNameData') {
-            $url = "$FUNCTIONS_BASE_URL/api/TestBasicHttpTrigger?Name=$InputNameData"
+            $url = "$FUNCTIONS_BASE_URL/api/$($FunctionName)?Name=$InputNameData"
         } else {
-            $url = "$FUNCTIONS_BASE_URL/api/TestBasicHttpTrigger"
+            $url = "$FUNCTIONS_BASE_URL/api/$($FunctionName)"
         }
 
         $res = { invoke-webrequest $url } |

--- a/test/E2E/TestFunctionApp/Profile.ps1
+++ b/test/E2E/TestFunctionApp/Profile.ps1
@@ -1,0 +1,3 @@
+function Get-ProfileString {
+    "PROFILE"
+}

--- a/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithProfile/function.json
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithProfile/function.json
@@ -1,0 +1,20 @@
+{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithProfile/run.ps1
+++ b/test/E2E/TestFunctionApp/TestBasicHttpTriggerWithProfile/run.ps1
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Input bindings are passed in via param block.
+param($req)
+
+Push-OutputBinding -Name res -Value ([HttpResponseContext]@{
+    StatusCode = 202
+    Body = (Get-ProfileString)
+})

--- a/test/E2E/setupE2Etests.ps1
+++ b/test/E2E/setupE2Etests.ps1
@@ -35,6 +35,7 @@ Expand-Archive $output -DestinationPath $FUNC_CLI_DIRECTORY
 Write-Host "Copying azure-functions-powershell-worker to  Functions Host workers directory..."
 
 $configuration = if ($env:CONFIGURATION) { $env:CONFIGURATION } else { 'Debug' }
+Remove-Item -Recurse -Force -Path "$FUNC_CLI_DIRECTORY/workers/powershell"
 Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp2.1/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
 
 Write-Host "Staring Functions Host..."

--- a/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -31,5 +31,14 @@
     <Content Include="Unit\PowerShell\TestScripts\testFunctionCleanup.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Unit\PowerShell\TestScripts\ProfileBasic\Profile.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit\PowerShell\TestScripts\ProfileWithTerminatingError\Profile.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit\PowerShell\TestScripts\ProfileWithNonTerminatingError\Profile.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -31,10 +31,10 @@
     <Content Include="Unit\PowerShell\TestScripts\testFunctionCleanup.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Unit\PowerShell\TestScripts\ProfileBasic\Profile.ps1">
+    <Content Include="Unit\PowerShell\TestScripts\ProfileBasic\profile.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Unit\PowerShell\TestScripts\ProfileWithTerminatingError\Profile.ps1">
+    <Content Include="Unit\PowerShell\TestScripts\ProfileWithTerminatingError\profile.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Unit\PowerShell\TestScripts\ProfileWithNonTerminatingError\Profile.ps1">

--- a/test/Unit/Function/FunctionLoaderTests.cs
+++ b/test/Unit/Function/FunctionLoaderTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             };
 
             var functionLoader = new FunctionLoader();
-            functionLoader.Load(functionLoadRequest);
+            functionLoader.LoadFunction(functionLoadRequest);
 
             var funcInfo = functionLoader.GetFunctionInfo(functionId);
 
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             };
 
             var functionLoader = new FunctionLoader();
-            functionLoader.Load(functionLoadRequest);
+            functionLoader.LoadFunction(functionLoadRequest);
 
             var funcInfo = functionLoader.GetFunctionInfo(functionId);
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             };
 
             var functionLoader = new FunctionLoader();
-            functionLoader.Load(functionLoadRequest);
+            functionLoader.LoadFunction(functionLoadRequest);
 
             var funcInfo = functionLoader.GetFunctionInfo(functionId);
 

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            manager.FunctionAppRootLocation = System.IO.Path.Join(
+            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
                 "Unit/PowerShell/TestScripts/ProfileBasic");
             
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            manager.FunctionAppRootLocation = AppDomain.CurrentDomain.BaseDirectory;
+            FunctionLoader.FunctionAppRootLocation = AppDomain.CurrentDomain.BaseDirectory;
             
             manager.InvokeProfile();
 
@@ -193,11 +193,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            manager.FunctionAppRootLocation = System.IO.Path.Join(
+            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
                 "Unit/PowerShell/TestScripts/ProfileWithTerminatingError");
             
-            Assert.Throws<RuntimeException>(() => manager.InvokeProfile());
+            Assert.Throws<CmdletInvocationException>(() => manager.InvokeProfile());
             Assert.Single(logger.FullLog);
             Assert.Matches("Error: Invoking the Profile had errors. See logs for details. Profile location: ", logger.FullLog[0]);
         }
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            manager.FunctionAppRootLocation = System.IO.Path.Join(
+            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
                 "Unit/PowerShell/TestScripts/ProfileWithNonTerminatingError");
             

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -165,9 +165,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
+
+            CleanupFunctionLoaderStaticPaths();
+            FunctionLoader.SetupWellKnownPaths(System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
-                "Unit/PowerShell/TestScripts/ProfileBasic");
+                "Unit/PowerShell/TestScripts/ProfileBasic"));
             
             manager.InvokeProfile();
 
@@ -180,7 +182,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            FunctionLoader.FunctionAppRootLocation = AppDomain.CurrentDomain.BaseDirectory;
+
+            CleanupFunctionLoaderStaticPaths();
+            FunctionLoader.SetupWellKnownPaths(AppDomain.CurrentDomain.BaseDirectory);
             
             manager.InvokeProfile();
 
@@ -193,9 +197,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
+
+            CleanupFunctionLoaderStaticPaths();
+            FunctionLoader.SetupWellKnownPaths(System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
-                "Unit/PowerShell/TestScripts/ProfileWithTerminatingError");
+                "Unit/PowerShell/TestScripts/ProfileWithTerminatingError"));
             
             Assert.Throws<CmdletInvocationException>(() => manager.InvokeProfile());
             Assert.Single(logger.FullLog);
@@ -207,15 +213,25 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             var logger = new ConsoleLogger();
             var manager = new PowerShellManager(logger);
-            FunctionLoader.FunctionAppRootLocation = System.IO.Path.Join(
+
+            CleanupFunctionLoaderStaticPaths();
+            FunctionLoader.SetupWellKnownPaths(System.IO.Path.Join(
                 AppDomain.CurrentDomain.BaseDirectory,
-                "Unit/PowerShell/TestScripts/ProfileWithNonTerminatingError");
+                "Unit/PowerShell/TestScripts/ProfileWithNonTerminatingError"));
             
             manager.InvokeProfile();
 
             Assert.Equal(2, logger.FullLog.Count);
             Assert.Equal("Error: ERROR: help me!", logger.FullLog[0]);
             Assert.Matches("Error: Invoking the Profile had errors. See logs for details. Profile location: ", logger.FullLog[1]);
+        }
+
+        // Helper function that sets all the well-known paths in the Function Loader back to null.
+        private void CleanupFunctionLoaderStaticPaths()
+        {
+            FunctionLoader.FunctionAppRootLocation = null;
+            FunctionLoader.FunctionAppProfileLocation = null;
+            FunctionLoader.FunctionAppModulesLocation = null;
         }
     }
 }

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 AppDomain.CurrentDomain.BaseDirectory,
                 "Unit/PowerShell/TestScripts/ProfileWithTerminatingError");
             
-            Assert.Throws(typeof(RuntimeException), () => manager.InvokeProfile());
+            Assert.Throws<RuntimeException>(() => manager.InvokeProfile());
             Assert.Single(logger.FullLog);
             Assert.Matches("Error: Invoking the Profile had errors. See logs for details. Profile location: ", logger.FullLog[0]);
         }

--- a/test/Unit/PowerShell/TestScripts/ProfileBasic/profile.ps1
+++ b/test/Unit/PowerShell/TestScripts/ProfileBasic/profile.ps1
@@ -1,0 +1,1 @@
+Write-Host "Hello PROFILE"

--- a/test/Unit/PowerShell/TestScripts/ProfileWithNonTerminatingError/Profile.ps1
+++ b/test/Unit/PowerShell/TestScripts/ProfileWithNonTerminatingError/Profile.ps1
@@ -1,0 +1,1 @@
+Write-Error "help me!"

--- a/test/Unit/PowerShell/TestScripts/ProfileWithTerminatingError/profile.ps1
+++ b/test/Unit/PowerShell/TestScripts/ProfileWithTerminatingError/profile.ps1
@@ -1,0 +1,1 @@
+throw "help me!"


### PR DESCRIPTION
This allows you to put a `Profile.ps1` in your Function App root that will be run at every COLD START of your Function App. Please refer to the empty `example/PSCoreApp/Profile.ps1` for usecases.

fixes #110 