### PR TITLE
Refactor and clean up based on the dependency management changes

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,17 +10,18 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
-using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
 using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 {
     using System.Management.Automation;
     using System.Management.Automation.Language;
     using System.Management.Automation.Runspaces;
-    using System.Threading.Tasks;
 
     internal class DependencyManager
     {
@@ -122,18 +122,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             try
             {
                 _dependencyError = null;
-                var initialSessionState = InitialSessionState.CreateDefault();
-                initialSessionState.ThreadOptions = PSThreadOptions.UseCurrentThread;
-                initialSessionState.EnvironmentVariables.Add(new SessionStateVariableEntry("PSModulePath", FunctionLoader.FunctionModulePath, null));
-                // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
-                if (Platform.IsWindows)
+                using (PowerShell pwsh = PowerShell.Create(Utils.GetInitialSessionState()))
                 {
-                    initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
-                }
-
-                using (PowerShell powerShellInstance = PowerShell.Create(initialSessionState))
-                {
-                    InstallFunctionAppDependencies(powerShellInstance, rpcLogger);
+                    InstallFunctionAppDependencies(pwsh, rpcLogger);
                 }
             }
             catch (Exception e)
@@ -152,6 +143,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         /// </summary>
         internal void Initialize(FunctionLoadRequest request)
         {
+            if (!request.ManagedDependencyEnabled)
+            {
+                return;
+            }
+
             try
             {
                 // Resolve the FunctionApp root path.

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             try
             {
                 _dependencyError = null;
-                using (PowerShell pwsh = PowerShell.Create(Utils.GetInitialSessionState()))
+                using (PowerShell pwsh = PowerShell.Create(Utils.SingletonISS.Value))
                 {
                     InstallFunctionAppDependencies(pwsh, rpcLogger);
                 }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             }
 
             _logger = logger;
-            _pwsh = PowerShell.Create(Utils.GetInitialSessionState());
+            _pwsh = PowerShell.Create(Utils.SingletonISS.Value);
 
             // Setup Stream event listeners
             var streamHandler = new StreamHandler(logger);

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -52,21 +52,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
             }
 
-            var initialSessionState = InitialSessionState.CreateDefault();
-            initialSessionState.ThreadOptions = PSThreadOptions.UseCurrentThread;
-            initialSessionState.EnvironmentVariables.Add(
-                new SessionStateVariableEntry("PSModulePath", FunctionLoader.FunctionModulePath, null));
-
-            // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
-            if(Platform.IsWindows)
-            {
-                // This sets the execution policy on Windows to Unrestricted which is required to run the user's function scripts on
-                // Windows client versions. This is needed if a user is testing their function locally with the func CLI
-                initialSessionState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
-            }
-
             _logger = logger;
-            _pwsh = PowerShell.Create(initialSessionState);
+            _pwsh = PowerShell.Create(Utils.GetInitialSessionState());
 
             // Setup Stream event listeners
             var streamHandler = new StreamHandler(logger);

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Text;
 using Microsoft.PowerShell.Commands;
 
@@ -17,6 +18,34 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         internal static CmdletInfo RemoveModuleCmdletInfo = new CmdletInfo("Remove-Module", typeof(RemoveModuleCommand));
         internal static CmdletInfo GetJobCmdletInfo = new CmdletInfo("Get-Job", typeof(GetJobCommand));
         internal static CmdletInfo RemoveJobCmdletInfo = new CmdletInfo("Remove-Job", typeof(RemoveJobCommand));
+
+        private static InitialSessionState s_initialSessionState = null;
+
+        internal static InitialSessionState GetInitialSessionState()
+        {
+            if (s_initialSessionState == null)
+            {
+                var iss = InitialSessionState.CreateDefault();
+                iss.ThreadOptions = PSThreadOptions.UseCurrentThread;
+                iss.EnvironmentVariables.Add(
+                    new SessionStateVariableEntry(
+                        "PSModulePath",
+                        FunctionLoader.FunctionModulePath,
+                        description: null));
+
+                // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
+                if(Platform.IsWindows)
+                {
+                    // This sets the execution policy on Windows to Unrestricted which is required to run the user's function scripts on
+                    // Windows client versions. This is needed if a user is testing their function locally with the func CLI.
+                    iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
+                }
+
+                s_initialSessionState = iss;
+            }
+
+            return s_initialSessionState;
+        }
 
         /// <summary>
         /// Helper method to do additional transformation on the input value based on the type constraints specified in the script.

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
     internal class Utils
     {
-        internal static CmdletInfo ImportModuleCmdletInfo = new CmdletInfo("Import-Module", typeof(ImportModuleCommand));
-        internal static CmdletInfo RemoveModuleCmdletInfo = new CmdletInfo("Remove-Module", typeof(RemoveModuleCommand));
-        internal static CmdletInfo GetJobCmdletInfo = new CmdletInfo("Get-Job", typeof(GetJobCommand));
-        internal static CmdletInfo RemoveJobCmdletInfo = new CmdletInfo("Remove-Job", typeof(RemoveJobCommand));
+        internal readonly static CmdletInfo ImportModuleCmdletInfo = new CmdletInfo("Import-Module", typeof(ImportModuleCommand));
+        internal readonly static CmdletInfo RemoveModuleCmdletInfo = new CmdletInfo("Remove-Module", typeof(RemoveModuleCommand));
+        internal readonly static CmdletInfo GetJobCmdletInfo = new CmdletInfo("Get-Job", typeof(GetJobCommand));
+        internal readonly static CmdletInfo RemoveJobCmdletInfo = new CmdletInfo("Remove-Job", typeof(RemoveJobCommand));
 
-        internal static Lazy<InitialSessionState> SingletonISS
+        internal readonly static Lazy<InitialSessionState> SingletonISS
             = new Lazy<InitialSessionState>(NewInitialSessionState, LazyThreadSafetyMode.PublicationOnly);
 
         private static InitialSessionState NewInitialSessionState()


### PR DESCRIPTION
Refactor and clean up the code base based on the dependency management changes.
- Reduce redundant code -- `initialsessionstate` creation and failure response in `FunctionLoad` processing
- Remove the unnecessary `_powershellPool.ReclaimUsedWorker(psManager);` in `ProcessInvocationRequest`.
- Change the line ending from `CRLF` to `LF` in `Utils.cs`.
   - It's easier to review with https://github.com/Azure/azure-functions-powershell-worker/pull/194/files?w=1 