### PR TITLE
Logging fixes

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 if (!_dependenciesFromManifest.Any())
                 {
-                    logger.Log(LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall, isUserOnlyLog: true);
+                    logger.Log(isUserOnlyLog: true, LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall);
                     return null;
                 }
 
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
 
             var logger = getLogger();
-            logger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, isUserOnlyLog: true);
+            logger.Log(isUserOnlyLog: true, LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress);
             WaitOnDependencyInstallationTask();
             return true;
         }
@@ -187,6 +187,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     if (!IsAnyInstallationStartedRecently())
                     {
                         logger.Log(
+                            isUserOnlyLog: false,
                             LogLevel.Trace,
                             PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
 
@@ -219,7 +220,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     var dependenciesNotUpdatedMessage =
                         string.Format(PowerShellWorkerStrings.DependenciesUpgradeSkippedMessage, _dependencyInstallationError.Message);
 
-                    logger.Log(LogLevel.Warning, dependenciesNotUpdatedMessage, _dependencyInstallationError);
+                    logger.Log(isUserOnlyLog: false, LogLevel.Warning, dependenciesNotUpdatedMessage, _dependencyInstallationError);
                 }
             }
 

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -188,8 +188,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     {
                         logger.Log(
                             LogLevel.Trace,
-                            PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled,
-                            isUserLog: true);
+                            PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
 
                         // Background installation: can't use the firstPwsh runspace because it belongs
                         // to the pool used to run functions code, so create a new runspace.
@@ -220,7 +219,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     var dependenciesNotUpdatedMessage =
                         string.Format(PowerShellWorkerStrings.DependenciesUpgradeSkippedMessage, _dependencyInstallationError.Message);
 
-                    logger.Log(LogLevel.Warning, dependenciesNotUpdatedMessage, _dependencyInstallationError, isUserLog: true);
+                    logger.Log(LogLevel.Warning, dependenciesNotUpdatedMessage, _dependencyInstallationError);
                 }
             }
 

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 if (!_dependenciesFromManifest.Any())
                 {
-                    logger.Log(LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall, isUserLog: true);
+                    logger.Log(LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall, isUserOnlyLog: true);
                     return null;
                 }
 
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
 
             var logger = getLogger();
-            logger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, isUserLog: true);
+            logger.Log(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, isUserOnlyLog: true);
             WaitOnDependencyInstallationTask();
             return true;
         }

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             PowerShell pwsh,
             ILogger logger)
         {
-            logger.Log(LogLevel.Trace, PowerShellWorkerStrings.InstallingFunctionAppDependentModules);
+            logger.Log(isUserOnlyLog: false, LogLevel.Trace, PowerShellWorkerStrings.InstallingFunctionAppDependentModules);
 
             var installingPath = CreateInstallingSnapshot(targetPath);
 
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                             _moduleProvider.SaveModule(pwsh, moduleName, latestVersion, installingPath);
 
                             var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, latestVersion);
-                            logger.Log(LogLevel.Trace, message);
+                            logger.Log(isUserOnlyLog: false, LogLevel.Trace, message);
 
                             break;
                         }
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         {
                             string currentAttempt = GetCurrentAttemptMessage(tries);
                             var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, moduleName, latestVersion, currentAttempt, e.Message);
-                            logger.Log(LogLevel.Error, errorMsg);
+                            logger.Log(isUserOnlyLog: false, LogLevel.Error, errorMsg);
 
                             if (tries >= MaxNumberOfTries)
                             {

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             PowerShell pwsh,
             ILogger logger)
         {
-            logger.Log(LogLevel.Trace, PowerShellWorkerStrings.InstallingFunctionAppDependentModules, isUserLog: true);
+            logger.Log(LogLevel.Trace, PowerShellWorkerStrings.InstallingFunctionAppDependentModules);
 
             var installingPath = CreateInstallingSnapshot(targetPath);
 
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                             _moduleProvider.SaveModule(pwsh, moduleName, latestVersion, installingPath);
 
                             var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, latestVersion);
