### PR TITLE
Fix issue with proxies

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // Also, we receive a FunctionLoadRequest when a proxy is configured. Proxies don't have the Metadata.Directory set
             // which would cause initialization issues with the PSModulePath. The only way to tell if a FunctionLoadRequest is
             // from a proxy is to test if Metadata.Directory is null or empty which is what we do here.
-            if (!_isFunctionAppInitialized && !string.IsNullOrEmpty(functionLoadRequest.Metadata.Directory))
+            if (!_isFunctionAppInitialized && !functionLoadRequest.Metadata.IsProxy)
             {
                 try
                 {

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -160,8 +160,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // message doesn't provide information about the FunctionApp. That information is not available until the first
             // 'FunctionLoadRequest' comes in. Therefore, we run initialization here.
             // Also, we receive a FunctionLoadRequest when a proxy is configured. Proxies don't have the Metadata.Directory set
-            // which would cause initialization issues with the PSModulePath. The only way to tell if a FunctionLoadRequest is
-            // from a proxy is to test if Metadata.Directory is null or empty which is what we do here.
+            // which would cause initialization issues with the PSModulePath. Since they don't have that set, we skip over them.
             if (!_isFunctionAppInitialized && !functionLoadRequest.Metadata.IsProxy)
             {
                 try

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -159,7 +159,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // Ideally, the initialization should happen when processing 'WorkerInitRequest', however, the 'WorkerInitRequest'
             // message doesn't provide information about the FunctionApp. That information is not available until the first
             // 'FunctionLoadRequest' comes in. Therefore, we run initialization here.
-            if (!_isFunctionAppInitialized)
+            // Also, we receive a FunctionLoadRequest when a proxy is configured. Proxies don't have the Metadata.Directory set
+            // which would cause initialization issues with the PSModulePath. The only way to tell if a FunctionLoadRequest is
+            // from a proxy is to test if Metadata.Directory is null or empty which is what we do here.
+            if (!_isFunctionAppInitialized && !string.IsNullOrEmpty(functionLoadRequest.Metadata.Directory))
             {
                 try
                 {


### PR DESCRIPTION
For some reason, we receive a `FunctionLoadRequest` for when a proxy is configured. Proxies don't have the `Metadata.Directory` set which caused initialization issues with the `PSModulePath`. The only way to tell if a `FunctionLoadRequest` is from a proxy is to test if `Metadata.Directory` is `null` or empty.

That is what this PR does.

I discovered this on my Twitch stream when I tried to run my [PSScriptAnalyzer as a service](https://pssafuncapp.azurewebsites.net) function app and it complained while debugging that PSScriptAnalyzer wasn't in any module path because the FunctionApp level module path was not appended to the `PSModulePath` properly.

This behavior did change because this Function App use to work with a proxy configured, but now it does not... so I'm not sure if the host started sending the `FunctionLoadRequest`s in a different order or newly decided to send proxies as `FunctionLoadRequest`s... cc @pragnagopa might be able to speak to that?