### PR TITLE
Refactor the code base to make it easy to support concurrency within a worker in future

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
         internal static string FunctionAppRootPath { get; private set; }
         internal static string FunctionAppProfilePath { get; private set; }
-        internal static string FunctionAppModulesPath { get; private set; }
+        internal static string FunctionModulePath { get; private set; }
 
         /// <summary>
         /// Query for function metadata can happen in parallel.
@@ -51,9 +51,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         internal static void SetupWellKnownPaths(FunctionLoadRequest request)
         {
+            // Resolve the FunctionApp root path
             FunctionAppRootPath = Path.GetFullPath(Path.Join(request.Metadata.Directory, ".."));
-            FunctionAppModulesPath =  Path.Join(FunctionAppRootPath, "Modules");
+            // Resolve module paths
+            var appLevelModulesPath = Path.Join(FunctionAppRootPath, "Modules");
+            var workerLevelModulesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
+            FunctionModulePath = $"{appLevelModulesPath}{Path.PathSeparator}{workerLevelModulesPath}";
 
+            // Resolve the FunctionApp profile path
             var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
             var profiles = Directory.EnumerateFiles(FunctionAppRootPath, "profile.ps1", options);
             FunctionAppProfilePath = profiles.FirstOrDefault();

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -72,16 +72,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
 
             // Initialize the Runspace
-            InvokeProfile();
+            InvokeProfile(FunctionLoader.FunctionAppProfilePath);
         }
 
         /// <summary>
-        /// This method invokes the Function App's profile.ps1.
+        /// This method invokes the FunctionApp's profile.ps1.
         /// </summary>
