### PR TITLE
No ops for other messages

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -106,6 +106,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
         internal StreamingMessage ProcessWorkerStatusRequest(StreamingMessage request)
         {
+            // WorkerStatusResponse type says that it is not used but this will create an empty one anyway to return to the host
             StreamingMessage response = NewStreamingMessageTemplate(
                 request.RequestId,
                 StreamingMessage.ContentOneofCase.WorkerStatusResponse,
@@ -259,11 +260,17 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 case StreamingMessage.ContentOneofCase.WorkerInitResponse:
                     response.WorkerInitResponse = new WorkerInitResponse() { Result = status };
                     break;
+                case StreamingMessage.ContentOneofCase.WorkerStatusResponse:
+                    response.WorkerStatusResponse = new WorkerStatusResponse();
+                    break;
                 case StreamingMessage.ContentOneofCase.FunctionLoadResponse:
                     response.FunctionLoadResponse = new FunctionLoadResponse() { Result = status };
                     break;
                 case StreamingMessage.ContentOneofCase.InvocationResponse:
                     response.InvocationResponse = new InvocationResponse() { Result = status };
+                    break;
+                case StreamingMessage.ContentOneofCase.FunctionEnvironmentReloadResponse:
+                    response.FunctionEnvironmentReloadResponse = new FunctionEnvironmentReloadResponse() { Result = status };
                     break;
                 default:
                     throw new InvalidOperationException("Unreachable code.");

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -75,10 +75,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 }
                 else
                 {
-                    logger.SetContext(request.RequestId, null);
-                    string errorMsg = string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase);
-                    logger.Log(LogLevel.Error, errorMsg, new InvalidOperationException(errorMsg));
-                    logger.ResetContext();
+                    logger.Log(LogLevel.Error, string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase));
                     continue;
                 }
 

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -7,7 +7,7 @@ using namespace System.Runtime.InteropServices
 
 $IsWindowsEnv = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows)
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
-$MinimalSDKVersion = '2.1.300'
+$MinimalSDKVersion = '2.2.0'
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
 
 function Find-Dotnet


### PR DESCRIPTION
Note: I marked this as a draft PR.

fixes #154 

Rather than using a `switch` for handling requests, I've changed it to a Dictionary of handles.
I've implemented all requests... some return responses, others do not.
The worker won't crash now if it receives a message it doesn't understand.

Things I was thinking about:
* maybe 2 dictionaries - 1 for requests (that return a message), 1 for "notifications" (that don't return a message)
* Not sure this PR needs tests with it... I would think we would just test what those Process methods will do