### PR TITLE
Clean up jobs started during the function execution

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 finally
                 {
                     // Clean up
-                    pwsh.AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
+                    pwsh.AddCommand(Utils.RemoveModuleCmdletInfo)
                         .AddParameter("Name", "PackageManagement, PowerShellGet")
                         .AddParameter("Force", true)
                         .AddParameter("ErrorAction", "SilentlyContinue")

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -99,10 +99,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             try
             {
                 // Import-Module on a .ps1 file will evaluate the script in the global scope.
-                _pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module")
+                _pwsh.AddCommand(Utils.ImportModuleCmdletInfo)
                         .AddParameter("Name", profilePath)
                         .AddParameter("PassThru", true)
-                     .AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
+                     .AddCommand(Utils.RemoveModuleCmdletInfo)
                         .AddParameter("Force", true)
                         .AddParameter("ErrorAction", "SilentlyContinue")
                      .InvokeAndClearCommands();
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 {
                     // If an entry point is defined, we import the script module.
                     moduleName = Path.GetFileNameWithoutExtension(scriptPath);
-                    _pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module")
+                    _pwsh.AddCommand(Utils.ImportModuleCmdletInfo)
                             .AddParameter("Name", scriptPath)
                          .InvokeAndClearCommands();
 
@@ -206,12 +206,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             if (!string.IsNullOrEmpty(moduleName))
             {
                 // If the function had an entry point, this will remove the module that was loaded
-                _pwsh.AddCommand("Microsoft.PowerShell.Core\\Remove-Module")
+                _pwsh.AddCommand(Utils.RemoveModuleCmdletInfo)
                         .AddParameter("Name", moduleName)
                         .AddParameter("Force", true)
                         .AddParameter("ErrorAction", "SilentlyContinue")
                      .InvokeAndClearCommands();
             }
+
+            // Clean up jobs started during the function execution.
+            _pwsh.AddCommand(Utils.GetJobCmdletInfo)
+                 .AddCommand(Utils.RemoveJobCmdletInfo)
+                    .AddParameter("Force", true)
+                    .AddParameter("ErrorAction", "SilentlyContinue")
+                 .InvokeAndClearCommands();
         }
     }
 }

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -7,11 +7,17 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Text;
+using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
     internal class Utils
     {
+        internal static CmdletInfo ImportModuleCmdletInfo = new CmdletInfo("Import-Module", typeof(ImportModuleCommand));
+        internal static CmdletInfo RemoveModuleCmdletInfo = new CmdletInfo("Remove-Module", typeof(RemoveModuleCommand));
+        internal static CmdletInfo GetJobCmdletInfo = new CmdletInfo("Get-Job", typeof(GetJobCommand));
+        internal static CmdletInfo RemoveJobCmdletInfo = new CmdletInfo("Remove-Job", typeof(RemoveJobCommand));
+
         /// <summary>
         /// Helper method to do additional transformation on the input value based on the type constraints specified in the script.
         /// </summary>


### PR DESCRIPTION
- Use cached `CmdletInfo` object for `Import-Module`, `Remove-Module`, `Start-Job` and `Remove-Job` to avoid the command lookup time.
- Clean up jobs started during the function execution