### PR TITLE
Adding function app dependencies installation retry logic with exponential back off.

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
@@ -249,14 +250,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                                 throw _dependencyError;
                             }
-
-                            // Update the retry counter
-                            tries++;
+                            else
+                            {
+                                var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallFuncAppDependency, moduleName, latestVersion, e.Message);
+                                logger.Log(LogLevel.Error, errorMsg, isUserLog: true);
+                            }
                         }
 
                         // Wait for 2^(tries-1) seconds between retries. In this case, it would be 1, 2, and 4 seconds, respectively.
-                        double waitTimeInSeconds = Math.Pow(2, tries - 1);
-                        TimeSpan.FromSeconds(waitTimeInSeconds);
+                        var waitTimeSpan = TimeSpan.FromSeconds(Math.Pow(2, tries - 1));
+                        Thread.Sleep(waitTimeSpan);
+
+                        // Update the retry counter
+                        tries++;
                     }
                 }
             }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -194,7 +194,7 @@
     <value>Invalid major version for module '{0}'. The maximum available major version is '{1}'.</value>
   </data>
   <data name="FailToInstallFuncAppDependencies" xml:space="preserve">
-    <value>Fail to install FunctionApp dependencies. Restarting the app may resolve the error. Error: '{0}'</value>
+    <value>Fail to install FunctionApp dependencies. For more information, please see error logs. Restarting the app may resolve the error. Error: '{0}'</value>
   </data>
   <data name="FailToResolveHomeDirectory" xml:space="preserve">
     <value>Fail to resolve '{0}' path in App Service.</value>
@@ -228,5 +228,8 @@
   </data>
   <data name="FailToCreateFunctionAppDependenciesDestinationPath" xml:space="preserve">
     <value>Fail to create FunctionApp dependencies destination path '{0}'. Please make sure you have write access to this location. Error '{1}''. </value>
+  </data>
+    <data name="FailToInstallFuncAppDependency" xml:space="preserve">
+    <value>Fail to install FunctionApp dependent module '{0}' version '{1}'. Error: '{2}''. </value>
   </data>
 </root>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -170,7 +170,7 @@
     <value>Cannot find a supported version for module '{0}' with major version '{0}'.</value>
   </data>
   <data name="FunctionAppDoesNotHaveDependentModulesToInstall" xml:space="preserve">
-    <value>Function App does have dependent modules to install.</value>
+    <value>FunctionApp does have dependent modules to install.</value>
   </data>
   <data name="DependencyPropertyIsNullOrEmpty" xml:space="preserve">
     <value>Dependency '{0}' is null or empty.</value>
@@ -179,7 +179,7 @@
     <value>Module name '{0}' version '{0}' has been installed.</value>
   </data>
   <data name="LatestFunctionAppDependenciesAlreadyInstalled" xml:space="preserve">
-    <value>Function app has the latest dependencies already installed.</value>
+    <value>FunctionApp has the latest dependencies already installed.</value>
   </data>
   <data name="ManagedDependencyNotSupported" xml:space="preserve">
     <value>Managed dependency name '{0}' is not supported.</value>
@@ -194,16 +194,16 @@
     <value>Invalid major version for module '{0}'. The maximum available major version is '{1}'.</value>
   </data>
   <data name="FailToInstallFuncAppDependencies" xml:space="preserve">
-    <value>Fail to install function app dependencies. Restarting the app may resolve the error. Error: '{0}'</value>
+    <value>Fail to install FunctionApp dependencies. Restarting the app may resolve the error. Error: '{0}'</value>
   </data>
   <data name="FailToResolveHomeDirectory" xml:space="preserve">
     <value>Fail to resolve '{0}' path in App Service.</value>
   </data>
   <data name="InstallingFunctionAppDependentModules" xml:space="preserve">
-    <value>Installing function app dependent modules.</value>
+    <value>Installing FunctionApp dependent modules.</value>
   </data>
   <data name="FailToClenupModuleDestinationPath" xml:space="preserve">
-    <value>Failed to clean up module destination path '{0}'</value>
+    <value>Fail to clean up module destination path '{0}'</value>
   </data>
   <data name="LogConcurrencyUpperBound" xml:space="preserve">
     <value>The enforced concurrency level (pool size limit) is '{0}'.</value>
@@ -225,5 +225,8 @@
   </data>
   <data name="UnrecognizedBehavior" xml:space="preserve">
     <value>Unrecognized data collecting behavior '{0}'.</value>
+  </data>
+  <data name="FailToCreateFunctionAppDependenciesDestinationPath" xml:space="preserve">
+    <value>Fail to create FunctionApp dependencies destination path '{0}'. Please make sure you have write access to this location. Error '{1}''. </value>
   </data>
 </root>


### PR DESCRIPTION
This PR addresses issue https://github.com/Azure/azure-functions-powershell-worker/issues/218.

Changes in this PR:

* Adding function app dependencies installation retry logic with exponential back off. If an issue is encountered. We retry a maximum of 3 times, and we wait in between tries 1, 2, 4 seconds, respectively. 

* Before we installed the function app dependencies, we need to ensure that the user has write access to their storage account. To validate this, we create the module destination path if it does not exist, and if it exists, we try to empty it. If an issue is encountered, we error out and advice to user to ensure that they have write access to the path where the dependencies will be installed. 

* Updated error messages to keep consistency.