-        internal void InvokeProfile()
+        internal void InvokeProfile(string profilePath)
         {
             Exception exception = null;
-            string profilePath = FunctionLoader.FunctionAppProfilePath;
             if (profilePath == null)
             {
                 _logger.Log(LogLevel.Trace, $"No 'profile.ps1' is found at the FunctionApp root folder: {FunctionLoader.FunctionAppRootPath}");

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -23,34 +23,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         private readonly ILogger _logger;
         private readonly PowerShell _pwsh;
 
-        internal PowerShellManager(ILogger logger)
-        {
-            var initialSessionState = InitialSessionState.CreateDefault();
-
-            // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
-            if(Platform.IsWindows)
-            {
-                // This sets the execution policy on Windows to Unrestricted which is required to run the user's function scripts on
-                // Windows client versions. This is needed if a user is testing their function locally with the func CLI
-                initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
-            }
-            _pwsh = PowerShell.Create(initialSessionState);
-            _logger = logger;
-
-            // Setup Stream event listeners
-            var streamHandler = new StreamHandler(logger);
-            _pwsh.Streams.Debug.DataAdding += streamHandler.DebugDataAdding;
-            _pwsh.Streams.Error.DataAdding += streamHandler.ErrorDataAdding;
-            _pwsh.Streams.Information.DataAdding += streamHandler.InformationDataAdding;
-            _pwsh.Streams.Progress.DataAdding += streamHandler.ProgressDataAdding;
-            _pwsh.Streams.Verbose.DataAdding += streamHandler.VerboseDataAdding;
-            _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
-        }
-
         /// <summary>
-        /// This method performs the one-time initialization at the worker process level.
+        /// Gets the Runspace InstanceId.
         /// </summary>
-        internal void PerformWorkerLevelInitialization()
+        internal Guid InstanceId => _pwsh.Runspace.InstanceId;
+
+        static PowerShellManager()
         {
             // Set the type accelerators for 'HttpResponseContext' and 'HttpResponseContext'.
             // We probably will expose more public types from the worker in future for the interop between worker and the 'PowerShellWorker' module.
@@ -60,16 +38,47 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             var addMethod = accelerator.GetMethod("Add", new Type[] { typeof(string), typeof(Type) });
             addMethod.Invoke(null, new object[] { "HttpResponseContext", typeof(HttpResponseContext) });
             addMethod.Invoke(null, new object[] { "HttpRequestContext", typeof(HttpRequestContext) });
+        }
 
-            // Set the PSModulePath
-            var workerModulesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
-            Environment.SetEnvironmentVariable("PSModulePath", $"{FunctionLoader.FunctionAppModulesPath}{Path.PathSeparator}{workerModulesPath}");
+        internal PowerShellManager(ILogger logger)
+        {
+            if (FunctionLoader.FunctionAppRootPath == null)
+            {
+                throw new InvalidOperationException($"The FunctionApp root hasn't been resolved yet!");
+            }
+
+            var initialSessionState = InitialSessionState.CreateDefault();
+            initialSessionState.EnvironmentVariables.Add(
+                new SessionStateVariableEntry("PSModulePath", FunctionLoader.FunctionModulePath, null));
+
+            // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
+            if(Platform.IsWindows)
+            {
+                // This sets the execution policy on Windows to Unrestricted which is required to run the user's function scripts on
+                // Windows client versions. This is needed if a user is testing their function locally with the func CLI
+                initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
+            }
+
+            _logger = logger;
+            _pwsh = PowerShell.Create(initialSessionState);
+
+            // Setup Stream event listeners
+            var streamHandler = new StreamHandler(logger);
+            _pwsh.Streams.Debug.DataAdding += streamHandler.DebugDataAdding;
+            _pwsh.Streams.Error.DataAdding += streamHandler.ErrorDataAdding;
+            _pwsh.Streams.Information.DataAdding += streamHandler.InformationDataAdding;
+            _pwsh.Streams.Progress.DataAdding += streamHandler.ProgressDataAdding;
+            _pwsh.Streams.Verbose.DataAdding += streamHandler.VerboseDataAdding;
+            _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
+
+            // Initialize the Runspace
+            InvokeProfile();
         }
 
         /// <summary>
-        /// This method performs initialization that has to be done for each Runspace, e.g. running the Function App's profile.ps1.
+        /// This method invokes the Function App's profile.ps1.
         /// </summary>
-        internal void PerformRunspaceLevelInitialization()
+        internal void InvokeProfile()
         {
             Exception exception = null;
             string profilePath = FunctionLoader.FunctionAppProfilePath;
@@ -193,25 +202,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                             .AddParameter("Depth", 3)
                             .AddParameter("Compress", true)
                         .InvokeAndClearCommands<string>()[0];
-        }
-
-        /// <summary>
-        /// Helper method to set the output binding metadata for the function that is about to run.
-        /// </summary>
-        internal void RegisterFunctionMetadata(AzFunctionInfo functionInfo)
-        {
-            var outputBindings = functionInfo.OutputBindings;
-            FunctionMetadata.OutputBindingCache.AddOrUpdate(_pwsh.Runspace.InstanceId,
-                                                            outputBindings,
-                                                            (key, value) => outputBindings);
-        }
-
-        /// <summary>
-        /// Helper method to clear the output binding metadata for the function that has done running.
-        /// </summary>
-        internal void UnregisterFunctionMetadata()
-        {
-            FunctionMetadata.OutputBindingCache.TryRemove(_pwsh.Runspace.InstanceId, out _);
         }
 
         private void ResetRunspace(string moduleName)

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -1,0 +1,63 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.Azure.Functions.PowerShellWorker.Utility;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
+{
+    using System.Management.Automation;
+
+    /// <summary>
+    /// The PowerShellManager pool for the in-proc concurrency support.
+    /// </summary>
+    internal class PowerShellManagerPool
+    {
+        private readonly ILogger _logger;
+        // Today we don't really support the in-proc concurrency. We just hold an instance of PowerShellManager in this field.
+        private PowerShellManager _psManager;
+
+        /// <summary>
+        /// Constructor of the pool.
+        /// </summary>
+        internal PowerShellManagerPool(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Initialize the pool and populate it with PowerShellManager instances.
+        /// When it's time to really implement this pool, we probably should instantiate PowerShellManager instances in a lazy way.
+        /// Maybe start from size 1 and increase the number of workers as needed.
+        /// </summary>
+        internal void Initialize()
+        {
+            _psManager = new PowerShellManager(_logger);
+        }
+
+        /// <summary>
+        /// Checkout an idle PowerShellManager instance.
+        /// When it's time to really implement this pool, this method is supposed to block when there is no idle instance available.
+        /// </summary>
+        internal PowerShellManager CheckoutIdleWorker(AzFunctionInfo functionInfo)
+        {
+            // Register the function with the Runspace before returning the idle PowerShellManager.
+            FunctionMetadata.RegisterFunctionMetadata(_psManager.InstanceId, functionInfo);
+            return _psManager;
+        }
+
+        /// <summary>
+        /// Return a used PowerShellManager instance to the pool.
+        /// </summary>
+        internal void ReclaimUsedWorker(PowerShellManager psManager)
+        {
+            if (psManager != null)
+            {
+                // Unregister the Runspace before reclaiming the used PowerShellManager.
+                FunctionMetadata.UnregisterFunctionMetadata(psManager.InstanceId);
+            }
+        }
+    }
+}

--- a/src/Public/FunctionMetadata.cs
+++ b/src/Public/FunctionMetadata.cs
@@ -26,5 +26,22 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             OutputBindingCache.TryGetValue(runspaceInstanceId, out outputBindings);
             return outputBindings;
         }
+
+        /// <summary>
+        /// Helper method to set the output binding metadata for the function that is about to run.
+        /// </summary>
+        internal static void RegisterFunctionMetadata(Guid instanceId, AzFunctionInfo functionInfo)
+        {
+            var outputBindings = functionInfo.OutputBindings;
+            OutputBindingCache.AddOrUpdate(instanceId, outputBindings, (key, value) => outputBindings);
+        }
+
+        /// <summary>
+        /// Helper method to clear the output binding metadata for the function that has done running.
+        /// </summary>
+        internal static void UnregisterFunctionMetadata(Guid instanceId)
+        {
+            OutputBindingCache.TryRemove(instanceId, out _);
+        }
     }
 }

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -14,44 +14,76 @@ using Xunit;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 {
-    public class PowerShellManagerTests
+    internal class TestUtils
     {
-        private const string TestInputBindingName = "req";
-        private const string TestOutputBindingName = "res";
-        private const string TestStringData = "Foo";
+        internal const string TestInputBindingName = "req";
+        internal const string TestOutputBindingName = "res";
 
-        private readonly string _functionDirectory;
-        private readonly ConsoleLogger _testLogger;
-        private readonly PowerShellManager _testManager;
-        private readonly List<ParameterBinding> _testInputData;
-        private readonly RpcFunctionMetadata _rpcFunctionMetadata;
-        private readonly FunctionLoadRequest _functionLoadRequest;
+        internal static readonly string FunctionDirectory;
+        internal static readonly RpcFunctionMetadata RpcFunctionMetadata;
+        internal static readonly FunctionLoadRequest FunctionLoadRequest;
 
-        public PowerShellManagerTests()
+        static TestUtils()
         {
-            _functionDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestScripts", "PowerShell");
-            _rpcFunctionMetadata = new RpcFunctionMetadata()
+            FunctionDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestScripts", "PowerShell");
+            RpcFunctionMetadata = new RpcFunctionMetadata()
             {
                 Name = "TestFuncApp",
-                Directory = _functionDirectory,
+                Directory = FunctionDirectory,
                 Bindings =
                 {
                     { TestInputBindingName , new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "httpTrigger" } },
                     { TestOutputBindingName, new BindingInfo { Direction = BindingInfo.Types.Direction.Out, Type = "http" } }
                 }
             };
-            _functionLoadRequest = new FunctionLoadRequest {FunctionId = "FunctionId", Metadata = _rpcFunctionMetadata};
-            FunctionLoader.SetupWellKnownPaths(_functionLoadRequest);
 
+            FunctionLoadRequest = new FunctionLoadRequest {FunctionId = "FunctionId", Metadata = RpcFunctionMetadata};
+            FunctionLoader.SetupWellKnownPaths(FunctionLoadRequest);
+        }
+
+        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger)
+        {
+            return new PowerShellManager(logger);
+        }
+
+        internal static AzFunctionInfo NewAzFunctionInfo(string scriptFile, string entryPoint)
+        {
+            RpcFunctionMetadata.ScriptFile = scriptFile;
+            RpcFunctionMetadata.EntryPoint = entryPoint;
+            RpcFunctionMetadata.Directory = Path.GetDirectoryName(scriptFile);
+            return new AzFunctionInfo(RpcFunctionMetadata);
+        }
+
+        internal static void Break()
+        {
+            /*
+            while (!System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Threading.Thread.Sleep(200);
+            }
+            System.Diagnostics.Debugger.Break();
+            */
+        }
+    }
+
+    public class PowerShellManagerTests
+    {
+        private const string TestStringData = "Foo";
+
+        private readonly ConsoleLogger _testLogger;
+        private readonly PowerShellManager _testManager;
+        private readonly List<ParameterBinding> _testInputData;
+
+        public PowerShellManagerTests()
+        {
             _testLogger = new ConsoleLogger();
-            _testManager = new PowerShellManager(_testLogger);
-            _testManager.PerformWorkerLevelInitialization();
+            _testManager = TestUtils.NewTestPowerShellManager(_testLogger);
 
             _testInputData = new List<ParameterBinding>
             {
                 new ParameterBinding
                 {
-                    Name = TestInputBindingName,
+                    Name = TestUtils.TestInputBindingName,
                     Data = new TypedData
                     {
                         String = TestStringData
@@ -60,65 +92,66 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             };
         }
 
-        private AzFunctionInfo GetAzFunctionInfo(string scriptFile, string entryPoint)
-        {
-            _rpcFunctionMetadata.ScriptFile = scriptFile;
-            _rpcFunctionMetadata.EntryPoint = entryPoint;
-            return new AzFunctionInfo(_rpcFunctionMetadata);
-        }
-
         [Fact]
         public void InvokeBasicFunctionWorks()
         {
-            string path = Path.Join(_functionDirectory, "testBasicFunction.ps1");
+            TestUtils.Break();
 
-            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            string path = Path.Join(TestUtils.FunctionDirectory, "testBasicFunction.ps1");
+
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, string.Empty);
             Hashtable result = _testManager.InvokeFunction(functionInfo, null, _testInputData);
 
-            Assert.Equal(TestStringData, result[TestOutputBindingName]);
+            Assert.Equal(TestStringData, result[TestUtils.TestOutputBindingName]);
         }
 
         [Fact]
         public void InvokeBasicFunctionWithTriggerMetadataWorks()
         {
-            string path = Path.Join(_functionDirectory, "testBasicFunctionWithTriggerMetadata.ps1");
+            TestUtils.Break();
+
+            string path = Path.Join(TestUtils.FunctionDirectory, "testBasicFunctionWithTriggerMetadata.ps1");
             Hashtable triggerMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase)
             {
-                { TestInputBindingName, TestStringData }
+                { TestUtils.TestInputBindingName, TestStringData }
             };
 
-            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, string.Empty);
             Hashtable result = _testManager.InvokeFunction(functionInfo, triggerMetadata, _testInputData);
 
-            Assert.Equal(TestStringData, result[TestOutputBindingName]);
+            Assert.Equal(TestStringData, result[TestUtils.TestOutputBindingName]);
         }
 
         [Fact]
         public void InvokeFunctionWithEntryPointWorks()
         {
-            string path = Path.Join(_functionDirectory, "testFunctionWithEntryPoint.psm1");
-            var functionInfo = GetAzFunctionInfo(path, "Run");
+            TestUtils.Break();
+
+            string path = Path.Join(TestUtils.FunctionDirectory, "testFunctionWithEntryPoint.psm1");
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, "Run");
             Hashtable result = _testManager.InvokeFunction(functionInfo, null, _testInputData);
 
