### PR TITLE
fix test failure on pwsh 6.2-preview.3

### DIFF
--- a/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -200,8 +200,13 @@ Describe 'Azure Functions PowerShell Langauge Worker Helper Module Tests' {
 
             $outStringResults = Write-TestObject | Out-String -Stream
             $ps.Streams.Information.Count | Should -BeExactly ($outStringResults.Count + 1)
-            $countWithoutTrailingNewLines = $outStringResults.Count - 2
-            for ($i = 0; $i -lt $countWithoutTrailingNewLines; $i++) {
+
+            $lastNonWhitespaceItem = $outStringResults.Count
+            while ([string]::IsNullOrWhiteSpace($outStringResults[$lastNonWhitespaceItem])) {
+                $lastNonWhitespaceItem--
+            }
+
+            for ($i = 0; $i -le $lastNonWhitespaceItem; $i++) {
                 $ps.Streams.Information[$i].MessageData | Should -BeExactly $outStringResults[$i]
                 $ps.Streams.Information[$i].Tags | Should -BeExactly "__PipelineObject__"
             }

--- a/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -201,7 +201,7 @@ Describe 'Azure Functions PowerShell Langauge Worker Helper Module Tests' {
             $outStringResults = Write-TestObject | Out-String -Stream
             $ps.Streams.Information.Count | Should -BeExactly ($outStringResults.Count + 1)
 
-            $lastNonWhitespaceItem = $outStringResults.Count
+            $lastNonWhitespaceItem = $outStringResults.Count - 1
             while ([string]::IsNullOrWhiteSpace($outStringResults[$lastNonWhitespaceItem])) {
                 $lastNonWhitespaceItem--
             }


### PR DESCRIPTION
Formatting tables is different in pwsh 6.2-preview.3. We can no longer be sure that the last 2 items in a format-table string are new lines.

Now we walk backwards until we hit the last not whitespace line.