### PR TITLE
Ignore function load requests with duplicate FunctionId values

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         internal static void LoadFunction(FunctionLoadRequest request)
         {
-            LoadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
+            if (!LoadedFunctions.ContainsKey(request.FunctionId))
+            {
+                LoadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
+            }
         }
 
         /// <summary>

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -42,10 +42,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         internal static void LoadFunction(FunctionLoadRequest request)
         {
-            if (!LoadedFunctions.ContainsKey(request.FunctionId))
-            {
-                LoadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
-            }
+            LoadedFunctions.Add(request.FunctionId, new AzFunctionInfo(request.Metadata));
         }
 
         /// <summary>

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -37,6 +37,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         }
 
         /// <summary>
+        /// Returns true if the function with the given functionId is already loaded.
+        /// </summary>
+        public static bool IsLoaded(string functionId)
+        {
+            return LoadedFunctions.ContainsKey(functionId);
+        }
+
+        /// <summary>
         /// This method runs once per 'FunctionLoadRequest' during the code start of the worker.
         /// It will always run synchronously because we process 'FunctionLoadRequest' synchronously.
         /// </summary>

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -145,6 +145,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 out StatusResult status);
             response.FunctionLoadResponse.FunctionId = functionLoadRequest.FunctionId;
 
+            // The worker may occasionally receive multiple function load requests with
+            // the same FunctionId. In order to make function load request idempotent,
+            // the worker should ignore the duplicates.
+            if (FunctionLoader.IsLoaded(functionLoadRequest.FunctionId))
+            {
+                // If FunctionLoader considers this function loaded, this means
+                // the previous request was successful, so respond accordingly.
+                return response;
+            }
+
             // When a functionLoadRequest comes in, we check to see if a dependency download has failed in a previous call
             // or if PowerShell could not be initialized. If this is the case, mark this as a failed request
             // and submit the exception to the Host (runtime).


### PR DESCRIPTION
This mitigates issue https://github.com/Azure/azure-functions-powershell-worker/issues/276.

The PowerShell worker seems to be relying on a guarantee that has never been explicitly provided by the Azure Functions host. Recently, the PowerShell worker started receiving more than one function load request with the same FunctionId. Apparently, this is caused by a change on the Azure Functions host side, and the root cause and the overall effect of this change are still to be investigated. In the meantime, we want to let the PowerShell worker tolerate this situation, which will make the load request operation idempotent.