-            Assert.Equal(TestStringData, result[TestOutputBindingName]);
+            Assert.Equal(TestStringData, result[TestUtils.TestOutputBindingName]);
         }
 
         [Fact]
         public void FunctionShouldCleanupVariableTable()
         {
-            string path = Path.Join(_functionDirectory, "testFunctionCleanup.ps1");
-            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            TestUtils.Break();
+
+            string path = Path.Join(TestUtils.FunctionDirectory, "testFunctionCleanup.ps1");
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, string.Empty);
 
             Hashtable result1 = _testManager.InvokeFunction(functionInfo, null, _testInputData);
-            Assert.Equal("is not set", result1[TestOutputBindingName]);
+            Assert.Equal("is not set", result1[TestUtils.TestOutputBindingName]);
 
-            // the value shoould not change if the variable table is properly cleaned up.
+            // the value should not change if the variable table is properly cleaned up.
             Hashtable result2 = _testManager.InvokeFunction(functionInfo, null, _testInputData);
-            Assert.Equal("is not set", result2[TestOutputBindingName]);
+            Assert.Equal("is not set", result2[TestUtils.TestOutputBindingName]);
         }
 
         [Fact]
-        public void ModulePathShouldBeSetByWorkerLevelInitialization()
+        public void ModulePathShouldBeSetCorrectly()
         {
             string workerModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
             string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
@@ -129,13 +162,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         [Fact]
         public void RegisterAndUnregisterFunctionMetadataShouldWork()
         {
-            string path = Path.Join(_functionDirectory, "testBasicFunction.ps1");
-            var functionInfo = GetAzFunctionInfo(path, string.Empty);
+            string path = Path.Join(TestUtils.FunctionDirectory, "testBasicFunction.ps1");
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, string.Empty);
 
             Assert.Empty(FunctionMetadata.OutputBindingCache);
-            _testManager.RegisterFunctionMetadata(functionInfo);
+            FunctionMetadata.RegisterFunctionMetadata(_testManager.InstanceId, functionInfo);
             Assert.Single(FunctionMetadata.OutputBindingCache);
-            _testManager.UnregisterFunctionMetadata();
+            FunctionMetadata.UnregisterFunctionMetadata(_testManager.InstanceId);
             Assert.Empty(FunctionMetadata.OutputBindingCache);
         }
 
