### PR TITLE
Use ConvertFromJson/ConvertToJson APIs directly

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -190,18 +190,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             }
         }
 
-        /// <summary>
-        /// Helper method to convert the result returned from a function to JSON.
-        /// </summary>
-        internal string ConvertToJson(object fromObj)
-        {
-            return _pwsh.AddCommand("Microsoft.PowerShell.Utility\\ConvertTo-Json")
-                            .AddParameter("InputObject", fromObj)
-                            .AddParameter("Depth", 3)
-                            .AddParameter("Compress", true)
-                        .InvokeAndClearCommands<string>()[0];
-        }
-
         private void ResetRunspace(string moduleName)
         {
             // Reset the runspace to the Initial Session State

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -164,7 +164,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                     ? InvokeOrchestrationFunction(psManager, functionInfo, invocationRequest)
                     : InvokeSingleActivityFunction(psManager, functionInfo, invocationRequest);
 
-                BindOutputFromResult(psManager, response.InvocationResponse, functionInfo, results);
+                BindOutputFromResult(response.InvocationResponse, functionInfo, results);
             }
             catch (Exception e)
             {
@@ -239,7 +239,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
         /// <summary>
         /// Set the 'ReturnValue' and 'OutputData' based on the invocation results appropriately.
         /// </summary>
-        private void BindOutputFromResult(PowerShellManager psManager, InvocationResponse response, AzFunctionInfo functionInfo, Hashtable results)
+        private void BindOutputFromResult(InvocationResponse response, AzFunctionInfo functionInfo, Hashtable results)
         {
             switch (functionInfo.Type)
             {
@@ -252,7 +252,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
                         object outValue = results[outBindingName];
                         object transformedValue = Utils.TransformOutBindingValueAsNeeded(outBindingName, bindingInfo, outValue);
-                        TypedData dataToUse = transformedValue.ToTypedData(psManager);
+                        TypedData dataToUse = transformedValue.ToTypedData();
 
                         // if one of the bindings is '$return' we need to set the ReturnValue
                         if(string.Equals(outBindingName, AzFunctionInfo.DollarReturn, StringComparison.OrdinalIgnoreCase))
@@ -273,7 +273,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
                 case AzFunctionType.OrchestrationFunction:
                 case AzFunctionType.ActivityFunction:
-                    response.ReturnValue = results[AzFunctionInfo.DollarReturn].ToTypedData(psManager);
+                    response.ReturnValue = results[AzFunctionInfo.DollarReturn].ToTypedData();
                     break;
 
                 default:

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -96,7 +96,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
         private static object ConvertFromJson(string json)
         {
-            object retObj = JsonObject.ConvertFromJson(json, returnHashtable: true, out _);
+            object retObj = JsonObject.ConvertFromJson(json, returnHashtable: true, error: out _);
+
+            if (retObj is PSObject psObj)
+            {
+                retObj = psObj.BaseObject;
+            }
 
             if (retObj is Hashtable hashtable)
             {

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -8,11 +8,11 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Reflection;
 
 using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
+using Microsoft.PowerShell.Commands;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
@@ -94,30 +94,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             }
         }
 
-        // PowerShell NuGet packages only have 'System.Management.Automation.dll' as the ref assembly, and thus types from other powershell assemblies
-        // cannot be used directly in an application that reference the PowerShell NuGet packages. This is tracked by PowerShell#8121.
-        // Here we need to use 'Microsoft.PowerShell.Commands.JsonObject' from 'Microsoft.PowerShell.Commands.Utility'. Due the above issue, we have to
-        // use reflection to call 'JsonObject.ConvertFromJson(...)'.
-        private static MethodInfo s_ConvertFromJson = null;
         private static object ConvertFromJson(string json)
         {
-            const string UtilityAssemblyFullName = "Microsoft.PowerShell.Commands.Utility, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
-
-            if (s_ConvertFromJson == null)
-            {
-                Assembly utilityAssembly = AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.FullName == UtilityAssemblyFullName);
-                Type jsonObjectType = utilityAssembly.GetType("Microsoft.PowerShell.Commands.JsonObject");
-                s_ConvertFromJson = jsonObjectType.GetMethod(
-                    name: "ConvertFromJson",
-                    types: new Type[] { typeof(string), typeof(bool), typeof(ErrorRecord).MakeByRefType() },
-                    modifiers: null);
-            }
-
-            object retObj = s_ConvertFromJson.Invoke(null, new object[] { json, true, null });
-            if (retObj is PSObject psObj)
-            {
-                retObj = psObj.BaseObject;
-            }
+            object retObj = JsonObject.ConvertFromJson(json, returnHashtable: true, out _);
 
             if (retObj is Hashtable hashtable)
             {
@@ -136,6 +115,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             return retObj;
         }
 
+        private static string ConvertToJson(object fromObj)
+        {
+            var context = new JsonObject.ConvertToJsonContext(
+                maxDepth: 3,
+                enumsAsStrings: false,
+                compressOutput: true);
+
+            return JsonObject.ConvertToJson(fromObj, in context);
+        }
+
         internal static RpcException ToRpcException(this Exception exception)
         {
             return new RpcException
@@ -146,7 +135,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             };
         }
 
-        private static RpcHttp ToRpcHttp(this HttpResponseContext httpResponseContext, PowerShellManager psHelper)
+        private static RpcHttp ToRpcHttp(this HttpResponseContext httpResponseContext)
         {
             var rpcHttp = new RpcHttp
             {
@@ -155,7 +144,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
             if (httpResponseContext.Body != null)
             {
-                rpcHttp.Body = httpResponseContext.Body.ToTypedData(psHelper);
+                rpcHttp.Body = httpResponseContext.Body.ToTypedData();
             }
 
             rpcHttp.EnableContentNegotiation = httpResponseContext.EnableContentNegotiation;
@@ -178,7 +167,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             return rpcHttp;
         }
 
-        internal static TypedData ToTypedData(this object value, PowerShellManager psHelper)
+        internal static TypedData ToTypedData(this object value)
         {
             if (value is TypedData self)
             {
@@ -218,14 +207,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     typedData.Stream = ByteString.FromStream(s);
                     break;
                 case HttpResponseContext http:
-                    typedData.Http = http.ToRpcHttp(psHelper);
+                    typedData.Http = http.ToRpcHttp();
                     break;
                 case string str:
                     if (IsValidJson(str)) { typedData.Json = str; } else { typedData.String = str; }
                     break;
                 default:
-                    if (psHelper == null) { throw new ArgumentNullException(nameof(psHelper)); }
-                    typedData.Json = psHelper.ConvertToJson(originalValue);
+                    typedData.Json = ConvertToJson(originalValue);
                     break;
             }
             return typedData;

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -20,16 +20,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 {
     public class TypeExtensionsTests
     {
-        private readonly ConsoleLogger _testLogger;
-        private readonly PowerShellManager _testManager;
-
-        public TypeExtensionsTests()
-        {
-            _testLogger = new ConsoleLogger();
-            _testManager = TestUtils.NewTestPowerShellManager(_testLogger);
-        }
-
         #region TypedDataToObject
+
         [Fact]
         public void TestTypedDataToObjectHttpRequestContextBasic()
         {
@@ -343,7 +335,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -366,7 +358,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -389,7 +381,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -412,7 +404,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -426,7 +418,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Int = data
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -440,7 +432,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Double = data
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -454,7 +446,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 String = data
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -468,7 +460,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Bytes = ByteString.CopyFrom(data)
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -483,7 +475,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                     Stream = ByteString.FromStream(data)
                 };
 
-                Assert.Equal(expected, input.ToTypedData(null));
+                Assert.Equal(expected, input.ToTypedData());
             }
         }
 
@@ -498,7 +490,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Json = data
             };
 
-            Assert.Equal(expected, input.ToTypedData(null));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -512,7 +504,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Json = "{\"foo\":\"bar\"}"
             };
 
-            Assert.Equal(expected, input.ToTypedData(_testManager));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -526,7 +518,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 Json = "{\"foo\":\"bar\"}"
             };
 
-            Assert.Equal(expected, input.ToTypedData(_testManager));
+            Assert.Equal(expected, input.ToTypedData());
         }
 
         [Fact]
