### PR TITLE
Managed dependency download on background thread

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         /// Waits for the dependency download task to finish 
         /// and sets it's reference to null to be picked for cleanup by next run of GC
         /// </summary>
-        internal void DownloadDependencyAndWait()
+        internal void WaitOnDependencyDownload()
         {
             if (_dependencyDownloadTask != null)
             {

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -14,14 +14,13 @@ using System.Linq;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
+using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 {
-    using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
     using System.Management.Automation;
     using System.Management.Automation.Language;
     using System.Management.Automation.Runspaces;
-    using System.Threading;
 
     internal class DependencyManager
     {
@@ -94,18 +93,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 using (PowerShell PowerShellInstance = PowerShell.Create(initialSessionState))
                 {
-                    RequestProcessor.IsDependencyDownloadInProgress = true;
                     InstallFunctionAppDependencies(PowerShellInstance, rpcLogger);
-                    RequestProcessor.IsDependencyDownloadInProgress = false;
                 }
             }
             catch (Exception e)
             {
                 _dependencyError = e;
-            }
-            finally
-            {
-                RequestProcessor.IsDependencyDownloadInProgress = false;
             }
         }
 

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             addMethod.Invoke(null, new object[] { "HttpRequestContext", typeof(HttpRequestContext) });
         }
 
-        internal PowerShellManager(ILogger logger, Action<PowerShell, ILogger> initAction = null)
+        internal PowerShellManager(ILogger logger)
         {
             if (FunctionLoader.FunctionAppRootPath == null)
             {

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// </summary>
         internal ILogger Logger => _logger;
 
+        /// <summary>
+        /// Gets the associated PowerShell instance
+        /// </summary>
+        internal PowerShell PowerShellInstance => _pwsh;
+
         static PowerShellManager()
         {
             // Set the type accelerators for 'HttpResponseContext' and 'HttpResponseContext'.
@@ -76,9 +81,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             _pwsh.Streams.Progress.DataAdding += streamHandler.ProgressDataAdding;
             _pwsh.Streams.Verbose.DataAdding += streamHandler.VerboseDataAdding;
             _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
-
-            // Install function app dependent modules
-            initAction?.Invoke(_pwsh, logger);
 
             // Initialize the Runspace
             InvokeProfile(FunctionLoader.FunctionAppProfilePath);

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -33,11 +33,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// </summary>
         internal ILogger Logger => _logger;
 
-        /// <summary>
-        /// Gets the associated PowerShell instance
-        /// </summary>
-        internal PowerShell PowerShellInstance => _pwsh;
-
         static PowerShellManager()
         {
             // Set the type accelerators for 'HttpResponseContext' and 'HttpResponseContext'.

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -47,26 +47,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
-        /// Initialize the pool and populate it with PowerShellManager instances.
-        /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
-        /// </summary>
-        internal void Initialize(string requestId)
-        {
-            var logger = new RpcLogger(_msgStream);
-
-            try
-            {
-                logger.SetContext(requestId, invocationId: null);
-                _pool.Add(new PowerShellManager(logger));
-                _poolSize = 1;
-            }
-            finally
-            {
-                logger.ResetContext();
-            }
-        }
-
-        /// <summary>
         /// Checkout an idle PowerShellManager instance in a non-blocking asynchronous way.
         /// </summary>
         internal PowerShellManager CheckoutIdleWorker(StreamingMessage request, AzFunctionInfo functionInfo)

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
             }
 
-            // Register the function with the Runspace PowerShellManager.
+            // Register the function with the Runspace before returning the idle PowerShellManager.
             FunctionMetadata.RegisterFunctionMetadata(psManager.InstanceId, functionInfo);
             psManager.Logger.SetContext(requestId, invocationId);
             return psManager;

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// <summary>
         /// Checkout an idle PowerShellManager instance in a non-blocking asynchronous way.
         /// </summary>
-        internal PowerShellManager CheckoutIdleWorker(StreamingMessage request, AzFunctionInfo functionInfo)
+        internal PowerShellManager CheckoutIdleWorker(StreamingMessage request)
         {
             PowerShellManager psManager = null;
             string requestId = request.RequestId;
@@ -98,8 +98,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
             }
 
-            // Register the function with the Runspace before returning the idle PowerShellManager.
-            FunctionMetadata.RegisterFunctionMetadata(psManager.InstanceId, functionInfo);
             psManager.Logger.SetContext(requestId, invocationId);
             return psManager;
         }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         private Dictionary<StreamingMessage.ContentOneofCase, Func<StreamingMessage, StreamingMessage>> _requestHandlers =
             new Dictionary<StreamingMessage.ContentOneofCase, Func<StreamingMessage, StreamingMessage>>();
 
-        internal static volatile bool IsDependencyDownloadInProgress;
         private volatile Task _dependencyDownloadTask;
 
         internal RequestProcessor(MessagingStream msgStream)

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 {
                     var rpcLogger = new RpcLogger(_msgStream);
                     rpcLogger.SetContext(request.RequestId, request.InvocationRequest?.InvocationId);
-                    rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, isUserLog: true);
+                    rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, isUserLog: true);
                     _dependencyManager.WaitOnDependencyDownload();
                 }
 
@@ -245,7 +245,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             }
             catch (Exception e)
             {
-                _powershellPool.ReclaimUsedWorker(psManager);
                 StreamingMessage response = NewStreamingMessageTemplate(
                     request.RequestId,
                     StreamingMessage.ContentOneofCase.InvocationResponse,
@@ -286,10 +285,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             {
                 status.Status = StatusResult.Types.Status.Failure;
                 status.Exception = e.ToRpcException();
-            }
-            finally
-            {
-                _powershellPool.ReclaimUsedWorker(psManager);
             }
 
             _msgStream.Write(response);

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -206,13 +206,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             try
             {
                 if (_dependencyManager.DependencyDownloadTask != null
-                    && ((_dependencyManager.DependencyDownloadTask.Status != TaskStatus.Canceled)
+                    && (_dependencyManager.DependencyDownloadTask.Status != TaskStatus.Canceled
                     || _dependencyManager.DependencyDownloadTask.Status != TaskStatus.Faulted
                     || _dependencyManager.DependencyDownloadTask.Status != TaskStatus.RanToCompletion))
                 {
                     var rpcLogger = new RpcLogger(_msgStream);
                     rpcLogger.SetContext(request.RequestId, request.InvocationRequest?.InvocationId);
-                    rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, true);
+                    rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, isUserLog: true);
                     _dependencyManager.WaitOnDependencyDownload();
                 }
 
@@ -230,7 +230,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 functionInfo = _functionLoader.GetFunctionInfo(request.InvocationRequest.FunctionId);
                 psManager = _powershellPool.CheckoutIdleWorker(request, functionInfo);
 
-                //ProcessInvocationRequestImpl(request, functionInfo, psManager);
                 if (_powershellPool.UpperBound == 1)
                 {
                     // When the concurrency upper bound is 1, we can handle only one invocation at a time anyways,

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -213,7 +213,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     var rpcLogger = new RpcLogger(_msgStream);
                     rpcLogger.SetContext(request.RequestId, request.InvocationRequest?.InvocationId);
                     rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, true);
-                    rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null);
                     _dependencyManager.DependencyDownloadTask.Wait();
                 }
 
