### PR TITLE
Enter-PSHostProcess workaround

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -67,6 +67,13 @@ if(!$NoBuild.IsPresent) {
     }
 
     Invoke-PSDepend -Path $requirements -Force
+
+    # TODO: Remove this once the SDK properly bundles modules
+    Get-WebFile -Url 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1' `
+        -OutFile "$PSScriptRoot/src/Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1"
+    Get-WebFile -Url 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1' `
+        -OutFile "$PSScriptRoot/src/Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1" 
+
     dotnet publish -c $Configuration $PSScriptRoot
     dotnet pack -c $Configuration "$PSScriptRoot/package"
 }

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -11,7 +11,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/dev/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/azure-functions-powershell-worker</projectUrl>
     <iconUrl>https://github.com/PowerShell/PowerShell/blob/master/assets/Powershell_black_64.png?raw=true</iconUrl>
     <description>The Azure Function PowerShell Language Worker allows users to write Azure Function Apps using PowerShell. It leverages the PowerShell Core SDK.</description>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -18,8 +18,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Grpc" Version="1.14.1" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />

--- a/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.2" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -174,7 +174,7 @@ function Get-WebFile {
         [string] $OutFile
     )
     $directoryName = [System.IO.Path]::GetDirectoryName($OutFile)
-    if (!Test-Path $directoryName) {
+    if (!(Test-Path $directoryName)) {
         New-Item -Type Directory $directoryName
     }
     Remove-Item $OutFile -ErrorAction SilentlyContinue

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -168,6 +168,19 @@ function Resolve-ProtoBufToolPath
     }
 }
 
+function Get-WebFile {
+    param (
+        [string] $Url,
+        [string] $OutFile
+    )
+    $directoryName = [System.IO.Path]::GetDirectoryName($OutFile)
+    if (!Test-Path $directoryName) {
+        New-Item -Type Directory $directoryName
+    }
+    Remove-Item $OutFile -ErrorAction SilentlyContinue
+    Invoke-RestMethod $Url -OutFile $OutFile
+}
+
 function Invoke-Tests
 {
     param(


### PR DESCRIPTION
Today, the PowerShell SDK does not lay out the modules in such a way that is easily importable by PSModulePath.

Until that day, we will simply bundle the `psd1`s of the `Microsoft.PowerShell.Utility` and `Microsoft.PowerShell.Management` modules with the worker.

In addition to that change, we need to also upgrade to preview3 for Enter-PSHostProcess to work on Unix. This required updating our version of `Newtonsoft.Json` since PowerShell SDK relies on `12.0.1`.

This PR also contains a tiny fix to the nuspec so that it builds the package without error - the `licenseUrl` field is deprecated in favor of the `license` field.