### PR TITLE
Improve throughput ... a bit

### DIFF
--- a/src/Messaging/MessagingStream.cs
+++ b/src/Messaging/MessagingStream.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Messaging
     internal class MessagingStream
     {
         private readonly AsyncDuplexStreamingCall<StreamingMessage, StreamingMessage> _call;
-        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
         internal MessagingStream(string host, int port)
         {

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             }
 
             var initialSessionState = InitialSessionState.CreateDefault();
-            initialSessionState.ThreadOptions = PSThreadOptions.ReuseThread;
+            initialSessionState.ThreadOptions = PSThreadOptions.UseCurrentThread;
             initialSessionState.EnvironmentVariables.Add(
                 new SessionStateVariableEntry("PSModulePath", FunctionLoader.FunctionModulePath, null));
 

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         private readonly BlockingCollection<PowerShellManager> _pool;
         private int _poolSize;
 
+        internal int UpperBound => _upperBound;
+
         /// <summary>
         /// Constructor of the pool.
         /// </summary>

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         private readonly BlockingCollection<PowerShellManager> _pool;
         private int _poolSize;
 
+        /// <summary>
+        /// Gets the concurrency upper bound.
+        /// </summary>
         internal int UpperBound => _upperBound;
 
         /// <summary>

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -211,10 +211,14 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
 
                 if (_powershellPool.UpperBound == 1)
                 {
+                    // When the concurrency upper bound is 1, we can handle only one invocation at a time anyways,
+                    // so it's better to just do it on the current thread to reduce the required synchronization.
                     ProcessInvocationRequestImpl(request, functionInfo, psManager);
                 }
                 else
                 {
+                    // When the concurrency upper bound is more than 1, we have to handle the invocation in a worker
+                    // thread, so multiple invocations can make progress at the same time, even though by time-sharing.
                     Task.Run(() => ProcessInvocationRequestImpl(request, functionInfo, psManager));
                 }
             }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -208,7 +208,15 @@ namespace  Microsoft.Azure.Functions.PowerShellWorker
             {
                 functionInfo = _functionLoader.GetFunctionInfo(request.InvocationRequest.FunctionId);
                 psManager = _powershellPool.CheckoutIdleWorker(request, functionInfo);
-                Task.Run(() => ProcessInvocationRequestImpl(request, functionInfo, psManager));
+
+                if (_powershellPool.UpperBound == 1)
+                {
+                    ProcessInvocationRequestImpl(request, functionInfo, psManager);
+                }
+                else
+                {
+                    Task.Run(() => ProcessInvocationRequestImpl(request, functionInfo, psManager));
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Synchronization, oh no ...

Look, I have been trying to figure out what is dragging the throughput of the PowerShell worker, and I believe synchronization is the root cause.
The following screenshot is the concurrency view of the PowerShell worker when running under throughput test.

### Test Environment Setup
The throughput test simulates 100 users for 100 seconds, each sends an HTTP trigger request every 1-3 seconds. The response from PS function is a simple 'OK' status.
Both the function host process and the worker process are configured with 1-core processor affinity, to mimic the sandbox environment.
The concurrency level of the PowerShell worker is configured to 1, meaning only one invocation request can be handled at a time. This is the default configuration.

### Summary
As we can see, threads spend 97% of their time on synchronization, and only 1% the time on execution.
All the synchronization is brought in by the gRPC library because it only provides async APIs for sending and receiving messages to the host.
So we sort of have to use `async/await` all the way up in the worker, which is a console application. The result of that is: the main thread is blocking forever while tasks and continuations spin up and down thread-pool threads.
So here comes a question: **does it really make sense for console application to use async/await APIs?** No answer to that :) /cc @pragnagopa 

![image](https://user-images.githubusercontent.com/127450/55663919-61fd7b80-57da-11e9-890f-6eb98d3fff2c.png)

## Changes

This PR makes some changes to avoid extra threads to be created when they are not needed:
1. If the pool size is 1, `ProcessInvocationRequest` should call `ProcessInvocationRequestImpl` directly, instead of creating a Task.
2. Use `PSThreadOptions.UseCurrentThread` for the Runspace we create, so `PowerShell.Invoke` will happen in the current thread, instead of executing the command on a separate thread.

As for the change in `MessagingStream.cs` -- from a `BlockingCollection` to `SemaphoreSlim`, it doesn't introduce any noticeable throughput increase. But theoretically, switching to `SemaphoreSlim` will reduce potential conflicts between running threads, because when calling `SemaphoreSlim.WaitAsync`, the Task object would be blocked, not a running thread.

For the change in `PowerShellManagerPool.cs`, it's actually changing from `CRLF` to `LF`. It's easier to view the diffs with
https://github.com/Azure/azure-functions-powershell-worker/pull/189/files?w=1

## Improvement by the changes

In my local throughput tests (with the same setup as described above), the throughput increased from 41.1 RPS on average to 44.1 RPS on average with changes in this PR.
This improvement is very little, but it kind of proves that the synchronization is the root cause, since I get better throughput by reducing involved threads.
You can find two test summary records below for the throughput tests with and without the changes in this PR. With the changes, we get better average response time (245 vs 421 ms).

**A typical test summary with the changes:**

```output
 Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /api/MyHttpTrigger                                          4231     0(0.00%)     245       0    1287  |     220   44.50
--------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                           4231     0(0.00%)                                      44.50

Percentage of the requests completed within given times
 Name                                                           # reqs    50%    66%    75%    80%    90%    95%    98%    99%   100%
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /api/MyHttpTrigger                                           4231    220    280    330    350    420    490   1000   1100   1300
--------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                            4231    220    280    330    350    420    490   1000   1100   1300
```

**A typical test summary without the changes:**

```output
  Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /api/MyHttpTrigger                                          3924     0(0.00%)     421       0    1440  |     400   40.80
--------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                           3924     0(0.00%)                                      40.80

Percentage of the requests completed within given times
 Name                                                           # reqs    50%    66%    75%    80%    90%    95%    98%    99%   100%
--------------------------------------------------------------------------------------------------------------------------------------------
 GET /api/MyHttpTrigger                                           3924    400    470    520    550    650    760   1000   1100   1400
--------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                            3924    400    470    520    550    650    760   1000   1100   1400
```

## Next Step

I will try to get rid of `async/await` in `RequestProcessor`, and see if that can help a bit in throughput.

**[Update]**
The idea is to not use async/await on `_msgStream.MoveNext()`, but to call it directly and hold the returned task object, so the task can be running in parallel while the main thread is taking care of the current request message.
So when the main thread reach back to the `while (moveNext.GetAwaiter().GetResult())` statement, there is a chance that the task is already complete, and then the main thread can just get the result and continue non-blockingly.

![image](https://user-images.githubusercontent.com/127450/55674266-20ff7880-5867-11e9-8397-3d790b259ec4.png)

I tried this idea and it didn't help with throughput. With the same setup, the throughput drops to 39.30 RPS on average.

I believe it's because it's a 1-core processor environment, and there is no actual parallelism. So when the main thread is running taking care of the current request message, the `MoveNext` task cannot make progress (except for it's network IO part). Hence, extra synchronization is needed between the main thread and thread-pool work threads, and it's more likely that when the main thread gets back to `while (moveNext.GetAwaiter().GetResult())`, the task hasn't completed yet.

This idea may help in a true multi-core environment, but not in the 1-core sandbox.