-                            logger.Log(LogLevel.Trace, message, isUserLog: true);
+                            logger.Log(LogLevel.Trace, message);
 
                             break;
                         }
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         {
                             string currentAttempt = GetCurrentAttemptMessage(tries);
                             var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, moduleName, latestVersion, currentAttempt, e.Message);
-                            logger.Log(LogLevel.Error, errorMsg, isUserLog: true);
+                            logger.Log(LogLevel.Error, errorMsg);
 
                             if (tries >= MaxNumberOfTries)
                             {

--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -82,14 +82,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 try
                 {
                     var message = string.Format(PowerShellWorkerStrings.RemovingDependenciesFolder, pathToRemove);
-                    logger.Log(LogLevel.Trace, message, null, isUserLog: true);
+                    logger.Log(LogLevel.Trace, message);
 
                     _storage.RemoveSnapshot(pathToRemove);
                 }
                 catch (IOException e)
                 {
                     var message = string.Format(PowerShellWorkerStrings.FailedToRemoveDependenciesFolder, pathToRemove, e.Message);
-                    logger.Log(LogLevel.Warning, message, e, isUserLog: true);
+                    logger.Log(LogLevel.Warning, message, e);
                 }
             }
         }
@@ -103,10 +103,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         {
             logger.Log(
                 LogLevel.Trace,
-                string.Format(
-                    PowerShellWorkerStrings.UpdatingManagedDependencySnapshotHeartbeat,
-                    path),
-                isUserLog: true);
+                string.Format(PowerShellWorkerStrings.UpdatingManagedDependencySnapshotHeartbeat, path));
 
             if (_storage.SnapshotExists(path))
             {
@@ -123,7 +120,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             catch (IOException e)
             {
                 var message = string.Format(PowerShellWorkerStrings.FailedToRetrieveDependenciesFolderAccessTime, path, e.Message);
-                logger.Log(LogLevel.Warning, message, e, isUserLog: true);
+                logger.Log(LogLevel.Warning, message, e);
                 return DateTime.MaxValue;
             }
         }

--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -82,14 +82,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 try
                 {
                     var message = string.Format(PowerShellWorkerStrings.RemovingDependenciesFolder, pathToRemove);
-                    logger.Log(LogLevel.Trace, message);
+                    logger.Log(isUserOnlyLog: false, LogLevel.Trace, message);
 
                     _storage.RemoveSnapshot(pathToRemove);
                 }
                 catch (IOException e)
                 {
                     var message = string.Format(PowerShellWorkerStrings.FailedToRemoveDependenciesFolder, pathToRemove, e.Message);
-                    logger.Log(LogLevel.Warning, message, e);
+                    logger.Log(isUserOnlyLog: false, LogLevel.Warning, message, e);
                 }
             }
         }
@@ -102,6 +102,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         internal void Heartbeat(string path, ILogger logger)
         {
             logger.Log(
+                isUserOnlyLog: false,
                 LogLevel.Trace,
                 string.Format(PowerShellWorkerStrings.UpdatingManagedDependencySnapshotHeartbeat, path));
 
@@ -120,7 +121,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             catch (IOException e)
             {
                 var message = string.Format(PowerShellWorkerStrings.FailedToRetrieveDependenciesFolderAccessTime, path, e.Message);
-                logger.Log(LogLevel.Warning, message, e);
+                logger.Log(isUserOnlyLog: false, LogLevel.Warning, message, e);
                 return DateTime.MaxValue;
             }
         }

--- a/src/Logging/ILogger.cs
+++ b/src/Logging/ILogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
     internal interface ILogger
     {
-        void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false);
+        void Log(bool isUserOnlyLog, LogLevel logLevel, string message, Exception exception = null);
         void SetContext(string requestId, string invocationId);
         void ResetContext();
     }