@@ -144,20 +177,20 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             //initialize fresh log
             _testLogger.FullLog.Clear();
-            var funcLoadReq = _functionLoadRequest.Clone();
-            funcLoadReq.Metadata.Directory = Path.Join(_functionDirectory, "ProfileBasic", "Func1");
+            var funcLoadReq = TestUtils.FunctionLoadRequest.Clone();
+            funcLoadReq.Metadata.Directory = Path.Join(TestUtils.FunctionDirectory, "ProfileBasic", "Func1");
 
             try
             {
                 FunctionLoader.SetupWellKnownPaths(funcLoadReq);
-                _testManager.PerformRunspaceLevelInitialization();
+                _testManager.InvokeProfile();
 
                 Assert.Single(_testLogger.FullLog);
                 Assert.Equal("Information: INFORMATION: Hello PROFILE", _testLogger.FullLog[0]);
             }
             finally
             {
-                FunctionLoader.SetupWellKnownPaths(_functionLoadRequest);
+                FunctionLoader.SetupWellKnownPaths(TestUtils.FunctionLoadRequest);
             }
         }
 
@@ -166,20 +199,20 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             //initialize fresh log
             _testLogger.FullLog.Clear();
-            var funcLoadReq = _functionLoadRequest.Clone();
+            var funcLoadReq = TestUtils.FunctionLoadRequest.Clone();
             funcLoadReq.Metadata.Directory = AppDomain.CurrentDomain.BaseDirectory;
 
             try
             {
                 FunctionLoader.SetupWellKnownPaths(funcLoadReq);
-                _testManager.PerformRunspaceLevelInitialization();
+                _testManager.InvokeProfile();
 
                 Assert.Single(_testLogger.FullLog);
                 Assert.Matches("Trace: No 'profile.ps1' is found at the FunctionApp root folder: ", _testLogger.FullLog[0]);
             }
             finally
             {
-                FunctionLoader.SetupWellKnownPaths(_functionLoadRequest);
+                FunctionLoader.SetupWellKnownPaths(TestUtils.FunctionLoadRequest);
             }
         }
 
