### PR TITLE
Move to rc.1 and support the CustomPipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ On macOS if you installed via `brew`
 
 Copy the result of the `publish` directory into a `powershell` folder under `workers`:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.1/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.2/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
 ```
 
 > NOTE: if the powershell folder already exists, you should delete it or debugging won't work.

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -19,7 +19,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-rc.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Grpc" Version="1.14.1" />

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Management.Automation.Remoting;
 using System.Threading.Tasks;
 
 using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
@@ -92,6 +93,16 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 request.RequestId,
                 StreamingMessage.ContentOneofCase.WorkerInitResponse,
                 out StatusResult status);
+
+            // If the environment variable is set, spin up the custom named pipe server.
+            // This is typically used for debugging. It will throw a friendly exception if the
+            // pipe name is not a valid pipename.
+            string pipeName = Environment.GetEnvironmentVariable("PSWorkerCustomPipeName");
+            if (!string.IsNullOrEmpty(pipeName))
+            {
+                Console.WriteLine(string.Format(PowerShellWorkerStrings.SpecifiedCustomPipeName, pipeName));
+                RemoteSessionNamedPipeServer.CreateCustomNamedPipeServer(pipeName);
+            }
 
             return response;
         }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -65,8 +65,6 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
         internal async Task ProcessRequestLoop()
         {
-            var logger = new RpcLogger(_msgStream);
-
             StreamingMessage request, response;
             while (await _msgStream.MoveNext())
             {
@@ -78,7 +76,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
                 }
                 else
                 {
-                    logger.Log(LogLevel.Error, string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase));
+                    _logger.Log(LogLevel.Error, string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase));
                     continue;
                 }
 
@@ -102,15 +100,7 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
             string pipeName = Environment.GetEnvironmentVariable("PSWorkerCustomPipeName");
             if (!string.IsNullOrEmpty(pipeName))
             {
-                try
-                {
-                    _logger.SetContext(request.RequestId, invocationId: null);
-                    _logger.Log(LogLevel.Information, string.Format(PowerShellWorkerStrings.SpecifiedCustomPipeName, pipeName));
-                } 
-                finally
-                {
-                    _logger.ResetContext();
-                }
+                _logger.Log(LogLevel.Information, string.Format(PowerShellWorkerStrings.SpecifiedCustomPipeName, pipeName));
                 RemoteSessionNamedPipeServer.CreateCustomNamedPipeServer(pipeName);
             }
 

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -163,4 +163,7 @@
   <data name="FailToConvertToHttpResponseContext" xml:space="preserve">
     <value>The given value for the 'http' output binding '{0}' cannot be converted to the type 'HttpResponseContext'. The conversion failed with the following error: {1}</value>
   </data>
+  <data name="SpecifiedCustomPipeName" xml:space="preserve">
+    <value>Custom pipe name specified. You can attach to the process by using vscode or by running `Enter-PSHostProcess -CustomPipeName {0}`</value>
+  </data>
 </root>

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-preview.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Here's an example of what the log looks like:

```
[3/8/19 1:39:09 AM] System Log: {
[3/8/19 1:39:09 AM]   Log-Message: Custom pipe name specified. You can attach to the process by using vscode or by running `Enter-PSHostProcess -CustomPipeName fooooooooood`
[3/8/19 1:39:09 AM] }
```

All you have to do is:

```
PS /MyFuncApp/ > $env:PSWorkerCustomPipeName = "helloworldfunc"
PS /MyFuncApp/ > func start
```

I've tested that this works along with [this vscode-powershell PR](https://github.com/powerShell/vscode-powershell/pull/1775) where you hit F5 and the debugger attaches to the correct runspace.

also a tiny README change