### PR TITLE
Fix no runspace available issue

### DIFF
--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -47,6 +47,26 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
+        /// Initialize the pool and populate it with PowerShellManager instances.
+        /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
+        /// </summary>
+        internal void Initialize(string requestId, bool skipProfile = false)
+        {
+            var logger = new RpcLogger(_msgStream);
+
+            try
+            {
+                logger.SetContext(requestId, invocationId: null);
+                _pool.Add(new PowerShellManager(logger, skipProfile));
+                _poolSize = 1;
+            }
+            finally
+            {
+                logger.ResetContext();
+            }
+        }
+
+        /// <summary>
         /// Checkout an idle PowerShellManager instance in a non-blocking asynchronous way.
         /// </summary>
         internal PowerShellManager CheckoutIdleWorker(StreamingMessage request, AzFunctionInfo functionInfo)

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -171,6 +171,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // Setup the FunctionApp root path and module path.
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
                     _dependencyManager.ProcessDependencyDownload(_msgStream, request);
+
+                    // Initialize the first runspace so that the debugger has something to attach to.
+                    // Upon the first invocation and completion of the dependencyDownload, the profile.ps1 will be run in the runspace.
+                    _powershellPool.Initialize(request.RequestId, skipProfile: true);
                 }
                 catch (Exception e)
                 {

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -154,6 +154,9 @@
   <data name="FailToRunProfile" xml:space="preserve">
     <value>Fail to run profile.ps1. See logs for detailed errors. Profile location: {0}.</value>
   </data>
+  <data name="DeferringProfileToFirstExecution" xml:space="preserve">
+    <value>Deferring profile execution until first function invocation. This allows dependency management time to install all the dependencies.</value>
+  </data>
   <data name="UnsupportedMessage" xml:space="preserve">
     <value>Unsupported message type: {0}.</value>
   </data>

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
         // Have a single place to get a PowerShellManager for testing.
         // This is to guarantee that the well known paths are setup before calling the constructor of PowerShellManager.
-        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger)
+        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger, bool skipProfile = false)
         {
-            return new PowerShellManager(logger);
+            return new PowerShellManager(logger, skipProfile);
         }
 
         internal static AzFunctionInfo NewAzFunctionInfo(string scriptFile, string entryPoint)
@@ -209,6 +209,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
             Assert.Single(_testLogger.FullLog);
             Assert.Equal("Information: INFORMATION: Hello PROFILE", _testLogger.FullLog[0]);
+        }
+
+        [Fact]
+        public void ProfileShouldNotRunIfSkipped()
+        {
+            //initialize fresh log
+            _testLogger.FullLog.Clear();
+            TestUtils.NewTestPowerShellManager(_testLogger, skipProfile: true);
+
+            Assert.Single(_testLogger.FullLog);
+            Assert.Equal("Trace: Deferring profile execution until first function invocation. This allows dependency management time to install all the dependencies.", _testLogger.FullLog[0]);
         }
 
         [Fact]


### PR DESCRIPTION
fixes #196 

I really wanted to put something at the end of the dependency manager's task... but I wanted to keep that as separate as possible.

I also wanted to put in the RequestProcessor instead... but that wasn't a good fit either.

This will initialize a PowerShellManager in the pool... then when the first invocation comes in and dependencies are grabbed, it will run the profile script.

draft PR for now...