@@ -188,20 +221,20 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             //initialize fresh log
             _testLogger.FullLog.Clear();
-            var funcLoadReq = _functionLoadRequest.Clone();
-            funcLoadReq.Metadata.Directory = Path.Join(_functionDirectory, "ProfileWithTerminatingError", "Func1");
+            var funcLoadReq = TestUtils.FunctionLoadRequest.Clone();
+            funcLoadReq.Metadata.Directory = Path.Join(TestUtils.FunctionDirectory, "ProfileWithTerminatingError", "Func1");
 
             try
             {
                 FunctionLoader.SetupWellKnownPaths(funcLoadReq);
 
-                Assert.Throws<CmdletInvocationException>(() => _testManager.PerformRunspaceLevelInitialization());
+                Assert.Throws<CmdletInvocationException>(() => _testManager.InvokeProfile());
                 Assert.Single(_testLogger.FullLog);
                 Assert.Matches("Error: Fail to run profile.ps1. See logs for detailed errors. Profile location: ", _testLogger.FullLog[0]);
             }
             finally
             {
-                FunctionLoader.SetupWellKnownPaths(_functionLoadRequest);
+                FunctionLoader.SetupWellKnownPaths(TestUtils.FunctionLoadRequest);
             }
         }
 
@@ -210,13 +243,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             //initialize fresh log
             _testLogger.FullLog.Clear();
