### PR TITLE
Move GetModuleLatestPublishedVersion from DependencyManager to DependencySnapshotInstaller

### DIFF
--- a/src/DependencyManagement/IDependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/IDependencySnapshotInstaller.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
     internal interface IDependencySnapshotInstaller
     {
         void InstallSnapshot(
-            IEnumerable<DependencyInfo> dependencies,
+            IEnumerable<DependencyManifestEntry> dependencies,
             string targetPath,
             PowerShell pwsh,
             ILogger logger);


### PR DESCRIPTION
Refactoring: moving GetModuleLatestPublishedVersion method from DependencyManager to DependencySnapshotInstaller. This simplifies the overall structure and makes DependencyManager unit tests cleaner.