### PR TITLE
Powershell custom module path support

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -46,13 +46,27 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         }
 
         /// <summary>
+        /// Sets up paths to powershell runtime resources
+        /// </summary>
+        /// <param name="functionBaseDirectory"> Function base directory</param>
+        /// <param name="managedModulePath">Managed module path</param>
+        internal static void SetupRuntimePaths(string functionBaseDirectory, string managedModulePath)
+        {
+            SetupWellKnownPaths(functionBaseDirectory);
+
+            // Setup managed module path only after setting up well know paths.
+            // This is important for preserving the priority (override) of function app modules over managed modules.
+            TrySetupManagedModulePath(managedModulePath);
+        }
+
+        /// <summary>
         /// Setup the well known paths about the FunctionApp.
         /// This method is called only once during the code start.
         /// </summary>
-        internal static void SetupWellKnownPaths(FunctionLoadRequest request)
+        private static void SetupWellKnownPaths(string functionBaseDirectory)
         {
             // Resolve the FunctionApp root path
-            FunctionAppRootPath = Path.GetFullPath(Path.Join(request.Metadata.Directory, ".."));
+            FunctionAppRootPath = Path.GetFullPath(Path.Join(functionBaseDirectory, ".."));
             // Resolve module paths
             var appLevelModulesPath = Path.Join(FunctionAppRootPath, "Modules");
             var workerLevelModulesPath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
@@ -62,6 +76,26 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
             var profiles = Directory.EnumerateFiles(FunctionAppRootPath, "profile.ps1", options);
             FunctionAppProfilePath = profiles.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Validates and appends managed module path (if supplied) to PsModulePath
+        /// </summary>
+        /// <param name="managedModulePath">Managed module path</param>
+        private static void TrySetupManagedModulePath(string managedModulePath)
+        {
+            if (string.IsNullOrEmpty(managedModulePath))
+            {
+                return; // no-op : for case in which no managed module path is supplied.
+            }
+
+            if (!Directory.Exists(managedModulePath))
+            {
+                // If a path is supplied, it should be a valid path
+                throw new ArgumentException("Invalid managed module path: '{0}'", managedModulePath);
+            }
+
+            FunctionModulePath = $"{FunctionModulePath}{Path.PathSeparator}{managedModulePath}";
         }
     }
 }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -20,15 +20,22 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
         private readonly FunctionLoader _functionLoader;
         private readonly MessagingStream _msgStream;
         private readonly PowerShellManagerPool _powershellPool;
+        private readonly string _managedModulePath;
 
         // Indicate whether the FunctionApp has been initialized.
         private bool _isFunctionAppInitialized;
 
-        internal RequestProcessor(MessagingStream msgStream)
+        internal RequestProcessor(RuntimeContext runtimeContext)
         {
-            _msgStream = msgStream;
-            _powershellPool = new PowerShellManagerPool(msgStream);
+            if (runtimeContext == null)
+            {
+                throw new ArgumentNullException("runtimeContext");
+            }
+
+            _msgStream = runtimeContext.MsgStream;
+            _powershellPool = new PowerShellManagerPool(runtimeContext.MsgStream);
             _functionLoader = new FunctionLoader();
+            _managedModulePath = runtimeContext.ManagedModulePath;
         }
 
         internal async Task ProcessRequestLoop()
@@ -92,7 +99,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 // 'FunctionLoadRequest' comes in. Therefore, we run initialization here.
                 if (!_isFunctionAppInitialized)
                 {
-                    FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
+                    FunctionLoader.SetupRuntimePaths(functionLoadRequest.Metadata.Directory, _managedModulePath);
                     _powershellPool.Initialize(request.RequestId);
                     _isFunctionAppInitialized = true;
                 }

--- a/src/RuntimeContext.cs
+++ b/src/RuntimeContext.cs
@@ -1,0 +1,37 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
+using System;
+using System.IO;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker
+{
+    internal class RuntimeContext
+    {
+        public RuntimeContext(MessagingStream msgStream, string managedModulePath)
+        {
+            if (!IsModulePathValid(managedModulePath))
+            {
+                throw new ArgumentException("Invalid managed module path: '{0}'", managedModulePath);
+            }
+            this.MsgStream = msgStream;
+            this.ManagedModulePath = managedModulePath;
+        }
+
+        internal MessagingStream MsgStream { get; private set; }
+
+        internal string ManagedModulePath { get; private set; }
+
+        /// <summary>
+        /// Checkes if the managed module path is valid
+        /// </summary>
+        /// <param name="managedModulePath">Path</param>
+        /// <returns>True if (i) path is not specified or (ii) specified path exists. False otherwise.</returns>
+        private bool IsModulePathValid(string managedModulePath)
+        {   // Empty/null path is okay.  If a path is supplied, it should be a valid path
+            return string.IsNullOrEmpty(managedModulePath) || Directory.Exists(managedModulePath);
+        }
+    }
+}

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 .WithNotParsed(err => Environment.Exit(1));
 
             var msgStream = new MessagingStream(arguments.Host, arguments.Port);
-            var requestProcessor = new RequestProcessor(msgStream);
+            var runtimeContext = new RuntimeContext(msgStream, arguments.ManagedModulePath);
+            var requestProcessor = new RequestProcessor(runtimeContext);
 
             // Send StartStream message
             var startedMessage = new StreamingMessage() {
@@ -59,5 +60,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
         [Option("grpcMaxMessageLength", Required = true, HelpText = "gRPC Maximum message size.")]
         public int MaxMessageLength { get; set; }
+
+        // This property is currently marked as optional in order to maintain the backward compatibility with the host as the host does not pass this param yet.
+        [Option("managedModulePath", Required = false, HelpText = "Managed module path.")]
+        public string ManagedModulePath { get; set; }
     }
 }

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             };
 
             FunctionLoadRequest = new FunctionLoadRequest {FunctionId = "FunctionId", Metadata = RpcFunctionMetadata};
