### PR TITLE
Rev the gRPC/protobuf nuget package version

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -20,11 +20,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="1.19.0" />
+    <PackageReference Include="Grpc.Core" Version="1.20.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.6.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Address #197 

Rev the gRPC/protobuf nuget package version.
We probably should enable [`dependabot`](https://github.com/PowerShell/PowerShell/pull/9264) for this repository.