--- a/src/Logging/ILogger.cs
+++ b/src/Logging/ILogger.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#pragma warning disable 1573 // "Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)"
+
 using System;
 using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
 
@@ -10,6 +12,27 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
     internal interface ILogger
     {
+        /// <param name="isUserOnlyLog">
+        /// isUserOnlyLog must be true when logging data that belongs to the user and may contain
+        /// secrets or PII, such as PowerShell streams produced by the Function code, console output
+        /// of external commands, etc.
+        /// Messages sent with isUserOnlyLog == true will be visible to the Function user only.
+        /// 
+        /// isUserOnlyLog must be false when logging internal telemetry messages free of secrets and PII
+        /// for diagnostic and statistical purposes.
+        /// Messages sent with isUserOnlyLog == false will be visible to both the user and the service engineers.
+        ///
+        /// Regardless of the isUserOnlyLog value, all these messages will be available at the
+        /// usual locations (for example, the current Azure Portal implementation will show them on
+        /// the Logs tab under the Function source code, on the Monitor page under the Function,
+        /// and in the Application Insights logs). The only difference is that the messages written
+        /// with isUserOnlyLog == true will be available to the user, but not to the service engineers.
+        /// The messages written with isUserOnlyLog == false will also be sent to a location like an
+        /// internal log storage available to the service engineers.
+        ///
+        /// It is important to understand and strictly maintain this separation.
+        /// When in doubt, use isUserOnlyLog == true.
+        /// </param>
         void Log(bool isUserOnlyLog, LogLevel logLevel, string message, Exception exception = null);
         void SetContext(string requestId, string invocationId);
         void ResetContext();

--- a/src/Logging/ILogger.cs
+++ b/src/Logging/ILogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 {
     internal interface ILogger
     {
-        void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false);
+        void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false);
         void SetContext(string requestId, string invocationId);
         void ResetContext();
     }

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             _invocationId = null;
         }
 
+        /// <inheritdoc/>
         public void Log(bool isUserOnlyLog, LogLevel logLevel, string message, Exception exception = null)
         {
             if (isUserOnlyLog)

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -69,17 +69,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
             // For system logs, we log to stdio with a prefix of LanguageWorkerConsoleLog.
             // These are picked up by the Functions Host
-            stringBuilder.Append(SystemLogPrefix).AppendLine("System Log: {");
+            stringBuilder.Append(SystemLogPrefix).Append("System Log: {");
             if (!string.IsNullOrEmpty(requestId))
             {
-                stringBuilder.AppendLine($"  Request-Id: {requestId}");
+                stringBuilder.Append($" Request-Id: {requestId};");
             }
             if (!string.IsNullOrEmpty(invocationId))
             {
-                stringBuilder.AppendLine($"  Invocation-Id: {invocationId}");
+                stringBuilder.Append($" Invocation-Id: {invocationId};");
             }
-            stringBuilder.AppendLine($"  Log-Level: {logLevel}");
-            stringBuilder.AppendLine($"  Log-Message: {message}").AppendLine("}");
+            stringBuilder.Append($" Log-Level: {logLevel};");
+            stringBuilder.Append($" Log-Message: {message}");
+            stringBuilder.AppendLine(" }");
 
             Console.WriteLine(stringBuilder.ToString());
             stringBuilder.Clear();

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
     {
         private const string SystemLogPrefix = "LanguageWorkerConsoleLog";
         private readonly MessagingStream _msgStream;
-        private readonly StringBuilder _systemLogMsg;
         private string _invocationId;
         private string _requestId;
 
         internal RpcLogger(MessagingStream msgStream)
         {
             _msgStream = msgStream;
-            _systemLogMsg = new StringBuilder();
         }
 
         public void SetContext(string requestId, string invocationId)
@@ -59,17 +57,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             }
             else
             {
-                WriteSystemLog(logLevel, message, _systemLogMsg, _requestId, _invocationId);
+                WriteSystemLog(logLevel, message, _requestId, _invocationId);
             }
         }
 
