### PR TITLE
Ignore function load requests with duplicate FunctionId values (#278)

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -37,6 +37,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         }
 
         /// <summary>
+        /// Returns true if the function with the given functionId is already loaded.
+        /// </summary>
+        public static bool IsLoaded(string functionId)
+        {
+            return LoadedFunctions.ContainsKey(functionId);
+        }
+
+        /// <summary>
         /// This method runs once per 'FunctionLoadRequest' during the code start of the worker.
         /// It will always run synchronously because we process 'FunctionLoadRequest' synchronously.
         /// </summary>

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -146,6 +146,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 out StatusResult status);
             response.FunctionLoadResponse.FunctionId = functionLoadRequest.FunctionId;
 
+            // The worker may occasionally receive multiple function load requests with
+            // the same FunctionId. In order to make function load request idempotent,
+            // the worker should ignore the duplicates.
+            if (FunctionLoader.IsLoaded(functionLoadRequest.FunctionId))
+            {
+                // If FunctionLoader considers this function loaded, this means
+                // the previous request was successful, so respond accordingly.
+                return response;
+            }
+
             // When a functionLoadRequest comes in, we check to see if a dependency download has failed in a previous call
             // or if PowerShell could not be initialized. If this is the case, mark this as a failed request
             // and submit the exception to the Host (runtime).


### PR DESCRIPTION
Cherry-picking https://github.com/Azure/azure-functions-powershell-worker/pull/278 fix from the dev branch in order to hotfix the https://github.com/Azure/azure-functions-powershell-worker/issues/276 issue.

* Add FunctionLoader IsLoaded method

* Return from ProcessFunctionLoadRequest early if already loaded