### PR TITLE
Create the first PowerShellManager instance when processing the first FunctionLoad request

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -47,6 +47,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
+        /// Constructor for setting the basic fields.
+        /// </summary>
+        private PowerShellManager(ILogger logger, PowerShell pwsh, int id)
+        {
+            _logger = logger;
+            _pwsh = pwsh;
+            _pwsh.Runspace.Name = $"PowerShellManager{id}";
+        }
+
+        /// <summary>
         /// Create a PowerShellManager instance but defer the Initialization.
         /// </summary>
         /// <remarks>
@@ -55,16 +65,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// the dependent modules are downloaded and all Az functions are loaded.
         /// </remarks>
         internal PowerShellManager(ILogger logger, PowerShell pwsh)
+            : this(logger, pwsh, id: 1)
         {
-            _logger = logger;
-            _pwsh = pwsh;
         }
 
         /// <summary>
         /// Create a PowerShellManager instance and initialize it.
         /// </summary>
-        internal PowerShellManager(ILogger logger) 
-            : this(logger, Utils.NewPwshInstance())
+        internal PowerShellManager(ILogger logger, int id)
+            : this(logger, Utils.NewPwshInstance(), id)
         {
             // Initialize the Runspace
             Initialize();

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             }
         }
 
+        /// <summary>
+        /// Extra initialization of the Runspace.
+        /// </summary>
         internal void Initialize()
         {
             if (!_runspaceInited)

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -46,30 +46,28 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             addMethod.Invoke(null, new object[] { "HttpRequestContext", typeof(HttpRequestContext) });
         }
 
-        internal PowerShellManager(ILogger logger, bool delayInit = false)
+        /// <summary>
+        /// Create a PowerShellManager instance but defer the Initialization.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is only for creating the very first PowerShellManager instance.
+        /// The initialization work is deferred until all prerequisites are ready, such as
+        /// the dependent modules are downloaded and all Az functions are loaded.
+        /// </remarks>
+        internal PowerShellManager(ILogger logger, PowerShell pwsh)
         {
-            if (FunctionLoader.FunctionAppRootPath == null)
-            {
-                throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
-            }
-
             _logger = logger;
-            _pwsh = PowerShell.Create(Utils.SingletonISS.Value);
+            _pwsh = pwsh;
+        }
 
-            // Setup Stream event listeners
-            var streamHandler = new StreamHandler(logger);
-            _pwsh.Streams.Debug.DataAdding += streamHandler.DebugDataAdding;
-            _pwsh.Streams.Error.DataAdding += streamHandler.ErrorDataAdding;
-            _pwsh.Streams.Information.DataAdding += streamHandler.InformationDataAdding;
-            _pwsh.Streams.Progress.DataAdding += streamHandler.ProgressDataAdding;
-            _pwsh.Streams.Verbose.DataAdding += streamHandler.VerboseDataAdding;
-            _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
-
+        /// <summary>
+        /// Create a PowerShellManager instance and initialize it.
+        /// </summary>
+        internal PowerShellManager(ILogger logger) 
+            : this(logger, Utils.NewPwshInstance())
+        {
             // Initialize the Runspace
-            if (!delayInit)
-            {
-                Initialize();
-            }
+            Initialize();
         }
 
         /// <summary>
@@ -79,9 +77,24 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if (!_runspaceInited)
             {
+                RegisterStreamEvents();
                 InvokeProfile(FunctionLoader.FunctionAppProfilePath);
                 _runspaceInited = true;
             }
+        }
+
+        /// <summary>
+        /// Setup Stream event listeners.
+        /// </summary>
+        private void RegisterStreamEvents()
+        {
+            var streamHandler = new StreamHandler(_logger);
+            _pwsh.Streams.Debug.DataAdding += streamHandler.DebugDataAdding;
+            _pwsh.Streams.Error.DataAdding += streamHandler.ErrorDataAdding;
+            _pwsh.Streams.Information.DataAdding += streamHandler.InformationDataAdding;
+            _pwsh.Streams.Progress.DataAdding += streamHandler.ProgressDataAdding;
+            _pwsh.Streams.Verbose.DataAdding += streamHandler.VerboseDataAdding;
+            _pwsh.Streams.Warning.DataAdding += streamHandler.WarningDataAdding;
         }
 
         /// <summary>

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// Initialize the pool and populate it with PowerShellManager instances.
         /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
         /// </summary>
