### PR TITLE
Add SupportsWildcards to Get-OutputBinding and fix help test

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -109,18 +109,20 @@ if($Test.IsPresent) {
         throw "Cannot find 'git'. Please make sure it's in the 'PATH'."
     }
 
-    # Cmdlet help docs should be up-to-date
-
+    # Cmdlet help docs should be up-to-date.
     # PlatyPS needs the module to be imported.
     Import-Module -Force (Join-Path $PSScriptRoot src Modules Microsoft.Azure.Functions.PowerShellWorker)
     try {
+        # Update the help and diff the result.
         $docsPath = Join-Path $PSScriptRoot docs cmdlets
         Update-MarkdownHelp -Path $docsPath
         $diff = git diff $docsPath
         if ($diff) {
             throw "Cmdlet help docs are not up-to-date, run Update-MarkdownHelp.`n$diff`n"
         }
+        Write-Host "Help is up-to-date."
     } finally {
+        # Clean up.
         Remove-Module Microsoft.Azure.Functions.PowerShellWorker -Force
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,8 @@ param(
     $Configuration = "Debug"
 )
 
+#Requires -Version 6.0
+
 Import-Module "$PSScriptRoot/tools/helper.psm1" -Force
 
 # Bootstrap step
@@ -108,9 +110,17 @@ if($Test.IsPresent) {
     }
 
     # Cmdlet help docs should be up-to-date
-    Update-MarkdownHelp -Path ./docs/cmdlets
-    $diff = git diff ./docs/cmdlets
-    if ($diff) {
-        throw "Cmdlet help docs are not up-to-date, run Update-MarkdownHelp.`n$diff`n"
+
+    # PlatyPS needs the module to be imported.
+    Import-Module -Force (Join-Path $PSScriptRoot src Modules Microsoft.Azure.Functions.PowerShellWorker)
+    try {
+        $docsPath = Join-Path $PSScriptRoot docs cmdlets
+        Update-MarkdownHelp -Path $docsPath
+        $diff = git diff $docsPath
+        if ($diff) {
+            throw "Cmdlet help docs are not up-to-date, run Update-MarkdownHelp.`n$diff`n"
+        }
+    } finally {
+        Remove-Module Microsoft.Azure.Functions.PowerShellWorker -Force
     }
 }

--- a/docs/cmdlets/Get-OutputBinding.md
+++ b/docs/cmdlets/Get-OutputBinding.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/cmdlets/Get-OutputBinding.md
+++ b/docs/cmdlets/Get-OutputBinding.md
@@ -57,7 +57,7 @@ Required: False
 Position: 1
 Default value: *
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Purge

--- a/docs/cmdlets/Push-OutputBinding.md
+++ b/docs/cmdlets/Push-OutputBinding.md
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/cmdlets/Trace-PipelineObject.md
+++ b/docs/cmdlets/Trace-PipelineObject.md
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -49,6 +49,7 @@ function Get-OutputBinding {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [SupportsWildcards()]
         [string[]]
         $Name = '*',
 


### PR DESCRIPTION
`SupportsWildcards` is what PlatyPS uses to set the field in the help.

Also, the PlatyPS test wasn't actually running the help because the module wasn't imported. This fixes that.