@@ -541,7 +533,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                     Json = "{\"foo\":\"bar\"}"
                 };
 
-                Assert.Equal(expected, input.ToTypedData(_testManager));
+                Assert.Equal(expected, input.ToTypedData());
             }
         }
 
@@ -551,7 +543,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var data = new byte[] { 12,23,34 };
             object input = PSObject.AsPSObject(data);
 
-            TypedData output = input.ToTypedData(_testManager);
+            TypedData output = input.ToTypedData();
 
             Assert.Equal(TypedData.DataOneofCase.Bytes, output.DataCase);
             Assert.Equal(3, output.Bytes.Length);
@@ -563,7 +555,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             using (var data = new MemoryStream(new byte[] { 12,23,34 }))
             {
                 object input = PSObject.AsPSObject(data);
-                TypedData output = input.ToTypedData(_testManager);
+                TypedData output = input.ToTypedData();
 
                 Assert.Equal(TypedData.DataOneofCase.Stream, output.DataCase);
                 Assert.Equal(3, output.Stream.Length);
@@ -574,7 +566,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         public void TestObjectToTypedData_PSObjectToString()
         {
             object input = PSObject.AsPSObject("Hello World");
-            TypedData output = input.ToTypedData(_testManager);
+            TypedData output = input.ToTypedData();
 
             Assert.Equal(TypedData.DataOneofCase.String, output.DataCase);
             Assert.Equal("Hello World", output.String);


### PR DESCRIPTION
`JsonObject.ConvertToJson` API was added in preview.4. The reference assembly for `Microsoft.PowerShell.Commands.Utility.dll` was also added in the SDK nuget package for preview.4, so we can use `JsonObject.ConvertFromJson` and `JsonObject.ConvertToJson` directly.