### PR TITLE
Build against dotnet SDK 2.2

### DIFF
--- a/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
@@ -4,7 +4,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -5,7 +5,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>  
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Product>Azure Function PowerShell Language Worker</Product>
     <AssemblyName>Microsoft.Azure.Functions.PowerShellWorker</AssemblyName>
     

--- a/test/E2E/setupE2Etests.ps1
+++ b/test/E2E/setupE2Etests.ps1
@@ -36,7 +36,7 @@ Write-Host "Copying azure-functions-powershell-worker to  Functions Host workers
 
 $configuration = if ($env:CONFIGURATION) { $env:CONFIGURATION } else { 'Debug' }
 Remove-Item -Recurse -Force -Path "$FUNC_CLI_DIRECTORY/workers/powershell"
-Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp2.1/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
+Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp2.2/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
 
 Write-Host "Staring Functions Host..."
 

--- a/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -49,7 +49,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = 'release',
-        [string]$Version = '2.1.401'
+        [string]$Version = '2.2.102'
     )
 
     try {


### PR DESCRIPTION
Build against dotnet SDK 2.2. The latest Azure-Function-Host is being built against dotnet 2.2 now.