### PR TITLE
Remove partially installed snapshots

### DIFF
--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -84,10 +84,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 _storage.PromoteInstallingSnapshotToInstalledAtomically(targetPath);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 var message = string.Format(PowerShellWorkerStrings.FailedToInstallDependenciesSnapshot, targetPath);
-                logger.Log(LogLevel.Warning, message, isUserLog: true);
+                logger.Log(isUserOnlyLog: false, LogLevel.Warning, message, e);
                 _storage.RemoveSnapshot(installingPath);
                 throw;
             }

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -84,6 +84,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 _storage.PromoteInstallingSnapshotToInstalledAtomically(targetPath);
             }
+            catch (Exception)
+            {
+                var message = string.Format(PowerShellWorkerStrings.FailedToInstallDependenciesSnapshot, targetPath);
+                logger.Log(LogLevel.Warning, message, isUserLog: true);
+                _storage.RemoveSnapshot(installingPath);
+                throw;
+            }
             finally
             {
                 _moduleProvider.Cleanup(pwsh);

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -256,4 +256,7 @@
   <data name="UpdatingManagedDependencySnapshotHeartbeat" xml:space="preserve">
     <value>Updating dependencies folder heartbeat for '{0}''.</value>
   </data>
+  <data name="FailedToInstallDependenciesSnapshot" xml:space="preserve">
+    <value>Failed to install dependencies into '{0}', removing the folder.</value>
+  </data>
 </root>

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -336,24 +336,27 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
                     var relevantLogs = _testLogger.FullLog.Where(
                         message => message.StartsWith("Error: Fail to install module")
-                                   || message.StartsWith("Trace: Installing FunctionApp dependent modules")).ToList();
+                                   || message.StartsWith("Trace: Installing FunctionApp dependent modules")
+                                   || message.StartsWith("Warning: Failed to install dependencies")).ToList();
 
                     // Here we will get four logs: one that says that we are installing the
                     // dependencies, and three for failing to install the module.
-                    Assert.Equal(4, relevantLogs.Count);
+                    Assert.Equal(5, relevantLogs.Count);
 
                     // The first log should say "Installing FunctionApp dependent modules."
                     Assert.Contains(PowerShellWorkerStrings.InstallingFunctionAppDependentModules, relevantLogs[0]);
 
                     // The subsequent logs should contain the following:
-                    for (int index = 1; index < relevantLogs.Count; index++)
+                    for (int index = 1; index < 4; index++)
                     {
                         Assert.Contains("Fail to install module", relevantLogs[index]);
                         var currentAttempt = DependencySnapshotInstaller.GetCurrentAttemptMessage(index);
                         Assert.Contains(currentAttempt, relevantLogs[index]);
                     }
 
-                    // Lastly, DependencyError should get set after unsuccessfully  retyring 3 times.
+                    Assert.Matches("Warning: Failed to install dependencies into '(.+?)', removing the folder", relevantLogs[4]);
+
+                    // Lastly, DependencyError should get set after unsuccessfully retrying 3 times.
                     Assert.NotNull(dependencyError);
                     Assert.Contains("Fail to install FunctionApp dependencies. Error:", dependencyError.Message);
                 }

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -339,8 +339,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                                    || message.StartsWith("Trace: Installing FunctionApp dependent modules")
                                    || message.StartsWith("Warning: Failed to install dependencies")).ToList();
 
-                    // Here we will get four logs: one that says that we are installing the
-                    // dependencies, and three for failing to install the module.
+                    // Here we will get five logs: one that says that we are installing the
+                    // dependencies, three for failing to install the module,
+                    // and one warning notifying of removing the dependencies folder.
                     Assert.Equal(5, relevantLogs.Count);
 
                     // The first log should say "Installing FunctionApp dependent modules."

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -109,6 +109,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     _ => _.GetLatestPublishedModuleVersion(It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(injectedException);
 
+            _mockStorage.Setup(_ => _.RemoveSnapshot(_targetPathInstalling));
+
             _mockModuleProvider.Setup(_ => _.Cleanup(dummyPowerShell));
 
             // Act
@@ -126,6 +128,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 Times.Never);
 
             _mockStorage.Verify(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()), Times.Never);
+            _mockStorage.Verify(_ => _.RemoveSnapshot(_targetPathInstalling));
             _mockModuleProvider.Verify(_ => _.Cleanup(dummyPowerShell), Times.Once);
         }
 
@@ -151,6 +154,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 _ => _.SaveModule(It.IsAny<PowerShell>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(injectedException);
 
+            _mockStorage.Setup(_ => _.RemoveSnapshot(_targetPathInstalling));
+
             _mockModuleProvider.Setup(_ => _.Cleanup(dummyPowerShell));
 
             // Act
@@ -164,6 +169,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             Assert.Contains(injectedException.Message, thrownException.Message);
 
             _mockStorage.Verify(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()), Times.Never);
+            _mockStorage.Verify(_ => _.RemoveSnapshot(_targetPathInstalling));
             _mockModuleProvider.Verify(_ => _.Cleanup(dummyPowerShell), Times.Once);
         }
 


### PR DESCRIPTION
If installing a managed dependencies snapshot fails for any reason, the current code just abandons the snapshot folder, relying on it to be eventually removed by regular purge. As a result, the partially installed snapshot keeps occupying file space, and prevents the next installation attempt from starting soon. There is no easy way to avoid these consequences when the PowerShell worker process is terminated. However, if the worker keeps running and it is aware of the installation attempt failure, it has an opportunity to perform the clean up sooner. This is what this PR achieves.