### PR TITLE
Make the Hashtable returned from ConvertFromJson case-insensitive as long as possible

### DIFF
--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -118,6 +118,21 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             {
                 retObj = psObj.BaseObject;
             }
+
+            if (retObj is Hashtable hashtable)
+            {
+                try
+                {
+                    // ConvertFromJson returns case-sensitive Hashtable by design -- JSON may contain keys that only differ in case.
+                    // We try casting the Hashtable to a case-insensitive one, but if that fails, we keep using the original one.
+                    retObj = new Hashtable(hashtable, StringComparer.OrdinalIgnoreCase);
+                }
+                catch
+                {
+                    retObj = hashtable;
+                }
+            }
+
             return retObj;
         }
 

--- a/test/E2E/HttpTrigger.Tests.ps1
+++ b/test/E2E/HttpTrigger.Tests.ps1
@@ -16,38 +16,59 @@ Describe 'HttpTrigger Tests' {
         Get-Job -Name FuncJob -ErrorAction SilentlyContinue | Stop-Job | Remove-Job
     }
 
-    It "Test basic HttpTrigger function - Ok - <FunctionName>" -TestCases @(
-        @{ 
-            FunctionName = 'TestBasicHttpTrigger'
-            ExpectedContent = 'Hello Atlas'
-        },
-        @{ 
-            FunctionName = 'TestBasicHttpTriggerWithTriggerMetadata'
-            ExpectedContent = 'Hello Atlas'
-        },
-        @{
-            FunctionName = 'TestBasicHttpTriggerWithProfile'
-            ExpectedContent = 'PROFILE'
-        },
-        @{
-            FunctionName = 'TestHttpTriggerWithEntryPoint'
-            ExpectedContent = 'Hello Atlas'
-        },
-        @{
-            FunctionName = 'TestHttpTriggerWithEntryPointAndTriggerMetadata'
-            ExpectedContent = 'Hello Atlas'
-        },
-        @{
-            FunctionName = 'TestHttpTriggerWithEntryPointAndProfile'
-            ExpectedContent = 'PROFILE'
+    Context "Test basic HttpTrigger function - Ok" {
+        BeforeAll {
+            $testCases = @(
+                @{
+                    FunctionName = 'TestBasicHttpTrigger'
+                    ExpectedContent = 'Hello Atlas'
+                    Parameter = 'Name'
+                },
+                @{
+                    FunctionName = 'TestBasicHttpTriggerWithTriggerMetadata'
+                    ExpectedContent = 'Hello Atlas'
+                    Parameter = 'name'
+                },
+                @{
+                    FunctionName = 'TestBasicHttpTriggerWithProfile'
+                    ExpectedContent = 'PROFILE'
+                    Parameter = 'Name'
+                },
+                @{
+                    FunctionName = 'TestHttpTriggerWithEntryPoint'
+                    ExpectedContent = 'Hello Atlas'
+                    Parameter = 'name'
+                },
+                @{
+                    FunctionName = 'TestHttpTriggerWithEntryPointAndTriggerMetadata'
+                    ExpectedContent = 'Hello Atlas'
+                    Parameter = 'Name'
+                },
+                @{
+                    FunctionName = 'TestHttpTriggerWithEntryPointAndProfile'
+                    ExpectedContent = 'PROFILE'
+                    Parameter = 'name'
+                }
+            )
         }
-    ) {
-        param ($FunctionName, $ExpectedContent)
 
-        $res = Invoke-WebRequest "$FUNCTIONS_BASE_URL/api/$($FunctionName)?Name=Atlas"
-        
-        $res.StatusCode | Should -Be ([HttpStatusCode]::Accepted)
-        $res.Content | Should -Be $ExpectedContent
+        It "Http GET request - <FunctionName>" -TestCases $testCases {
+            param ($FunctionName, $ExpectedContent, $Parameter)
+
+            $res = Invoke-WebRequest "${FUNCTIONS_BASE_URL}/api/${FunctionName}?${Parameter}=Atlas"
+
+            $res.StatusCode | Should -Be ([HttpStatusCode]::Accepted)
+            $res.Content | Should -Be $ExpectedContent
+        }
+
+        It "Http POST request - <FunctionName>" -TestCases $testCases {
+            param ($FunctionName, $ExpectedContent, $Parameter)
+
+            $res = Invoke-WebRequest "${FUNCTIONS_BASE_URL}/api/${FunctionName}" -Body "{ `"$Parameter`" : `"Atlas`" }" -Method Post -ContentType "application/json"
+
+            $res.StatusCode | Should -Be ([HttpStatusCode]::Accepted)
+            $res.Content | Should -Be $ExpectedContent
+        }
     }
 
     It "Test basic HttpTrigger function - BadRequest - <FunctionName>" -TestCases @(


### PR DESCRIPTION
Fix #137

Cast the Hashtable returned from `JsonObject.CovnertFromJson` to a case-insensitive Hashtable as long as it's doable.
If the cast fails, because of keys differ only in case, then we use the original case-sensitive Hashtable.