-            FunctionLoader.SetupWellKnownPaths(FunctionLoadRequest);
+            FunctionLoader.SetupRuntimePaths(FunctionLoadRequest.Metadata.Directory, managedModulePath: string.Empty);
         }
 
         // Have a single place to get a PowerShellManager for testing.

--- a/test/Unit/PowerShell/PowershellManagedModulePathTests.cs
+++ b/test/Unit/PowerShell/PowershellManagedModulePathTests.cs
@@ -50,11 +50,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Unit.PowerShell
             // create a temporary managed module directory
             Directory.CreateDirectory(validManagedModulePath);
 
-            FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
-            Assert.Contains(validManagedModulePath, FunctionLoader.FunctionModulePath);
-
-            // clean up temporary managed module directory
-            Directory.Delete(validManagedModulePath);
+            try
+            {
+                FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
+                Assert.Contains(validManagedModulePath, FunctionLoader.FunctionModulePath);
+            }
+            finally
+            {
+                // clean up temporary managed module directory
+                Directory.Delete(validManagedModulePath);
+            }
         }
 
         [Fact]
@@ -63,13 +68,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Unit.PowerShell
             var validManagedModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, this.GetRandomFolderName());
             Directory.CreateDirectory(validManagedModulePath);
 
-            FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
-            string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
-            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{_workerModulePath}{Path.PathSeparator}{validManagedModulePath}";
+            try
+            {
+                FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
+                string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
+                string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{_workerModulePath}{Path.PathSeparator}{validManagedModulePath}";
 
-            Assert.Equal(expectedPath, FunctionLoader.FunctionModulePath);
-
-            Directory.Delete(validManagedModulePath);
+                Assert.Equal(expectedPath, FunctionLoader.FunctionModulePath);
+            }
+            finally
+            {
+                Directory.Delete(validManagedModulePath);
+            }
         }
 
         private string GetRandomFolderName()

--- a/test/Unit/PowerShell/PowershellManagedModulePathTests.cs
+++ b/test/Unit/PowerShell/PowershellManagedModulePathTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Unit.PowerShell
+{
+    public class PowershellManagedModulePathTests
+    {
+        private readonly string _functionDirectory;
+        private readonly string _workerModulePath;
+
+        public PowershellManagedModulePathTests()
+        {
+            _functionDirectory = TestUtils.FunctionDirectory;
+            _workerModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "Modules");
+        }
+
+        [Fact]
+        public void FunctionLoaderHandlesEmptyManagedModulePath()
+        {
+            FunctionLoader.SetupRuntimePaths(_functionDirectory, string.Empty);
+            string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
+            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{_workerModulePath}";
+            Assert.Equal(expectedPath, FunctionLoader.FunctionModulePath);
+        }
+
+        [Fact]
+        public void FunctionLoaderHandlesNullManagedModulePath()
+        {
+            FunctionLoader.SetupRuntimePaths(_functionDirectory, null);
+            string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
+            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{_workerModulePath}";
+            Assert.Equal(expectedPath, FunctionLoader.FunctionModulePath);
+        }
+
+        [Fact]
+        public void FunctionLoaderThrowsUponNonExistentManagedModulePath()
+        {
+            var nonExistentManagedModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, this.GetRandomFolderName());
+
+            Assert.Throws<ArgumentException>(() => FunctionLoader.SetupRuntimePaths(_functionDirectory, nonExistentManagedModulePath));
+        }
+
+        [Fact]
+        public void FunctionLoaderIncludesValidManagedModulePath()
+        {
+            var validManagedModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, this.GetRandomFolderName());
+            // create a temporary managed module directory
+            Directory.CreateDirectory(validManagedModulePath);
+
+            FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
+            Assert.Contains(validManagedModulePath, FunctionLoader.FunctionModulePath);
+
+            // clean up temporary managed module directory
+            Directory.Delete(validManagedModulePath);
+        }
+
+        [Fact]
+        public void FunctionLoaderAddsValidManagedModulePathAfterAppModulePaths()
+        {
+            var validManagedModulePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, this.GetRandomFolderName());
+            Directory.CreateDirectory(validManagedModulePath);
+
+            FunctionLoader.SetupRuntimePaths(_functionDirectory, validManagedModulePath);
+            string funcAppModulePath = Path.Join(FunctionLoader.FunctionAppRootPath, "Modules");
+            string expectedPath = $"{funcAppModulePath}{Path.PathSeparator}{_workerModulePath}{Path.PathSeparator}{validManagedModulePath}";
+
+            Assert.Equal(expectedPath, FunctionLoader.FunctionModulePath);
+
+            Directory.Delete(validManagedModulePath);
+        }
+
+        private string GetRandomFolderName()
+        {
+            // Path.GetRandomFileName() generates a 12 chars with dot starting at the 9th position. So, take the first 8 chars.
+            return Path.GetRandomFileName().Substring(0, 8);
+        }
+    }
+}


### PR DESCRIPTION
-Adding managed module path support for powershell runtime.
- Passing managedModulePath is curretly optional for backward compatibility
- ManagedModulePath setup tests are included