-        internal void Initialize(string requestId)
+        internal void Initialize()
         {
             _pool.Add(new PowerShellManager(new RpcLogger(_msgStream), delayInit: true));
             _poolSize = 1;

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -47,6 +47,26 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
+        /// Initialize the pool and populate it with PowerShellManager instances.
+        /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
+        /// </summary>
+        internal void Initialize(string requestId, bool skipProfile = false)
+        {
+            var logger = new RpcLogger(_msgStream);
+
+            try
+            {
+                logger.SetContext(requestId, invocationId: null);
+                _pool.Add(new PowerShellManager(logger, skipProfile));
+                _poolSize = 1;
+            }
+            finally
+            {
+                logger.ResetContext();
+            }
+        }
+
+        /// <summary>
         /// Checkout an idle PowerShellManager instance in a non-blocking asynchronous way.
         /// </summary>
         internal PowerShellManager CheckoutIdleWorker(StreamingMessage request, AzFunctionInfo functionInfo)

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -50,9 +50,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// Initialize the pool and populate it with PowerShellManager instances.
         /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
         /// </summary>
-        internal void Initialize()
+        internal void Initialize(PowerShell pwsh)
         {
-            _pool.Add(new PowerShellManager(new RpcLogger(_msgStream), delayInit: true));
+            var logger = new RpcLogger(_msgStream);
+            var psManager = new PowerShellManager(logger, pwsh);
+            _pool.Add(psManager);
             _poolSize = 1;
         }
 

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         }
 
         /// <summary>
-        /// Initialize the pool and populate it with PowerShellManager instances.
+        /// Populate the pool with the very first PowerShellManager instance.
         /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
         /// </summary>
         internal void Initialize(PowerShell pwsh)

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -50,14 +50,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// Initialize the pool and populate it with PowerShellManager instances.
         /// We instantiate PowerShellManager instances in a lazy way, starting from size 1 and increase the number of workers as needed.
         /// </summary>
-        internal void Initialize(string requestId, bool skipProfile = false)
+        internal void Initialize(string requestId)
         {
             var logger = new RpcLogger(_msgStream);
 
             try
             {
                 logger.SetContext(requestId, invocationId: null);
-                _pool.Add(new PowerShellManager(logger, skipProfile));
+                _pool.Add(new PowerShellManager(logger, delayInit: true));
                 _poolSize = 1;
             }
             finally
@@ -101,6 +101,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             // Register the function with the Runspace before returning the idle PowerShellManager.
             FunctionMetadata.RegisterFunctionMetadata(psManager.InstanceId, functionInfo);
             psManager.Logger.SetContext(requestId, invocationId);
+
+            psManager.Initialize();
             return psManager;
         }
 

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // Create the first Runspace so that the debugger has the target to attach to.
                     // The further initialization of the Runspace (e.g. invoking profile.ps1) is delayed until
                     // the first invocation and completion of the dependency download.
