### PR TITLE
Add ManagedDependencies folder to Function App module path.

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -53,10 +53,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         {
             // Resolve the FunctionApp root path
             FunctionAppRootPath = Path.GetFullPath(Path.Join(request.Metadata.Directory, ".."));
+
             // Resolve module paths
             var appLevelModulesPath = Path.Join(FunctionAppRootPath, "Modules");
             var workerLevelModulesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
-            FunctionModulePath = $"{appLevelModulesPath}{Path.PathSeparator}{workerLevelModulesPath}";
+
+            // Managed dependencies are modules managed by Azure Functions
+            var workerLevelManagedDependencies = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "ManagedDependencies");
+
+            // Set FunctionApp module path
+            FunctionModulePath = $"{appLevelModulesPath}{Path.PathSeparator}" +
+                                 $"{workerLevelModulesPath}{Path.PathSeparator}" +
+                                 $"{workerLevelManagedDependencies}";
 
             // Resolve the FunctionApp profile path
             var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -59,12 +59,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             var workerLevelModulesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
 
             // Managed dependencies are modules managed by Azure Functions
-            var workerLevelManagedDependencies = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "ManagedDependencies");
+            var appLevelManagedDependenciesPath = Path.Join(FunctionAppRootPath, "ManagedDependencies");
 
             // Set FunctionApp module path
             FunctionModulePath = $"{appLevelModulesPath}{Path.PathSeparator}" +
                                  $"{workerLevelModulesPath}{Path.PathSeparator}" +
-                                 $"{workerLevelManagedDependencies}";
+                                 $"{appLevelManagedDependenciesPath}";
 
             // Resolve the FunctionApp profile path
             var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -147,8 +147,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         public void ModulePathShouldBeSetCorrectly()
         {
             string workerModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
+            string workerManagedDependenciesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "ManagedDependencies");
             string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
-            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{workerModulePath}";
+            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}" +
+                                  $"{workerModulePath}{Path.PathSeparator}" +
+                                  $"{workerManagedDependenciesPath}";
             Assert.Equal(expectedPath, Environment.GetEnvironmentVariable("PSModulePath"));
         }
 

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -147,11 +147,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         public void ModulePathShouldBeSetCorrectly()
         {
             string workerModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
-            string workerManagedDependenciesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "ManagedDependencies");
             string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
+            string funcAppManagedDependenciesPath = Path.Join(FunctionLoader.FunctionAppRootPath, "ManagedDependencies");
             string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}" +
                                   $"{workerModulePath}{Path.PathSeparator}" +
-                                  $"{workerManagedDependenciesPath}";
+                                  $"{funcAppManagedDependenciesPath}";
             Assert.Equal(expectedPath, Environment.GetEnvironmentVariable("PSModulePath"));
         }
 


### PR DESCRIPTION
Add ManagedDependencies folder to Function App module path:

* When a new Function App is initialized locally (via func init), the managedDependencies setting will be added to the host.json on the local machine for PowerShell. The initialization of the Function App will download the latest Azure (Az) modules and place them in the ManagedDependencies folder in the Function App. When a function is uploaded, the values in host.json is read and this is applied to the Function App. The local modules  in the ManagedDependencies folder are not packaged up and uploaded to the service.

* During function runtime in the service, if the managedDependencies setting is set, the latest module version of the modules are used in the service. Azure Functions has a service in the back end which manage minor updates for the Azure modules and makes them available to the customer at runtime. 

* Module’s folder structure for a Function App:
c:\MyFunction\Modules                            --> These are the customer modules
c:\MyFunction\ManagedDependencies    --> These are modules managed by Azure Functions


### Client UX from CLI + PowerShell Core
```powershell
<#
Prerequisites: 
    - PowerShell Core
    - Func.exe via CLI
#>

# Start PowerShell Core.
# Make sure the Functions CLI is part of the PATH environment. 

# Create a local directory where the function app will be created
New-Item -Path c:\MyFunction -ItemType Directory -Force

# Create a function app via func.exe. When running this command,
# the user gets prompt to install Managed Dependencies
func init MyFunctionApplication --worker-runtime powershell

# Prompt  the user
Would you like to install the Azure modules and have these automatically managed in Azure?
Yes

<#
# After this, the Az modules are installed under the Function App
c:\MyFunction\Modules
c:\MyFunction\ManagedDependencies\Az
c:\MyFunction\ManagedDependencies\Az\1.0.0
c:\MyFunction\ManagedDependencies\Az.Aks\1.0.0
c:\MyFunction\ManagedDependencies\Az.AnalysisServices\1.0.0
c:\MyFunction\ManagedDependencies\Az.ApiManagement\1.0.0
c:\MyFunction\ManagedDependencies\Az.ApplicationInsights\1.0.0
c:\MyFunction\ManagedDependencies\Az.Automation\1.0.0
c:\MyFunction\ManagedDependencies\Az.Batch\1.0.0
c:\MyFunction\ManagedDependencies\Az.Billing\1.0.0
c:\MyFunction\ManagedDependencies\Az.Cdn\1.0.0
# More Az modules...
#>

# Entry in Host.json for managed dependencies
Host.json file:
    "managedDependencies": [
        {
            "Name": "Az",
            "MajorVersion": "~1"            
        }
    ]

```



