### PR TITLE
Clear pushed output binding values on exceptions (#281)

### DIFF
--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -37,6 +37,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         }
 
         /// <summary>
+        /// Returns true if the function with the given functionId is already loaded.
+        /// </summary>
+        public static bool IsLoaded(string functionId)
+        {
+            return LoadedFunctions.ContainsKey(functionId);
+        }
+
+        /// <summary>
         /// This method runs once per 'FunctionLoadRequest' during the code start of the worker.
         /// It will always run synchronously because we process 'FunctionLoadRequest' synchronously.
         /// </summary>

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -194,6 +194,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             string scriptPath = functionInfo.ScriptPath;
             string entryPoint = functionInfo.EntryPoint;
 
+            Hashtable outputBindings = FunctionMetadata.GetOutputBindingHashtable(_pwsh.Runspace.InstanceId);
+
             try
             {
                 if (string.IsNullOrEmpty(entryPoint))
@@ -231,9 +233,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 Collection<object> pipelineItems = _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Trace-PipelineObject")
                                                         .InvokeAndClearCommands<object>();
 
-                Hashtable outputBindings = FunctionMetadata.GetOutputBindingHashtable(_pwsh.Runspace.InstanceId);
                 Hashtable result = new Hashtable(outputBindings, StringComparer.OrdinalIgnoreCase);
-                outputBindings.Clear();
 
                 /*
                  * TODO: See GitHub issue #82. We are not settled on how to handle the Azure Functions concept of the $returns Output Binding
@@ -253,6 +253,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             }
             finally
             {
+                outputBindings.Clear();
                 ResetRunspace();
             }
         }

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -146,6 +146,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 out StatusResult status);
             response.FunctionLoadResponse.FunctionId = functionLoadRequest.FunctionId;
 
+            // The worker may occasionally receive multiple function load requests with
+            // the same FunctionId. In order to make function load request idempotent,
+            // the worker should ignore the duplicates.
+            if (FunctionLoader.IsLoaded(functionLoadRequest.FunctionId))
+            {
+                // If FunctionLoader considers this function loaded, this means
+                // the previous request was successful, so respond accordingly.
+                return response;
+            }
+
             // When a functionLoadRequest comes in, we check to see if a dependency download has failed in a previous call
             // or if PowerShell could not be initialized. If this is the case, mark this as a failed request
             // and submit the exception to the Host (runtime).


### PR DESCRIPTION
Cherry-picking #281 fix from the dev branch into master to release hot fix.

Fixed issue:
If a PowerShell function invokes Push-OutputBinding and then throws an exception, the next invocation response contains data passed to Push-OutputBinding on the previous invocation.