-                    _powershellPool.Initialize(request.RequestId);
+                    _powershellPool.Initialize();
                 }
                 catch (Exception e)
                 {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -171,6 +171,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // Setup the FunctionApp root path and module path.
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
                     _dependencyManager.ProcessDependencyDownload(_msgStream, request);
+
+                    // Initialize the first runspace so that the debugger has something to attach to.
+                    // Upon the first invocation and completion of the dependencyDownload, the profile.ps1 will be run in the runspace.
+                    _powershellPool.Initialize(request.RequestId, skipProfile: true);
                 }
                 catch (Exception e)
                 {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
                     // Initialize the first runspace so that the debugger has something to attach to.
                     // Upon the first invocation and completion of the dependencyDownload, the profile.ps1 will be run in the runspace.
-                    _powershellPool.Initialize(request.RequestId, skipProfile: true);
+                    _powershellPool.Initialize(request.RequestId);
                 }
                 catch (Exception e)
                 {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -170,12 +170,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
                     // Setup the FunctionApp root path and module path.
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
-                    _dependencyManager.ProcessDependencyDownload(_msgStream, request);
 
-                    // Create the first Runspace so that the debugger has the target to attach to.
-                    // The further initialization of the Runspace (e.g. invoking profile.ps1) is delayed until
-                    // the first invocation and completion of the dependency download.
-                    _powershellPool.Initialize();
+                    // Create the very first Runspace so the debugger has the target to attach to.
+                    // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
+                    // and the dependency manager (used to download dependent modules if needed).
+                    var pwsh = Utils.NewPwshInstance();
+                    _powershellPool.Initialize(pwsh);
+
+                    // Start the download asynchronously if needed.
+                    _dependencyManager.ProcessDependencyDownload(_msgStream, request, pwsh);
                 }
                 catch (Exception e)
                 {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -172,8 +172,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest);
                     _dependencyManager.ProcessDependencyDownload(_msgStream, request);
 
-                    // Initialize the first runspace so that the debugger has something to attach to.
-                    // Upon the first invocation and completion of the dependencyDownload, the profile.ps1 will be run in the runspace.
+                    // Create the first Runspace so that the debugger has the target to attach to.
+                    // The further initialization of the Runspace (e.g. invoking profile.ps1) is delayed until
+                    // the first invocation and completion of the dependency download.
                     _powershellPool.Initialize(request.RequestId);
                 }
                 catch (Exception e)

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -22,15 +22,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         internal readonly static CmdletInfo RemoveJobCmdletInfo = new CmdletInfo("Remove-Job", typeof(RemoveJobCommand));
 
         private static InitialSessionState s_iss;
-        private static InitialSessionState SingletonISS
-        {
-            get
-            {
-                if (s_iss != null)
-                {
-                    return s_iss;
-                }
 
+        /// <summary>
+        /// Create a new PowerShell instance using our singleton InitialSessionState instance.
+        /// </summary>
+        internal static PowerShell NewPwshInstance()
+        {
+            if (s_iss == null)
+            {
                 if (FunctionLoader.FunctionAppRootPath == null)
                 {
                     throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
@@ -51,20 +50,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     // Windows client versions. This is needed if a user is testing their function locally with the func CLI.
                     s_iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Unrestricted;
                 }
-
-                return s_iss;
             }
-        }
 
-        /// <summary>
-        /// Create a new PowerShell instance using our singleton InitialSessionState instance.
-        /// </summary>
-        internal static PowerShell NewPwshInstance()
-        {
-            var pwsh = PowerShell.Create(SingletonISS);
-            pwsh.Runspace.Name = "PowerShellManager";
-
-            return pwsh;
+            return PowerShell.Create(s_iss);
         }
 
         /// <summary>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -154,9 +154,6 @@
   <data name="FailToRunProfile" xml:space="preserve">
     <value>Fail to run profile.ps1. See logs for detailed errors. Profile location: {0}.</value>
   </data>
-  <data name="DeferringProfileToFirstExecution" xml:space="preserve">
-    <value>Deferring profile execution until first function invocation. This allows dependency management time to install all the dependencies.</value>
-  </data>
   <data name="UnsupportedMessage" xml:space="preserve">
     <value>Unsupported message type: {0}.</value>
   </data>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -154,6 +154,9 @@
   <data name="FailToRunProfile" xml:space="preserve">
     <value>Fail to run profile.ps1. See logs for detailed errors. Profile location: {0}.</value>
   </data>
+  <data name="DeferringProfileToFirstExecution" xml:space="preserve">
+    <value>Deferring profile execution until first function invocation. This allows dependency management time to install all the dependencies.</value>
+  </data>
   <data name="UnsupportedMessage" xml:space="preserve">
     <value>Unsupported message type: {0}.</value>
   </data>

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -7,13 +7,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Management.Automation;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
+using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Xunit;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 {
+    using System.Management.Automation;
+
     internal class TestUtils
     {
         internal const string TestInputBindingName = "req";
@@ -43,9 +45,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
         // Have a single place to get a PowerShellManager for testing.
         // This is to guarantee that the well known paths are setup before calling the constructor of PowerShellManager.
-        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger, bool delayInit = false)
+        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger, PowerShell pwsh = null)
         {
-            return new PowerShellManager(logger, delayInit);
+            return pwsh != null ? new PowerShellManager(logger, pwsh) : new PowerShellManager(logger);
         }
 
         internal static AzFunctionInfo NewAzFunctionInfo(string scriptFile, string entryPoint)
@@ -252,7 +254,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             //initialize fresh log
             _testLogger.FullLog.Clear();
-            TestUtils.NewTestPowerShellManager(_testLogger, delayInit: true);
+            TestUtils.NewTestPowerShellManager(_testLogger, Utils.NewPwshInstance());
 
             Assert.Empty(_testLogger.FullLog);
         }

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         // This is to guarantee that the well known paths are setup before calling the constructor of PowerShellManager.
         internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger, PowerShell pwsh = null)
         {
-            return pwsh != null ? new PowerShellManager(logger, pwsh) : new PowerShellManager(logger);
+            return pwsh != null ? new PowerShellManager(logger, pwsh) : new PowerShellManager(logger, id: 2);
         }
 
         internal static AzFunctionInfo NewAzFunctionInfo(string scriptFile, string entryPoint)

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
         // Have a single place to get a PowerShellManager for testing.
         // This is to guarantee that the well known paths are setup before calling the constructor of PowerShellManager.