-        private static void WriteSystemLog(LogLevel logLevel, string message, StringBuilder stringBuilder, string requestId, string invocationId)
+        private static void WriteSystemLog(LogLevel logLevel, string message, string requestId, string invocationId)
         {
-            stringBuilder = stringBuilder ?? new StringBuilder();
-
             // For system logs, we log to stdio with a prefix of LanguageWorkerConsoleLog.
             // These are picked up by the Functions Host
-            stringBuilder.Append(SystemLogPrefix).Append("System Log: {");
+            var stringBuilder = new StringBuilder(SystemLogPrefix);
+
+            stringBuilder.Append("System Log: {");
             if (!string.IsNullOrEmpty(requestId))
             {
                 stringBuilder.Append($" Request-Id: {requestId};");
@@ -83,12 +81,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             stringBuilder.AppendLine(" }");
 
             Console.WriteLine(stringBuilder.ToString());
-            stringBuilder.Clear();
         }
 
         internal static void WriteSystemLog(LogLevel logLevel, string message)
         {
-            WriteSystemLog(logLevel, message, stringBuilder: null, requestId: null, invocationId: null);
+            WriteSystemLog(logLevel, message, requestId: null, invocationId: null);
         }
     }
 }

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             }
             else
             {
-                WriteSystemLog(message, _systemLogMsg, _requestId, _invocationId);
+                WriteSystemLog(logLevel, message, _systemLogMsg, _requestId, _invocationId);
             }
         }
 
-        private static void WriteSystemLog(string message, StringBuilder stringBuilder, string requestId, string invocationId)
+        private static void WriteSystemLog(LogLevel logLevel, string message, StringBuilder stringBuilder, string requestId, string invocationId)
         {
             stringBuilder = stringBuilder ?? new StringBuilder();
 
@@ -78,15 +78,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             {
                 stringBuilder.AppendLine($"  Invocation-Id: {invocationId}");
             }
+            stringBuilder.AppendLine($"  Log-Level: {logLevel}");
             stringBuilder.AppendLine($"  Log-Message: {message}").AppendLine("}");
 
             Console.WriteLine(stringBuilder.ToString());
             stringBuilder.Clear();
         }
 
-        internal static void WriteSystemLog(string message)
+        internal static void WriteSystemLog(LogLevel logLevel, string message)
         {
-            WriteSystemLog(message, stringBuilder: null, requestId: null, invocationId: null);
+            WriteSystemLog(logLevel, message, stringBuilder: null, requestId: null, invocationId: null);
         }
     }
 }

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             _invocationId = null;
         }
 
-        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false)
+        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false)
         {
-            if (isUserLog)
+            if (isUserOnlyLog)
             {
                 // For user logs, we send them over Rpc with details about the invocation.
                 var logMessage = new StreamingMessage

--- a/src/Logging/RpcLogger.cs
+++ b/src/Logging/RpcLogger.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             _invocationId = null;
         }
 
-        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false)
+        public void Log(bool isUserOnlyLog, LogLevel logLevel, string message, Exception exception = null)
         {
             if (isUserOnlyLog)
             {

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 if (_pwsh.HadErrors)
                 {
                     string errorMsg = string.Format(PowerShellWorkerStrings.FailToRunProfile, profilePath);
-                    _logger.Log(LogLevel.Error, errorMsg, exception, isUserLog: true);
+                    _logger.Log(LogLevel.Error, errorMsg, exception, isUserOnlyLog: true);
                 }
             }
         }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             if (profilePath == null)
             {
                 string noProfileMsg = string.Format(PowerShellWorkerStrings.FileNotFound, "profile.ps1", FunctionLoader.FunctionAppRootPath);
-                _logger.Log(LogLevel.Trace, noProfileMsg);
+                _logger.Log(isUserOnlyLog: false, LogLevel.Trace, noProfileMsg);
                 return;
             }
 
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 if (_pwsh.HadErrors)
                 {
                     string errorMsg = string.Format(PowerShellWorkerStrings.FailToRunProfile, profilePath);
-                    _logger.Log(LogLevel.Error, errorMsg, exception, isUserOnlyLog: true);
+                    _logger.Log(isUserOnlyLog: true, LogLevel.Error, errorMsg, exception);
                 }
             }
         }