-            var funcLoadReq = _functionLoadRequest.Clone();
-            funcLoadReq.Metadata.Directory = Path.Join(_functionDirectory, "ProfileWithNonTerminatingError", "Func1");
+            var funcLoadReq = TestUtils.FunctionLoadRequest.Clone();
+            funcLoadReq.Metadata.Directory = Path.Join(TestUtils.FunctionDirectory, "ProfileWithNonTerminatingError", "Func1");
 
             try
             {
                 FunctionLoader.SetupWellKnownPaths(funcLoadReq);
-                _testManager.PerformRunspaceLevelInitialization();
+                _testManager.InvokeProfile();
 
                 Assert.Equal(2, _testLogger.FullLog.Count);
                 Assert.Equal("Error: ERROR: help me!", _testLogger.FullLog[0]);
@@ -224,7 +257,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             }
             finally
             {
-                FunctionLoader.SetupWellKnownPaths(_functionLoadRequest);
+                FunctionLoader.SetupWellKnownPaths(TestUtils.FunctionLoadRequest);
             }
         }
     }

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         public TypeExtensionsTests()
         {
             _testLogger = new ConsoleLogger();
-            _testManager = new PowerShellManager(_testLogger);
+            _testManager = TestUtils.NewTestPowerShellManager(_testLogger);
         }
 
         #region TypedDataToObject


### PR DESCRIPTION
Refactor the code base to make it easy to support concurrency within a worker in future.
- Add `PowerShellManagerPool` , but it's just the skeleton. Today the pool only has one PowerShellManager instance. We can add the real pool implementation if we decide to support concurrency within a worker process.
- Setup the `PSModule` environment variable as part of `Runspace.Open` by using `InitialSessionState.EnvironmentVariables`. This fixes the mysterious `ModulePathShouldBeSetCorrectly` test failure by making sure the env variable is set to the expected one as part of the `Runspace.Open` of every `PowerShellManager`. It failed before because:
   1. `dotnet test` runs tests in parallel by default
   1. when creating a new `PowerShellManager`, the `PSModulePath` environment variable will be set again within `Runspace.Open` (by `SetModulePath` called from `ModuleIntrisic` constructor). That makes value unexpected.
- Update tests to make them more reliable.