### PR TITLE
Updating Managed Dependencies folder installation path for local development.

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         // Central repository for acquiring PowerShell modules.
         private const string Repository = "PSGallery";
 
+        // AzureFunctions folder name.
+        private const string AzureFunctionsFolderName = "AzureFunctions";
+
         // Managed Dependencies folder name.
         private const string ManagedDependenciesFolderName = "ManagedDependencies";
 
@@ -305,9 +308,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         /// <summary>
         /// Gets the Managed Dependencies folder path.
         /// If we are running in Azure, the path is HOME\data\ManagedDependencies.
-        /// Otherwise, the path is functionAppRoot\ManagedDependencies.
+        /// Otherwise, the path is LocalApplicationData\AzureFunctions\FunctionAppName\ManagedDependencies.
         /// </summary>
-        private string GetManagedDependenciesPath(string functionAppRoot)
+        private string GetManagedDependenciesPath(string functionAppRootPath)
         {
             string managedDependenciesFolderPath = null;
 
@@ -325,8 +328,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
             else
             {
-                // Otherwise, the ManagedDependencies folder is created under the function app root.
-                managedDependenciesFolderPath = Path.Join(functionAppRoot, ManagedDependenciesFolderName);
+                // Otherwise, the ManagedDependencies folder is created under LocalApplicationData\AzureFunctions\FunctionAppName\ManagedDependencies.
+                string functionAppName = Path.GetFileName(functionAppRootPath);
+                string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+                managedDependenciesFolderPath = Path.Combine(appDataFolder, AzureFunctionsFolderName, functionAppName, ManagedDependenciesFolderName);
             }
 
             return managedDependenciesFolderPath;

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         private readonly string _dependencyManagementDirectory;
         private readonly string _functionId;
         private const string ManagedDependenciesFolderName = "ManagedDependencies";
+        private const string AzureFunctionsFolderName = "AzureFunctions";
 
         public DependencyManagementTests()
         {
@@ -42,6 +43,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             return functionLoadRequest;
         }
 
+        private string GetManagedDependenciesPath(string functionAppRootPath)
+        {
+            string functionAppName = Path.GetFileName(functionAppRootPath);
+            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+            string managedDependenciesFolderPath = Path.Combine(appDataFolder, AzureFunctionsFolderName, functionAppName, ManagedDependenciesFolderName);
+            return managedDependenciesFolderPath;
+        }
+
         private void TestCaseCleanup()
         {
             // We run a test case clean up to reset DependencyManager.Dependencies and DependencyManager.DependenciesPath
@@ -66,10 +75,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 // Test case setup.
                 var requirementsDirectoryName = "BasicRequirements";
-                var functionFolderPath = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName,
-                    "FunctionDirectory");
-                var managedDependenciesFolderPath = Path.Combine(_dependencyManagementDirectory,
-                    requirementsDirectoryName, ManagedDependenciesFolderName);
+                var functionFolderPath = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName, "FunctionDirectory");
+                var functionAppRoot = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName);
+                var managedDependenciesFolderPath = GetManagedDependenciesPath(functionAppRoot);
+
                 var functionLoadRequest = GetFuncLoadRequest(functionFolderPath, true);
 
                 // Create DependencyManager and process the requirements.psd1 file at the function app root.
@@ -97,10 +106,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             {
                 // Test case setup.
                 var requirementsDirectoryName = "EmptyHashtableRequirement";
-                var functionFolderPath = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName,
-                    "FunctionDirectory");
-                var managedDependenciesFolderPath = Path.Combine(_dependencyManagementDirectory,
-                    requirementsDirectoryName, ManagedDependenciesFolderName);
+                var functionFolderPath = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName,"FunctionDirectory");
+                var functionAppRoot = Path.Combine(_dependencyManagementDirectory, requirementsDirectoryName);
+                var managedDependenciesFolderPath = GetManagedDependenciesPath(functionAppRoot);
                 var functionLoadRequest = GetFuncLoadRequest(functionFolderPath, true);
 
                 // Create DependencyManager and process the requirements.psd1 file at the function app root.


### PR DESCRIPTION
Updating Managed Dependencies folder installation path for local development.

In the PowerShell worker, for local development, we install the function app dependencies (ManagedDependencies) under the function app root. However, when this happens, the Process Host gets restarted (since new files were added to the function app root). This causes the CLI to go into an infinite loop. This doesn’t happen in the cloud because we install the function app dependencies under home/data/ManagedDependencies.