--- a/src/PowerShell/PowerShellManagerPool.cs
+++ b/src/PowerShell/PowerShellManagerPool.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -14,6 +13,7 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 {
     using System.Management.Automation;
+    using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
 
     /// <summary>
     /// The PowerShellManager pool for the in-proc concurrency support.
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
 
             _msgStream = msgStream;
             _pool = new BlockingCollection<PowerShellManager>(_upperBound);
-            RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogConcurrencyUpperBound, _upperBound.ToString()));
+            RpcLogger.WriteSystemLog(LogLevel.Information, string.Format(PowerShellWorkerStrings.LogConcurrencyUpperBound, _upperBound.ToString()));
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                         logger.SetContext(requestId, invocationId);
                         psManager = new PowerShellManager(logger, id);
 
-                        RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.LogNewPowerShellManagerCreated, id.ToString()));
+                        RpcLogger.WriteSystemLog(LogLevel.Trace, string.Format(PowerShellWorkerStrings.LogNewPowerShellManagerCreated, id.ToString()));
                     }
                 }
 

--- a/src/PowerShell/StreamHandler.cs
+++ b/src/PowerShell/StreamHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is DebugRecord record)
             {
-                _logger.Log(LogLevel.Debug, $"DEBUG: {record.Message}", isUserLog: true);
+                _logger.Log(LogLevel.Debug, $"DEBUG: {record.Message}", isUserOnlyLog: true);
             }
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is ErrorRecord record)
             {
-                _logger.Log(LogLevel.Error, $"ERROR: {record.Exception.Message}", record.Exception, isUserLog: true);
+                _logger.Log(LogLevel.Error, $"ERROR: {record.Exception.Message}", record.Exception, isUserOnlyLog: true);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             if(e.ItemAdded is InformationRecord record)
             {
                 string prefix = (record.Tags.Count == 1 && record.Tags[0] == "__PipelineObject__") ? "OUTPUT:" : "INFORMATION:";
-                _logger.Log(LogLevel.Information, $"{prefix} {record.MessageData}", isUserLog: true);
+                _logger.Log(LogLevel.Information, $"{prefix} {record.MessageData}", isUserOnlyLog: true);
             }
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is ProgressRecord record)
             {
-                _logger.Log(LogLevel.Trace, $"PROGRESS: {record.StatusDescription}", isUserLog: true);
+                _logger.Log(LogLevel.Trace, $"PROGRESS: {record.StatusDescription}", isUserOnlyLog: true);
             }
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is VerboseRecord record)
             {
-                _logger.Log(LogLevel.Trace, $"VERBOSE: {record.Message}", isUserLog: true);
+                _logger.Log(LogLevel.Trace, $"VERBOSE: {record.Message}", isUserOnlyLog: true);
             }
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is WarningRecord record)
             {
-                _logger.Log(LogLevel.Warning, $"WARNING: {record.Message}", isUserLog: true);
+                _logger.Log(LogLevel.Warning, $"WARNING: {record.Message}", isUserOnlyLog: true);
             }
         }
     }

