### PR TITLE
Allow installing pre-release module versions

### DIFF
--- a/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
+++ b/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 .AddParameter("Repository", Repository)
                 .AddParameter("Name", moduleName)
                 .AddParameter("RequiredVersion", version)
+                .AddParameter("AllowPrerelease", Utils.BoxedTrue)
                 .AddParameter("Path", path)
                 .AddParameter("Force", Utils.BoxedTrue)
                 .AddParameter("ErrorAction", "Stop")


### PR DESCRIPTION
If a module on the PowerShell gallery has both regular and prerelease versions present within the same major version (for example, both `2.1` and `2.2-alpha4` are present), and `requirements.psd1` specifies `'MyModule' = '2.*'`, the PowerShell worker does not handle this situation very well.

From the user perspective, any of the following options would make some sense:

1. Install the latest version even if it is a prerelease version (`2.2-alpha4` in this example).
2. Install the latest version excluding prerelease versions (`2.1` in this example).
3. Make it possible for the user to express the intent, perhaps by providing the module version specification in `requirements.psd1` accordingly.

What actually happens is different from any of these options: the PowerShell worker chooses `2.2-alpha4` for installation but then fails to install it, potentially blocking the user.

Eventually, we will want to implement Option 3. In the meantime, this simple PR enables Option 1 (not perfect, but better than the current behavior).