### PR TITLE
Update the protobuf in the worker repo and also update 'New-gRPCAutoGenCode' accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ src/Modules
 protobuf/*
 FunctionRpc.cs
 FunctionRpcGrpc.cs
+ClaimsIdentityRpc.cs
 
 # pulled in for tests
 Azure.Functions.Cli

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -24,7 +24,7 @@ From within the Azure Functions language worker repo:
 
 From within the Azure Functions language worker repo:
 1.	Define remote branch for cleaner git commands
-    -	`git remote add proto-file https://github.com/mhoeger/azure-functions-language-worker-protobuf.git`
+    -	`git remote add proto-file https://github.com/azure/azure-functions-language-worker-protobuf.git`
     -	`git fetch proto-file`
 2.	Merge updates
     -   `git merge -s subtree proto-file/<version branch> --squash --allow-unrelated-histories` 

--- a/protobuf/src/proto/FunctionRpc.proto
+++ b/protobuf/src/proto/FunctionRpc.proto
@@ -10,6 +10,7 @@ option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 package AzureFunctionsRpcMessages;
 
 import "google/protobuf/duration.proto";
+import "identity/ClaimsIdentityRpc.proto";
 
 // Interface exported by the server.
 service FunctionRpc {
@@ -65,6 +66,10 @@ message StreamingMessage {
 
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
+
+    FunctionEnvironmentReloadRequest function_environment_reload_request = 25;
+
+    FunctionEnvironmentReloadResponse function_environment_reload_response = 26;
   }
 }
 
@@ -180,6 +185,16 @@ message WorkerStatusRequest{
 message WorkerStatusResponse {
 }
 
+message FunctionEnvironmentReloadRequest {
+  // Environment variables from the current process
+  map<string, string> environment_variables = 1;
+}
+
+message FunctionEnvironmentReloadResponse {
+  // Status of the response
+  StatusResult result = 3;
+}
+
 // Host tells the worker to load a Function
 message FunctionLoadRequest {
   // unique function identifier (avoid name collisions, facilitate reload case)
@@ -287,11 +302,21 @@ message BindingInfo {
       inout = 2;
     }
 
+    // Indicates the type of the data for the binding
+    enum DataType {
+      undefined = 0;
+      string = 1;
+      binary = 2;
+      stream = 3;
+    }
+
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
 
   // Direction of the given binding
   Direction direction = 3;
+
+  DataType data_type = 4;
 }
 
 // Used to send logs back to the Host 
@@ -355,4 +380,5 @@ message RpcHttp {
   map<string,string> query = 15;
   bool enable_content_negotiation= 16;
   TypedData rawBody = 17;
+  repeated RpcClaimsIdentity identities = 18;
 }

--- a/protobuf/src/proto/identity/ClaimsIdentityRpc.proto
+++ b/protobuf/src/proto/identity/ClaimsIdentityRpc.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+// protobuf vscode extension: https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3
+
+// Light-weight representation of a .NET System.Security.Claims.ClaimsIdentity object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimsIdentitySlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimsIdentitySlim.cs
+message RpcClaimsIdentity {
+  string authentication_type = 1;
+  string name_claim_type = 2;
+  string role_claim_type = 3;
+  repeated RpcClaim claims = 4;
+}
+
+// Light-weight representation of a .NET System.Security.Claims.Claim object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimSlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimSlim.cs
+message RpcClaim {
+  string value = 1;
+  string type = 2;
+}

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -99,11 +99,20 @@ function New-gRPCAutoGenCode
         $outputDir = "$RepoRoot/src/Messaging"
         Remove-Item "$outputDir/FunctionRpc*.cs" -Force -ErrorAction SilentlyContinue
 
-        & $Script:protoc_Path $Script:protobuf_file_Path --csharp_out $outputDir `
-                                                         --grpc_out=$outputDir `
-                                                         --plugin=protoc-gen-grpc=$Script:grpc_csharp_plugin_Path `
-                                                         --proto_path=$Script:protobuf_dir_Path `
-                                                         --proto_path=$Script:google_protobuf_tools_Path
+        & $Script:protoc_Path $Script:claimsIdentityRpc_proto_file_Path `
+            --csharp_out $outputDir `
+            --grpc_out=$outputDir `
+            --plugin=protoc-gen-grpc=$Script:grpc_csharp_plugin_Path `
+            --proto_path=$Script:identity_dir_Path `
+            --proto_path=$Script:google_protobuf_tools_Path
+
+        & $Script:protoc_Path $Script:functionRpc_proto_file_Path `
+            --csharp_out $outputDir `
+            --grpc_out=$outputDir `
+            --plugin=protoc-gen-grpc=$Script:grpc_csharp_plugin_Path `
+            --proto_path=$Script:protobuf_dir_Path `
+            --proto_path=$Script:google_protobuf_tools_Path
+
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to generate the CSharp code for gRPC communication."
         }
@@ -164,7 +173,9 @@ function Resolve-ProtoBufToolPath
         }
 
         $Script:protobuf_dir_Path = "$RepoRoot/protobuf/src/proto"
-        $Script:protobuf_file_Path = "$Script:protobuf_dir_Path/FunctionRpc.proto"
+        $Script:functionRpc_proto_file_Path = "$Script:protobuf_dir_Path/FunctionRpc.proto"
+        $Script:identity_dir_Path = "$RepoRoot/protobuf/src/proto/identity"
+        $Script:claimsIdentityRpc_proto_file_Path = "$Script:identity_dir_Path/ClaimsIdentityRpc.proto"
     }
 }
 


### PR DESCRIPTION
Update the protobuf in the worker repo and also update 'New-gRPCAutoGenCode' accordingly.

- The `dataType` field was added to `BindingInfo` type which reflects the type of the incoming blob content. We can use that info now for pre-validation.
- `FunctionEnvironmentReloadRequest` and `FunctionEnvironmentReloadResponse` were added. We need to review all the supported requests and responses in the protocol, to see if we should support them in PS worker.
- `RpcClaimsIdentity` was added to `RpcHttp`, we need to add the translation logic to convert information from it to `ClaimsPrincipal` or `ClaimsIdentity` (need to look into it closely).