--- a/src/PowerShell/StreamHandler.cs
+++ b/src/PowerShell/StreamHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is DebugRecord record)
             {
-                _logger.Log(LogLevel.Debug, $"DEBUG: {record.Message}", isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Debug, $"DEBUG: {record.Message}");
             }
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is ErrorRecord record)
             {
-                _logger.Log(LogLevel.Error, $"ERROR: {record.Exception.Message}", record.Exception, isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Error, $"ERROR: {record.Exception.Message}", record.Exception);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             if(e.ItemAdded is InformationRecord record)
             {
                 string prefix = (record.Tags.Count == 1 && record.Tags[0] == "__PipelineObject__") ? "OUTPUT:" : "INFORMATION:";
-                _logger.Log(LogLevel.Information, $"{prefix} {record.MessageData}", isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Information, $"{prefix} {record.MessageData}");
             }
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is ProgressRecord record)
             {
-                _logger.Log(LogLevel.Trace, $"PROGRESS: {record.StatusDescription}", isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Trace, $"PROGRESS: {record.StatusDescription}");
             }
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is VerboseRecord record)
             {
-                _logger.Log(LogLevel.Trace, $"VERBOSE: {record.Message}", isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Trace, $"VERBOSE: {record.Message}");
             }
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is WarningRecord record)
             {
-                _logger.Log(LogLevel.Warning, $"WARNING: {record.Message}", isUserOnlyLog: true);
+                _logger.Log(isUserOnlyLog: true, LogLevel.Warning, $"WARNING: {record.Message}");
             }
         }
     }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -17,6 +17,8 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker
 {
+    using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
+
     internal class RequestProcessor
     {
         private readonly MessagingStream _msgStream;
@@ -76,7 +78,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 }
                 else
                 {
-                    RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase));
+                    RpcLogger.WriteSystemLog(LogLevel.Warning, string.Format(PowerShellWorkerStrings.UnsupportedMessage, request.ContentCase));
                     continue;
                 }
 
@@ -100,7 +102,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             string pipeName = Environment.GetEnvironmentVariable("PSWorkerCustomPipeName");
             if (!string.IsNullOrEmpty(pipeName))
             {
-                RpcLogger.WriteSystemLog(string.Format(PowerShellWorkerStrings.SpecifiedCustomPipeName, pipeName));
+                RpcLogger.WriteSystemLog(LogLevel.Trace, string.Format(PowerShellWorkerStrings.SpecifiedCustomPipeName, pipeName));
                 RemoteSessionNamedPipeServer.CreateCustomNamedPipeServer(pipeName);
             }
 

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -334,10 +334,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             _mockLogger.Verify(
                 _ => _.Log(
+                        expectedIsUserLog,
                         expectedLogLevel,
                         It.Is<string>(message => message.Contains(expectedMessage)),
-                        It.IsAny<Exception>(),
-                        expectedIsUserLog));
+                        It.IsAny<Exception>()));
         }
 
         private DependencyManager CreateDependencyManagerWithMocks()

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Management.Automation;
 
     using Moq;
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var dependenciesPath = dependencyManager.Initialize(_mockLogger.Object);
 
             Assert.Null(dependenciesPath);
-            VerifyMessageLogged(LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall);
+            VerifyMessageLogged(LogLevel.Warning, PowerShellWorkerStrings.FunctionAppDoesNotHaveDependentModulesToInstall, expectedIsUserLog: true);
         }
 
         [Fact]
@@ -160,7 +159,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var hadToWait = dependencyManager.WaitForDependenciesAvailability(() => _mockLogger.Object);
 
             Assert.True(hadToWait);
-            VerifyMessageLogged(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress);
+            VerifyMessageLogged(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, expectedIsUserLog: true);
             VerifyExactlyOneSnapshotInstalled();
             _mockPurger.Verify(_ => _.Purge(It.IsAny<ILogger>()), Times.Never);
         }
@@ -256,7 +255,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var hadToWait = dependencyManager.WaitForDependenciesAvailability(() => _mockLogger.Object);
 
             Assert.True(hadToWait);
-            VerifyMessageLogged(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress);
+            VerifyMessageLogged(LogLevel.Information, PowerShellWorkerStrings.DependencyDownloadInProgress, expectedIsUserLog: true);
             VerifyExactlyOneSnapshotInstalled();
         }
 
@@ -300,10 +299,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     Assert.Throws<DependencyInstallationException>(
                         () => dependencyManager.WaitForBackgroundDependencyInstallationTaskCompletion());
 
