### PR TITLE
Make the binding-info dictionary case-insensitive on the key (binding name)

### DIFF
--- a/src/FunctionInfo.cs
+++ b/src/FunctionInfo.cs
@@ -68,9 +68,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             var parametersCopy = new Dictionary<string, PSScriptParamInfo>(psScriptParams, StringComparer.OrdinalIgnoreCase);
             parametersCopy.Remove(TriggerMetadata);
 
-            var allBindings = new Dictionary<string, ReadOnlyBindingInfo>();
-            var inputBindings = new Dictionary<string, ReadOnlyBindingInfo>();
-            var outputBindings = new Dictionary<string, ReadOnlyBindingInfo>();
+            var allBindings = new Dictionary<string, ReadOnlyBindingInfo>(StringComparer.OrdinalIgnoreCase);
+            var inputBindings = new Dictionary<string, ReadOnlyBindingInfo>(StringComparer.OrdinalIgnoreCase);
+            var outputBindings = new Dictionary<string, ReadOnlyBindingInfo>(StringComparer.OrdinalIgnoreCase);
 
             var inputsMissingFromParams = new List<string>();
             foreach (var binding in metadata.Bindings)

--- a/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             Push-OutputBinding -Name QUeue -Value 'MixedCase'
 
             $result = Get-OutputBinding -Purge
-            $result["response"] | Should -BeExactly 'UpperCase'
+            $result["RESPONSE"] | Should -BeExactly 'UpperCase'
             $result["queue"] | Should -BeExactly 'MixedCase'
         }
 

--- a/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -131,6 +131,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             $result[$Key][1] | Should -BeExactly 2
         }
 
+        It 'Can add value with binding name that differs in case' {
+            Push-OutputBinding -Name RESPONSE -Value 'UpperCase'
+            Push-OutputBinding -Name QUeue -Value 'MixedCase'
+
+            $result = Get-OutputBinding -Purge
+            $result["response"] | Should -BeExactly 'UpperCase'
+            $result["queue"] | Should -BeExactly 'MixedCase'
+        }
+
         It 'Can add a value via pipeline' {
             'Baz' | Push-OutputBinding -Name response
             'item1', 'item2', 'item3' | Push-OutputBinding -Name queue

--- a/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
+++ b/test/Unit/Modules/Microsoft.Azure.Functions.PowerShellWorker.Tests.ps1
@@ -136,8 +136,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             Push-OutputBinding -Name QUeue -Value 'MixedCase'
 
             $result = Get-OutputBinding -Purge
-            $result["RESPONSE"] | Should -BeExactly 'UpperCase'
-            $result["queue"] | Should -BeExactly 'MixedCase'
+            if ($IsWindows) {
+                $result["response"] | Should -BeExactly 'UpperCase'
+                $result["queue"] | Should -BeExactly 'MixedCase'
+            } else {
+                # Hashtable on Ubuntu 18.04 server is case-sensitive.
+                # It's fixed in 6.2, but the 'pwsh' used in AppVeyor is not 6.2
+                $result["RESPONSE"] | Should -BeExactly 'UpperCase'
+                $result["QUeue"] | Should -BeExactly 'MixedCase'
+            }
         }
 
         It 'Can add a value via pipeline' {


### PR DESCRIPTION
Make the binding-info dictionary case-insensitive on the key (binding name).

When testing the bindings in our priority list, I found currently `Push-OutputBinding` treat the output binding name case-sensitively.
If the output binding name in `function.json` is `outblob`, then `Push-OutputBinding -Name outBlob` will fail. This PR fixes that issue.