-        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger)
+        internal static PowerShellManager NewTestPowerShellManager(ConsoleLogger logger, bool skipProfile = false)
         {
-            return new PowerShellManager(logger);
+            return new PowerShellManager(logger, skipProfile);
         }
 
         internal static AzFunctionInfo NewAzFunctionInfo(string scriptFile, string entryPoint)
@@ -209,6 +209,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
             Assert.Single(_testLogger.FullLog);
             Assert.Equal("Information: INFORMATION: Hello PROFILE", _testLogger.FullLog[0]);
+        }
+
+        [Fact]
+        public void ProfileShouldNotRunIfSkipped()
+        {
+            //initialize fresh log
+            _testLogger.FullLog.Clear();
+            TestUtils.NewTestPowerShellManager(_testLogger, skipProfile: true);
+
+            Assert.Single(_testLogger.FullLog);
+            Assert.Equal("Trace: Deferring profile execution until first function invocation. This allows dependency management time to install all the dependencies.", _testLogger.FullLog[0]);
         }
 
         [Fact]


### PR DESCRIPTION
This is to fix the regression in local debugging.
We create the first `PowerShellManager` instance when processing the first `FunctionLoad` request, so the debugger has the target Runspace to attach to.
However, we delay the initialization of the first `PowerShellManager` instance until the first invocation (when checking out the instance from pool).

It turns out we cannot have the dependency manager to create a separate Runspace for downloading.
The VS Code local debugging assumes the target `Runspace` has `Id = 1`, which was true before as only one Runspace will be created initially.
Now, the dependency manager creates a separate `Runspace` for downloading, and there will be a race condition -- sometimes the `Runspace` created for the downloading has `Id = 1`, and thus the debugger will attach to that Runspace, which will be reclaimed after the download and causing the `Wait-Debugger` in the user's function script to not be hit.

This refactoring make sure only one `Runspace` is created initially -- the `PowerShell` instance used for the downloading is also used to serve the first invocation request.
So there is no race condition and local debugging can work reliably.

Fix #196.