### PR TITLE
Bring back the code that shares output binding metadata with the helper module

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ if ($Bootstrap.IsPresent) {
 # Clean step
 if($Clean.IsPresent) {
     Push-Location $PSScriptRoot
-    git clean -fdx
+    git clean -fdX
     Pop-Location
 }
 

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         private readonly PowerShell _pwsh;
 
         /// <summary>
+        /// Gets the Runspace InstanceId.
+        /// </summary>
+        internal Guid InstanceId => _pwsh.Runspace.InstanceId;
+
+        /// <summary>
         /// Gets the associated logger.
         /// </summary>
         internal ILogger Logger => _logger;

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
             }
 
+            // Register the function with the Runspace before returning the idle PowerShellManager.
+            FunctionMetadata.RegisterFunctionMetadata(psManager.InstanceId, functionInfo);
             psManager.Logger.SetContext(requestId, invocationId);
             return psManager;
         }
@@ -101,6 +103,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if (psManager != null)
             {
+                // Unregister the Runspace before reclaiming the used PowerShellManager.
+                FunctionMetadata.UnregisterFunctionMetadata(psManager.InstanceId);
                 psManager.Logger.ResetContext();
                 _pool.Add(psManager);
             }

--- a/src/Public/FunctionMetadata.cs
+++ b/src/Public/FunctionMetadata.cs
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Azure.Functions.PowerShellWorker
+{
+    /// <summary>
+    /// Function metadata for the PowerShellWorker module to query.
+    /// </summary>
+    public static class FunctionMetadata
+    {
+        internal static ConcurrentDictionary<Guid, ReadOnlyDictionary<string, ReadOnlyBindingInfo>> OutputBindingCache
+            = new ConcurrentDictionary<Guid, ReadOnlyDictionary<string, ReadOnlyBindingInfo>>();
+
+        /// <summary>
+        /// Get the binding metadata for the given Runspace instance id.
+        /// </summary>
+        public static ReadOnlyDictionary<string, ReadOnlyBindingInfo> GetOutputBindingInfo(Guid runspaceInstanceId)
+        {
+            ReadOnlyDictionary<string, ReadOnlyBindingInfo> outputBindings = null;
+            OutputBindingCache.TryGetValue(runspaceInstanceId, out outputBindings);
+            return outputBindings;
+        }
+
+        /// <summary>
+        /// Helper method to set the output binding metadata for the function that is about to run.
+        /// </summary>
+        internal static void RegisterFunctionMetadata(Guid instanceId, AzFunctionInfo functionInfo)
+        {
+            var outputBindings = functionInfo.OutputBindings;
+            OutputBindingCache.AddOrUpdate(instanceId, outputBindings, (key, value) => outputBindings);
+        }
+
+        /// <summary>
+        /// Helper method to clear the output binding metadata for the function that has done running.
+        /// </summary>
+        internal static void UnregisterFunctionMetadata(Guid instanceId)
+        {
+            OutputBindingCache.TryRemove(instanceId, out _);
+        }
+    }
+}

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -153,6 +153,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         }
 
         [Fact]
+        public void RegisterAndUnregisterFunctionMetadataShouldWork()
+        {
+            string path = Path.Join(TestUtils.FunctionDirectory, "testBasicFunction.ps1");
+            var functionInfo = TestUtils.NewAzFunctionInfo(path, string.Empty);
+
+            Assert.Empty(FunctionMetadata.OutputBindingCache);
+            FunctionMetadata.RegisterFunctionMetadata(_testManager.InstanceId, functionInfo);
+            Assert.Single(FunctionMetadata.OutputBindingCache);
+            FunctionMetadata.UnregisterFunctionMetadata(_testManager.InstanceId);
+            Assert.Empty(FunctionMetadata.OutputBindingCache);
+        }
+
+        [Fact]
         public void ProfileShouldWork()
         {
             //initialize fresh log


### PR DESCRIPTION
Bring back the code that was removed in #134. The post-invocation data transformation was moved from the helper module to the worker in that PR, and that makes this code useless at that moment.

When script from the helper module is running, it can use `[FuncMetadata]::GetOutputBindingInfo([Runspace]::DefaultRunspace.InstanceId)` to get the output binding info about the function that is currently running. Hence, `Push-OutputBinidng` can do smart things based on the `-Name`.