### PR TITLE
Add 'InvocationId', 'FunctionDirectory' and 'FunctionName' to $TriggerMetadata

### DIFF
--- a/src/FunctionInfo.cs
+++ b/src/FunctionInfo.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         internal const string TriggerMetadata = "TriggerMetadata";
         internal const string DollarReturn = "$return";
 
+        internal readonly bool HasTriggerMetadataParam;
         internal readonly string FuncDirectory;
         internal readonly string FuncName;
         internal readonly string EntryPoint;
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             FuncParameters = new ReadOnlyDictionary<string, PSScriptParamInfo>(psScriptParams);
 
             var parametersCopy = new Dictionary<string, PSScriptParamInfo>(psScriptParams, StringComparer.OrdinalIgnoreCase);
-            parametersCopy.Remove(TriggerMetadata);
+            HasTriggerMetadataParam = parametersCopy.Remove(TriggerMetadata);
 
             var allBindings = new Dictionary<string, ReadOnlyBindingInfo>(StringComparer.OrdinalIgnoreCase);
             var inputBindings = new Dictionary<string, ReadOnlyBindingInfo>(StringComparer.OrdinalIgnoreCase);

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
 
                 // Gives access to additional Trigger Metadata if the user specifies TriggerMetadata
-                if(functionInfo.FuncParameters.ContainsKey(AzFunctionInfo.TriggerMetadata))
+                if(functionInfo.HasTriggerMetadataParam)
                 {
                     _pwsh.AddParameter(AzFunctionInfo.TriggerMetadata, triggerMetadata);
                 }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -357,15 +357,37 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         private Hashtable InvokeSingleActivityFunction(PowerShellManager psManager, AzFunctionInfo functionInfo, InvocationRequest invocationRequest)
         {
+            const string InvocationId = "InvocationId";
+            const string FunctionDirectory = "FunctionDirectory";
+            const string FunctionName = "FunctionName";
+
             // Bundle all TriggerMetadata into Hashtable to send down to PowerShell
-            var triggerMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            foreach (var dataItem in invocationRequest.TriggerMetadata)
+            Hashtable triggerMetadata = null;
+
+            if (functionInfo.HasTriggerMetadataParam)
             {
-                // MapField<K, V> is case-sensitive, but powershell is case-insensitive,
-                // so for keys differ only in casing, the first wins.
-                if (!triggerMetadata.ContainsKey(dataItem.Key))
+                triggerMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                foreach (var dataItem in invocationRequest.TriggerMetadata)
                 {
-                    triggerMetadata.Add(dataItem.Key, dataItem.Value.ToObject());
+                    // MapField<K, V> is case-sensitive, but powershell is case-insensitive,
+                    // so for keys differ only in casing, the first wins.
+                    if (!triggerMetadata.ContainsKey(dataItem.Key))
+                    {
+                        triggerMetadata.Add(dataItem.Key, dataItem.Value.ToObject());
+                    }
+                }
+
+                if (!triggerMetadata.ContainsKey(InvocationId))
+                {
+                    triggerMetadata.Add(InvocationId, invocationRequest.InvocationId);
+                }
+                if (!triggerMetadata.ContainsKey(FunctionDirectory))
+                {
+                    triggerMetadata.Add(FunctionDirectory, functionInfo.FuncDirectory);
+                }
+                if (!triggerMetadata.ContainsKey(FunctionName))
+                {
+                    triggerMetadata.Add(FunctionName, functionInfo.FuncName);
                 }
             }
 

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/HttpEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/HttpEndToEndTests.cs
@@ -14,6 +14,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         [InlineData("HttpTrigger", "?name=John&lastName=Doe", HttpStatusCode.OK, "Hello John")]
         [InlineData("HttpTriggerThrows", "", HttpStatusCode.InternalServerError, "")]
         [InlineData("HttpTrigger", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
+        [InlineData("HttpTriggerWithMetadata", "?name=Test", HttpStatusCode.OK, "HttpTriggerWithMetadata True False")]
         public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedMessage)
         {
             // TODO: Verify exception on 500 after https://github.com/Azure/azure-functions-host/issues/3589

--- a/test/E2E/TestFunctionApp/HttpTriggerWithMetadata/function.json
+++ b/test/E2E/TestFunctionApp/HttpTriggerWithMetadata/function.json
@@ -1,0 +1,20 @@
+{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/HttpTriggerWithMetadata/run.ps1
+++ b/test/E2E/TestFunctionApp/HttpTriggerWithMetadata/run.ps1
@@ -1,0 +1,31 @@
+param($req, $triggerMetadata)
+
+# You can write to the Azure Functions log streams as you would in a normal PowerShell script.
+Write-Verbose "PowerShell HTTP trigger function processed a request." -Verbose
+
+# You can interact with query parameters, the body of the request, etc.
+$name = $req.Query.Name
+if (-not $name) { $name = $req.Body.Name }
+
+if($name) {
+    $status = 200
+
+    $invocationId = $triggerMetadata.InvocationId
+    $funcDirectory = $triggerMetadata.FunctionDirectory
+    $funcName = $triggerMetadata.FunctionName
+
+    $FuncDirSameAsScriptRoot = $funcDirectory -eq $PSScriptRoot
+    $InvocationIdNullOrEmpty = [string]::IsNullOrEmpty($invocationId)
+
+    $body = "{0} {1} {2}" -f $funcName, $FuncDirSameAsScriptRoot, $InvocationIdNullOrEmpty
+}
+else {
+    $status = 400
+    $body = "Please pass a name on the query string or in the request body."
+}
+
+# You associate values to output bindings by calling 'Push-OutputBinding'.
+Push-OutputBinding -Name res -Value ([HttpResponseContext]@{
+    StatusCode = $status
+    Body = $body
+})


### PR DESCRIPTION
Fix #187

Add `InvocationId`, `FunctionDirectory` and `FunctionName` to `$TriggerMetadata` to make it consistent with the Python worker.
Also, construct the `TriggerMetadata` value only if it's specified.