### PR TITLE
Managed Dependencies: Ignore prerelease module versions

### DIFF
--- a/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
+++ b/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 // Find the version information
                 XmlNode root = doc.DocumentElement;
-                var props = root.SelectNodes("//m:properties/d:Version", nsmgr);
+                var props = root.SelectNodes("//m:properties[d:IsPrerelease = \"false\"]/d:Version", nsmgr);
 
                 if (props != null && props.Count > 0)
                 {


### PR DESCRIPTION
If a module on the PowerShell gallery has both regular and prerelease versions present within the same major version (for example, both `2.1` and `2.2-alpha4` are present), and `requirements.psd1` specifies `'MyModule' = '2.*'`, the PowerShell worker does not handle this situation very well.

From the user perspective, any of the following options would make some sense:

1. Install the latest version even if it is a prerelease version (`2.2-alpha4` in this example).
2. Install the latest version excluding prerelease versions (`2.1` in this example).
3. Make it possible for the user to express the intent, perhaps by providing the module version specification in `requirements.psd1` accordingly.

What actually happens is different from any of these options: the PowerShell worker chooses `2.2-alpha4` for installation but then fails to install it, potentially blocking the user.

Eventually, we will want to implement Option 3, but this requires some thinking. In the meantime, this simple PR implements Option 2 (not perfect, but better than the current behavior).