-                VerifyMessageLogged(LogLevel.Trace, PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
+                VerifyMessageLogged(LogLevel.Trace, PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled, expectedIsUserLog: false);
 
                 Assert.Contains(injectedException.Message, caughtException.Message);
-                VerifyMessageLogged(LogLevel.Warning, injectedException.Message);
+                VerifyMessageLogged(LogLevel.Warning, injectedException.Message, expectedIsUserLog: false);
             }
             else
             {
@@ -331,14 +330,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _mockInstaller.VerifyNoOtherCalls();
         }
 
-        private void VerifyMessageLogged(LogLevel expectedLogLevel, string expectedMessage)
+        private void VerifyMessageLogged(LogLevel expectedLogLevel, string expectedMessage, bool expectedIsUserLog)
         {
             _mockLogger.Verify(
                 _ => _.Log(
                         expectedLogLevel,
                         It.Is<string>(message => message.Contains(expectedMessage)),
                         It.IsAny<Exception>(),
-                        true));
+                        expectedIsUserLog));
         }
 
         private DependencyManager CreateDependencyManagerWithMocks()

--- a/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
@@ -179,11 +179,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockLogger.Verify(
                 _ => _.Log(
+                    false,
                     LogLevel.Warning,
                     It.Is<string>(message => message.Contains("Failed to retrieve dependencies folder '2' access time")
                                              && message.Contains(injectedException.Message)),
-                    injectedException,
-                    false),
+                    injectedException),
                 Times.Once);
         }
 
@@ -216,11 +216,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockLogger.Verify(
                 _ => _.Log(
+                    false,
                     LogLevel.Warning,
                     It.Is<string>(message => message.Contains("Failed to remove old dependencies folder '1'")
                                              && message.Contains(injectedException.Message)),
-                    injectedException,
-                    false),
+                    injectedException),
                 Times.Once);
         }
 

--- a/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     It.Is<string>(message => message.Contains("Failed to retrieve dependencies folder '2' access time")
                                              && message.Contains(injectedException.Message)),
                     injectedException,
-                    true),
+                    false),
                 Times.Once);
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     It.Is<string>(message => message.Contains("Failed to remove old dependencies folder '1'")
                                              && message.Contains(injectedException.Message)),
                     injectedException,
-                    true),
+                    false),
                 Times.Once);
         }
 

--- a/test/Unit/Logging/ConsoleLogger.cs
+++ b/test/Unit/Logging/ConsoleLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
     {
         public List<string> FullLog = new List<string>();
 
-        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false)
+        public void Log(bool isUserOnlyLog, LogLevel logLevel, string message, Exception exception = null)
         {
             var log = $"{logLevel}: {message}";
             Console.WriteLine(log);

--- a/test/Unit/Logging/ConsoleLogger.cs
+++ b/test/Unit/Logging/ConsoleLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
     {
         public List<string> FullLog = new List<string>();
 
-        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserLog = false)
+        public void Log(LogLevel logLevel, string message, Exception exception = null, bool isUserOnlyLog = false)
         {
             var log = $"{logLevel}: {message}";
             Console.WriteLine(log);


### PR DESCRIPTION
Logging fixes:
- In order to make the separation between user-only logs and internal service logs very explicit, the `isUserLog` parameter is renamed to `isUserOnlyLog`, moved to the front, and made mandatory.
- Most managed dependencies logs are switched to `isUserOnlyLog: false`. As a result, the logs written by the background task will not be lost anymore, and they will now be available to both the users and the service engineers.
- `RpcLogger.WriteSystemLog` used to write the log message as three separate lines, and only the first line had the required `LanguageWorkerConsoleLog` prefix. As a result, the main part of the log message was not sent to the service logs. Fixed by merging the message into a single line.
- Sharing a single `StringBuilder` instance between `Log` calls was not thread-safe - removed.