### PR TITLE
Special case the 'RpcHttp.RawBody' field to always return the literal string

### DIFF
--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -58,7 +58,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
             if (rpcHttp.RawBody != null)
             {
-                httpRequestContext.RawBody = rpcHttp.RawBody.ToObject();
+                object rawBody = rpcHttp.RawBody.DataCase == TypedData.DataOneofCase.String
+                    ? rpcHttp.RawBody.String
+                    : rpcHttp.RawBody.ToObject();
+
+                httpRequestContext.RawBody = rawBody;
             }
 
             return httpRequestContext;

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var method = "Get";
             var url = "https://example.com";
             var data = "Hello World";
+            var rawData = "{\"Foo\":\"Bar\"}";
 
             var input = new TypedData
             {
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                     },
                     RawBody = new TypedData
                     {
-                        String = data
+                        String = rawData
                     }
                 }
             };
@@ -121,7 +122,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(httpRequestContext.Method, method);
             Assert.Equal(httpRequestContext.Url, url);
             Assert.Equal(httpRequestContext.Body, data);
-            Assert.Equal(httpRequestContext.RawBody, data);
+            Assert.Equal(httpRequestContext.RawBody, rawData);
             Assert.Empty(httpRequestContext.Headers);
             Assert.Empty(httpRequestContext.Params);
             Assert.Empty(httpRequestContext.Query);


### PR DESCRIPTION
Fix #205

Special case `RpcHttp.RawBody` field to always return the literal string.
NodeJS worker does the same for `RawBody`: https://github.com/Azure/azure-functions-nodejs-worker/blob/dev/src/Converters.ts#L18