### PR TITLE
Enable tiered compilation for the worker to help the code start

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -7,6 +7,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TieredCompilation>true</TieredCompilation>
     <Product>Azure Function PowerShell Language Worker</Product>
     <AssemblyName>Microsoft.Azure.Functions.PowerShellWorker</AssemblyName>
     


### PR DESCRIPTION
Quoted from https://devblogs.microsoft.com/dotnet/tiered-compilation-preview-in-net-core-2-1/
> In our testing, time spent jitting would often decrease by about 35%.

Enable tiered compilation for the worker to help the code start.