### PR TITLE
Fix the pool size log to reflect the correct size when the env variable is not set

### DIFF
--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         internal PowerShellManagerPool(MessagingStream msgStream)
         {
             string upperBound = Environment.GetEnvironmentVariable("PSWorkerInProcConcurrencyUpperBound");
-            RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogConcurrencyUpperBound, upperBound));
-
             if (string.IsNullOrEmpty(upperBound) || !int.TryParse(upperBound, out _upperBound))
             {
                 _upperBound = 1;
@@ -40,6 +38,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
             _msgStream = msgStream;
             _pool = new BlockingCollection<PowerShellManager>(_upperBound);
+            RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogConcurrencyUpperBound, _upperBound.ToString()));
         }
 
         /// <summary>

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     logger.SetContext(requestId, invocationId);
                     psManager = new PowerShellManager(logger);
 
-                    RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogNewPowerShellManagerCreated, _poolSize));
+                    RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogNewPowerShellManagerCreated, _poolSize.ToString()));
                 }
                 else
                 {


### PR DESCRIPTION
Fix the pool size log to reflect the correct size when the env variable is not set