### PR TITLE
Fix E2E test on Linux: allow both '/' and '\' in module path

### DIFF
--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/ManagedDependenciesEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/ManagedDependenciesEndToEndTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,7 +15,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         {
             var actualResponseMessage =
                 await Utilities.InvokeHttpTrigger("UsingManagedDependencies", string.Empty, HttpStatusCode.OK);
-            Assert.Matches(new Regex(@"[\\/]ManagedDependencies[\\/]Az[\\/]"), actualResponseMessage);
+
+            var expectedAzModulePathPart = Path.DirectorySeparatorChar + Path.Combine("ManagedDependencies", "Az") + Path.DirectorySeparatorChar;
+            Assert.Contains(expectedAzModulePathPart, actualResponseMessage);
         }
     }
 }

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/ManagedDependenciesEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/ManagedDependenciesEndToEndTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         {
             var actualResponseMessage =
                 await Utilities.InvokeHttpTrigger("UsingManagedDependencies", string.Empty, HttpStatusCode.OK);
-            Assert.Contains(@"\ManagedDependencies\Az\", actualResponseMessage);
+            Assert.Matches(new Regex(@"[\\/]ManagedDependencies[\\/]Az[\\/]"), actualResponseMessage);
         }
     }
 }


### PR DESCRIPTION
Allow both '/' and '\' in module path