### PR TITLE
Fixing faulty logic in InstallFunctionAppDependencies

### DIFF
--- a/src/DependencyManagement/DependencyManagementUtils.cs
+++ b/src/DependencyManagement/DependencyManagementUtils.cs
@@ -53,6 +53,34 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         }
 
         /// <summary>
+        /// Sets/prepares the destination path where the function app dependencies will be installed.
+        /// </summary>
+        internal static void SetDependenciesDestinationPath(string path)
+        {
+            // Save-Module supports downloading side-by-size module versions. However, we only want to keep one version at the time.
+            // If the ManagedDependencies folder exits, remove all its contents.
+            if (Directory.Exists(path))
+            {
+                EmptyDirectory(path);
+            }
+            else
+            {
+                // If the destination path does not exist, create it.
+                // If the user does not have write access to the path, an exception will be raised.
+                try
+                {
+                    Directory.CreateDirectory(path);
+                }
+                catch (Exception e)
+                {
+                    var errorMsg = string.Format(PowerShellWorkerStrings.FailToCreateFunctionAppDependenciesDestinationPath, path, e.Message);
+                    throw new InvalidOperationException(errorMsg);
+                }
+            }
+        }
+
+
+        /// <summary>
         /// Returns the latest module version from the PSGallery for the given module name and major version.
         /// </summary>
         internal static string GetModuleLatestSupportedVersion(string moduleName, string majorVersion)

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -192,25 +192,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             // Install the function dependencies.
             logger.Log(LogLevel.Trace, PowerShellWorkerStrings.InstallingFunctionAppDependentModules, isUserLog: true);
 
-            if (Directory.Exists(DependenciesPath))
+            try
             {
-                // Save-Module supports downloading side-by-size module versions. However, we only want to keep one version at the time.
-                // If the ManagedDependencies folder exits, remove all its contents.
-                DependencyManagementUtils.EmptyDirectory(DependenciesPath);
+                DependencyManagementUtils.SetDependenciesDestinationPath(DependenciesPath);
             }
-            else
+            catch (Exception e)
             {
-                // If the destination path does not exist, create it.
-                // If the user does not have write access to the path, an exception will be raised.
-                try
-                {
-                    Directory.CreateDirectory(DependenciesPath);
-                }
-                catch (Exception e)
-                {
-                    var message = string.Format(PowerShellWorkerStrings.FailToCreateFunctionAppDependenciesDestinationPath, DependenciesPath, e.Message);
-                    logger.Log(LogLevel.Trace, message, isUserLog: true);
-                }
+                logger.Log(LogLevel.Error, e.Message, isUserLog: true);
+                _dependencyError = new DependencyInstallationException(e.Message, e);
+                return;
             }
 
             try
@@ -247,8 +237,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                             {
                                 var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallFuncAppDependencies, e.Message);
                                 _dependencyError = new DependencyInstallationException(errorMsg, e);
-
-                                throw _dependencyError;
+                                return;
                             }
                             else
                             {


### PR DESCRIPTION
Fixing faulty logic in InstallFunctionAppDependencies, so that if an exception thrown, it will get caught, logged, and wrapped in a DependencyInstallationException for post processing. 

In the InstallFunctionAppDependencies, we perform two operations: 
1) Prepare the folder destination path where the function app dependencies will be installed.
* If the destination folder exist, we try to empty it
* If the folder does not exist, we create it

2) Call Save-Module to install the function app dependency

If an issue is encountered in either (1) or (2), the exception will be caught, logged and wrapped in a DependencyInstallationException for post processing. This exception is expose via DependencyManager.DependencyError