@@ -328,7 +327,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // Setup the FunctionApp root path and module path.
             FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
             _dependencyManager.ProcessDependencyDownload(_msgStream, request);
-            _powershellPool.Initialize(request.RequestId);
         }
 
         /// <summary>

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     var rpcLogger = new RpcLogger(_msgStream);
                     rpcLogger.SetContext(request.RequestId, request.InvocationRequest?.InvocationId);
                     rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, true);
-                    _dependencyManager.DependencyDownloadTask.Wait();
+                    _dependencyManager.DownloadDependencyAndWait();
                 }
 
                 if (_dependencyManager.DependencyError != null)

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     var rpcLogger = new RpcLogger(_msgStream);
                     rpcLogger.SetContext(request.RequestId, request.InvocationRequest?.InvocationId);
                     rpcLogger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, null, true);
-                    _dependencyManager.DownloadDependencyAndWait();
+                    _dependencyManager.WaitOnDependencyDownload();
                 }
 
                 if (_dependencyManager.DependencyError != null)

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -59,8 +59,8 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,41 +26,41 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -166,7 +166,7 @@
   <data name="SpecifiedCustomPipeName" xml:space="preserve">
     <value>Custom pipe name specified. You can attach to the process by using vscode or by running `Enter-PSHostProcess -CustomPipeName {0}`</value>
   </data>
-    <data name="CannotFindModuleVersion" xml:space="preserve">
+  <data name="CannotFindModuleVersion" xml:space="preserve">
     <value>Cannot find a supported version for module '{0}' with major version '{0}'.</value>
   </data>
   <data name="FunctionAppDoesNotHaveDependentModulesToInstall" xml:space="preserve">
@@ -194,7 +194,7 @@
     <value>Invalid major version for module '{0}'. The maximum available major version is '{1}'.</value>
   </data>
   <data name="FailToInstallFuncAppDependencies" xml:space="preserve">
-    <value>Fail to install function app dependencies. Error: '{0}'</value>
+    <value>Fail to install function app dependencies. Restarting the app may resolve the error. Error: '{0}'</value>
   </data>
   <data name="FailToResolveHomeDirectory" xml:space="preserve">
     <value>Fail to resolve '{0}' path in App Service.</value>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -211,4 +211,7 @@
   <data name="LogNewPowerShellManagerCreated" xml:space="preserve">
     <value>A new PowerShell manager instance is added to the pool. Current pool size '{0}'.</value>
   </data>
+  <data name="DependencyDownloadInProgress" xml:space="preserve">
+    <value>Managed dependency download is in progress, function execution will continue when it's done.</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR has the changes to download managed dependency on a background thread and show the managed dependency download in progress message on the azure portal and on the CLI console when a function invocation is triggered while managed dependency download is in-progress