### PR TITLE
Allow exact module versions in requirements.psd1

### DIFF
--- a/docs/designs/PowerShell-AzF-Overall-Design.md
+++ b/docs/designs/PowerShell-AzF-Overall-Design.md
@@ -466,14 +466,19 @@ Note that, checking out a PowerShell Manager instance from the pool is a blockin
 
 The goal is to let the user declare the dependencies required by functions, and rely on the service automatically locating and installing the dependencies from the PowerShell Gallery or other sources, taking care of selecting the proper versions, and automatically upgrading the dependencies to the latest versions (if allowed by the version specifications provided by the user).
 
-Dependencies are declared in the _requirements.psd1_ file (_manifest_) as a collection of pairs (<_name_>, <_version specification_>). Currently, the version specification should strictly match the following pattern: `<major version>.*`, so a typical manifest looks like this:
+Dependencies are declared in the _requirements.psd1_ file (_manifest_) as a collection of pairs (<_name_>, <_version specification_>). Currently, the version specification should either be an exact and complete version, or strictly match the following pattern: `<major version>.*`. So, a typical manifest may look like this:
 
 ``` PowerShell
 @{
   'Az' = '2.*'
   'PSDepend' = '0.*'
+  'Pester' = '5.0.0-alpha3'
 }
 ```
+
+When the `<major version>.*` format is used, the worker will retrieve the latest available module version (within the specified major version) from the PowerShell Gallery, ignoring prerelease versions.
+
+When the exact version is specified, the worker will retrieve the specified version only, ignoring any other version. Prerelease versions are allowed in this case.
 
 The number of entries in the _requirements.psd1_ file should not exceed **10**. This limit is not user-configurable.
 

--- a/src/DependencyManagement/DependencyInfo.cs
+++ b/src/DependencyManagement/DependencyInfo.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
     internal class DependencyInfo
     {
         internal readonly string Name;
-        internal readonly string LatestVersion;
+        internal readonly string ExactVersion;
 
-        internal DependencyInfo(string name, string latestVersion)
+        internal DependencyInfo(string name, string exactVersion)
         {
             Name = name;
-            LatestVersion = latestVersion;
+            ExactVersion = exactVersion;
         }
     }
 }

--- a/src/DependencyManagement/DependencyManagerStorage.cs
+++ b/src/DependencyManagement/DependencyManagerStorage.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             return Directory.EnumerateDirectories(_managedDependenciesRootPath);
         }
 
+        // TODO: replace with IsMajorModuleVersionInstalled?
         public IEnumerable<string> GetInstalledModuleVersions(string snapshotPath, string moduleName, string majorVersion)
         {
             var modulePath = Path.Join(snapshotPath, moduleName);
@@ -64,6 +65,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
 
             return Directory.EnumerateDirectories(modulePath, $"{majorVersion}.*");
+        }
+
+        public bool IsModuleVersionInstalled(string snapshotPath, string moduleName, string version)
+        {
+            var moduleVersionPath = Path.Join(snapshotPath, moduleName, version);
+            return Directory.Exists(moduleVersionPath);
         }
 
         public string CreateNewSnapshotPath()

--- a/src/DependencyManagement/DependencyManagerStorage.cs
+++ b/src/DependencyManagement/DependencyManagerStorage.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             return Directory.EnumerateDirectories(_managedDependenciesRootPath);
         }
 
-        // TODO: replace with IsMajorModuleVersionInstalled?
         public IEnumerable<string> GetInstalledModuleVersions(string snapshotPath, string moduleName, string majorVersion)
         {
             var modulePath = Path.Join(snapshotPath, moduleName);

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -67,10 +67,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         majorVersion);
                 }
 
-                // This is a very basic sanity check of the format that allows us detect some
+                // At this point, we know this is not the 'MajorVersion.*' pattern.
+                // We want to perform a very basic sanity check of the format to detect some
                 // obviously wrong cases: make sure afterMajorVersion starts with a dot,
                 // does not contain * anywhere, and ends with a word character.
-                // Not even trying to match the actual version format rules, though.
+                // Not even trying to match the actual version format rules,
+                // as they are quite complex and controlled by the server side anyway.
                 if (Regex.IsMatch(afterMajorVersion, @"^(\.[^\*]*?\w)?$"))
                 {
                     return new DependencyManifestEntry(

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 //     'ModuleName'='MajorVersion.*'
                 // or
                 //     'ModuleName'='ExactVersion'
-                var name = (string)entry.Key;
-                var version = (string)entry.Value;
 
-                yield return CreateDependencyManifestEntry(name, version);
+                yield return CreateDependencyManifestEntry(
+                                name: (string)entry.Key,
+                                version: (string)entry.Value);
             }
         }
 

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -57,13 +57,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             if (match.Success)
             {
                 // Look for the 'MajorVersion.*' pattern first.
+                var majorVersion = match.Groups[1].Value;
                 var afterMajorVersion = match.Groups[2].Value;
                 if (afterMajorVersion == ".*")
                 {
                     return new DependencyManifestEntry(
                         name,
                         VersionSpecificationType.MajorVersion,
-                        match.Groups[1].Value);
+                        majorVersion);
                 }
 
                 // This is a very basic sanity check of the format that allows us detect some

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
                 ValidateModuleName(name);
 
-                yield return new DependencyManifestEntry(name, GetMajorVersion(version));
+                yield return new DependencyManifestEntry(
+                    name,
+                    VersionSpecificationType.MajorVersion,
+                    GetMajorVersion(version));
             }
         }
 

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
             if (!IsValidVersionFormat(version))
             {
-                var errorMessage = string.Format(PowerShellWorkerStrings.InvalidVersionFormat, "MajorVersion.*");
+                var errorMessage = string.Format(PowerShellWorkerStrings.InvalidVersionFormat, version, "MajorVersion.*");
                 throw new ArgumentException(errorMessage);
             }
         }

--- a/src/DependencyManagement/DependencyManifestEntry.cs
+++ b/src/DependencyManagement/DependencyManifestEntry.cs
@@ -13,10 +13,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         public string VersionSpecification { get; }
 
-        public DependencyManifestEntry(string name, string versionSpecification)
+        public DependencyManifestEntry(
+            string name,
+            VersionSpecificationType versionSpecificationType,
+            string versionSpecification)
         {
             Name = name;
-            VersionSpecificationType = VersionSpecificationType.MajorVersion;
+            VersionSpecificationType = versionSpecificationType;
             VersionSpecification = versionSpecification;
         }
     }

--- a/src/DependencyManagement/DependencyManifestEntry.cs
+++ b/src/DependencyManagement/DependencyManifestEntry.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         public VersionSpecificationType VersionSpecificationType { get;  }
 
-        public string MajorVersion { get; }
+        public string VersionSpecification { get; }
 
-        public DependencyManifestEntry(string name, string majorVersion)
+        public DependencyManifestEntry(string name, string versionSpecification)
         {
             Name = name;
             VersionSpecificationType = VersionSpecificationType.MajorVersion;
-            MajorVersion = majorVersion;
+            VersionSpecification = versionSpecification;
         }
     }
 }

--- a/src/DependencyManagement/DependencyManifestEntry.cs
+++ b/src/DependencyManagement/DependencyManifestEntry.cs
@@ -9,11 +9,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
     {
         public string Name { get; }
 
+        public VersionSpecificationType VersionSpecificationType { get;  }
+
         public string MajorVersion { get; }
 
         public DependencyManifestEntry(string name, string majorVersion)
         {
             Name = name;
+            VersionSpecificationType = VersionSpecificationType.MajorVersion;
             MajorVersion = majorVersion;
         }
     }

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             {
                 foreach (DependencyInfo module in GetExactVersionsOfDependencies(dependencies))
                 {
-                    string moduleName = module.Name;
-                    string exactVersion = module.ExactVersion;
-
-                    logger.Log(isUserOnlyLog: false, LogLevel.Trace, string.Format(PowerShellWorkerStrings.StartedInstallingModule, moduleName, exactVersion));
+                    logger.Log(isUserOnlyLog: false, LogLevel.Trace, string.Format(PowerShellWorkerStrings.StartedInstallingModule, module.Name, module.ExactVersion));
 
                     int tries = 1;
 
@@ -56,9 +53,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     {
                         try
                         {
-                            _moduleProvider.SaveModule(pwsh, moduleName, exactVersion, installingPath);
+                            _moduleProvider.SaveModule(pwsh, module.Name, module.ExactVersion, installingPath);
 
-                            var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, exactVersion);
+                            var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, module.Name, module.ExactVersion);
                             logger.Log(isUserOnlyLog: false, LogLevel.Trace, message);
 
                             break;
@@ -66,7 +63,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         catch (Exception e)
                         {
                             string currentAttempt = GetCurrentAttemptMessage(tries);
-                            var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, moduleName, exactVersion, currentAttempt, e.Message);
+                            var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, module.Name, module.ExactVersion, currentAttempt, e.Message);
                             logger.Log(isUserOnlyLog: false, LogLevel.Error, errorMsg);
 
                             if (tries >= MaxNumberOfTries)

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
             foreach (var entry in dependencies)
             {
-                var latestVersion = GetModuleLatestPublishedVersion(entry.Name, entry.MajorVersion);
+                var latestVersion = GetModuleLatestPublishedVersion(entry.Name, entry.VersionSpecification);
 
                 var dependencyInfo = new DependencyInfo(entry.Name, latestVersion);
                 result.Add(dependencyInfo);

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
             try
             {
-                foreach (DependencyInfo module in GetLatestPublishedVersionsOfDependencies(dependencies))
+                foreach (DependencyInfo module in GetExactVersionsOfDependencies(dependencies))
                 {
                     string moduleName = module.Name;
                     string exactVersion = module.ExactVersion;
@@ -127,20 +127,33 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
         }
 
-        private List<DependencyInfo> GetLatestPublishedVersionsOfDependencies(
+        private List<DependencyInfo> GetExactVersionsOfDependencies(
             IEnumerable<DependencyManifestEntry> dependencies)
         {
             var result = new List<DependencyInfo>();
 
             foreach (var entry in dependencies)
             {
-                var latestVersion = GetModuleLatestPublishedVersion(entry.Name, entry.VersionSpecification);
-
-                var dependencyInfo = new DependencyInfo(entry.Name, latestVersion);
+                var dependencyInfo = new DependencyInfo(entry.Name, GetExactVersion(entry));
                 result.Add(dependencyInfo);
             }
 
             return result;
+        }
+
+        private string GetExactVersion(DependencyManifestEntry entry)
+        {
+            switch (entry.VersionSpecificationType)
+            {
+                case VersionSpecificationType.ExactVersion:
+                    return entry.VersionSpecification;
+
+                case VersionSpecificationType.MajorVersion:
+                    return GetModuleLatestPublishedVersion(entry.Name, entry.VersionSpecification);
+
+                default:
+                    throw new ArgumentException($"Unknown version specification type: {entry.VersionSpecificationType}");
+            }
         }
 
         /// <summary>

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 foreach (DependencyInfo module in GetLatestPublishedVersionsOfDependencies(dependencies))
                 {
                     string moduleName = module.Name;
-                    string latestVersion = module.LatestVersion;
+                    string exactVersion = module.ExactVersion;
 
-                    logger.Log(isUserOnlyLog: false, LogLevel.Trace, string.Format(PowerShellWorkerStrings.StartedInstallingModule, moduleName, latestVersion));
+                    logger.Log(isUserOnlyLog: false, LogLevel.Trace, string.Format(PowerShellWorkerStrings.StartedInstallingModule, moduleName, exactVersion));
 
                     int tries = 1;
 
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     {
                         try
                         {
-                            _moduleProvider.SaveModule(pwsh, moduleName, latestVersion, installingPath);
+                            _moduleProvider.SaveModule(pwsh, moduleName, exactVersion, installingPath);
 
-                            var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, latestVersion);
+                            var message = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, exactVersion);
                             logger.Log(isUserOnlyLog: false, LogLevel.Trace, message);
 
                             break;
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         catch (Exception e)
                         {
                             string currentAttempt = GetCurrentAttemptMessage(tries);
-                            var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, moduleName, latestVersion, currentAttempt, e.Message);
+                            var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallModule, moduleName, exactVersion, currentAttempt, e.Message);
                             logger.Log(isUserOnlyLog: false, LogLevel.Error, errorMsg);
 
                             if (tries >= MaxNumberOfTries)

--- a/src/DependencyManagement/IDependencyManagerStorage.cs
+++ b/src/DependencyManagement/IDependencyManagerStorage.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         IEnumerable<string> GetInstalledModuleVersions(string snapshotPath, string moduleName, string majorVersion);
 
+        bool IsModuleVersionInstalled(string snapshotPath, string moduleName, string version);
+
         string CreateNewSnapshotPath();
 
         string CreateInstallingSnapshot(string path);

--- a/src/DependencyManagement/InstalledDependenciesLocator.cs
+++ b/src/DependencyManagement/InstalledDependenciesLocator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         {
             var installedVersions =
                 _storage.GetInstalledModuleVersions(
-                    snapshotPath, dependency.Name, dependency.MajorVersion);
+                    snapshotPath, dependency.Name, dependency.VersionSpecification);
 
             return installedVersions.Any();
         }

--- a/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
+++ b/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 .AddParameter("Repository", Repository)
                 .AddParameter("Name", moduleName)
                 .AddParameter("RequiredVersion", version)
+                .AddParameter("AllowPrerelease", version)
                 .AddParameter("Path", path)
                 .AddParameter("Force", Utils.BoxedTrue)
                 .AddParameter("ErrorAction", "Stop")

--- a/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
+++ b/src/DependencyManagement/PowerShellGalleryModuleProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 .AddParameter("Repository", Repository)
                 .AddParameter("Name", moduleName)
                 .AddParameter("RequiredVersion", version)
-                .AddParameter("AllowPrerelease", version)
+                .AddParameter("AllowPrerelease", Utils.BoxedTrue)
                 .AddParameter("Path", path)
                 .AddParameter("Force", Utils.BoxedTrue)
                 .AddParameter("ErrorAction", "Stop")

--- a/src/DependencyManagement/VersionSpecificationType.cs
+++ b/src/DependencyManagement/VersionSpecificationType.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma warning disable 1591
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
+{
+    public enum VersionSpecificationType
+    {
+        ExactVersion,
+        MajorVersion
+    }
+}

--- a/src/DependencyManagement/VersionSpecificationType.cs
+++ b/src/DependencyManagement/VersionSpecificationType.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#pragma warning disable 1591
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member 'member'
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 {

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -188,7 +188,7 @@
     <value>The PowerShell data file '{0}' is invalid since it cannot be evaluated into a Hashtable object.</value>
   </data>
   <data name="InvalidVersionFormat" xml:space="preserve">
-    <value>Version is not in the correct format. Please use the following notation: '{0}'</value>
+    <value>Version specification '{0}' is not in the correct format. Please specify the exact version or use the following notation: '{1}'</value>
   </data>
   <data name="FailToInstallFuncAppDependencies" xml:space="preserve">
     <value>Fail to install FunctionApp dependencies. Error: '{0}'</value>

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -179,9 +179,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 var exception = Assert.Throws<DependencyInstallationException>(
                                     () => { dependencyManager.Initialize(_testLogger); });
 
-                Assert.Contains("Version is not in the correct format.", exception.Message);
-                Assert.Contains("Please use the following notation:", exception.Message);
-                Assert.Contains("MajorVersion.*", exception.Message);
+                Assert.Contains("not in the correct format.", exception.Message);
+                Assert.Contains("1.0.*", exception.Message);
+                Assert.Contains("Please specify the exact version or use the following notation: 'MajorVersion.*'", exception.Message);
             }
         }
 

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         public void Initialize_ReturnsNewSnapshotPath_WhenNoAcceptableDependencyVersionsInstalled()
         {
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(
-                new[] { new DependencyManifestEntry("ModuleName", "1") });
+                new[] { new DependencyManifestEntry("ModuleName", VersionSpecificationType.MajorVersion, "1") });
             _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
                 .Returns(default(string));
             _mockStorage.Setup(_ => _.CreateNewSnapshotPath()).Returns("NewSnapshot");
@@ -100,9 +100,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             var dependencyManifestEntries = new[]
                 {
-                    new DependencyManifestEntry("A", "3"),
-                    new DependencyManifestEntry("C", "7"),
-                    new DependencyManifestEntry("B", "11")
+                    new DependencyManifestEntry("A", VersionSpecificationType.MajorVersion, "3"),
+                    new DependencyManifestEntry("C", VersionSpecificationType.MajorVersion, "7"),
+                    new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
                 };
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(dependencyManifestEntries);
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
         private static DependencyManifestEntry[] GetAnyNonEmptyDependencyManifestEntries()
         {
-            return new[] { new DependencyManifestEntry("ModuleName", "1") };
+            return new[] { new DependencyManifestEntry("ModuleName", VersionSpecificationType.MajorVersion, "1") };
         }
 
         private void VerifyExactlyOneSnapshotInstalled()

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void Initialize_ReturnsNewSnapshotPath_WhenNoAcceptableDependencyVersionsInstalled()
         {
-            _mockStorage.Setup(_ => _.GetDependencies()).Returns(
-                new[] { new DependencyManifestEntry("ModuleName", VersionSpecificationType.MajorVersion, "1") });
+            _mockStorage.Setup(_ => _.GetDependencies()).Returns(GetAnyNonEmptyDependencyManifestEntries());
             _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
                 .Returns(default(string));
             _mockStorage.Setup(_ => _.CreateNewSnapshotPath()).Returns("NewSnapshot");

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -98,12 +98,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
                 .Returns(default(string));
 
-            var dependencyManifestEntries = new[]
-                {
-                    new DependencyManifestEntry("A", VersionSpecificationType.MajorVersion, "3"),
-                    new DependencyManifestEntry("C", VersionSpecificationType.MajorVersion, "7"),
-                    new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
-                };
+            var dependencyManifestEntries = GetAnyNonEmptyDependencyManifestEntries();
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(dependencyManifestEntries);
             _mockStorage.Setup(_ => _.CreateNewSnapshotPath()).Returns("NewSnapshot");

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -93,40 +93,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void StartDependencyInstallationIfNeeded_InstallsSnapshotWithLatestPublishedModuleVersions()
-        {
-            _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
-                .Returns(default(string));
-
-            var dependencyManifestEntries = GetAnyNonEmptyDependencyManifestEntries();
-
-            _mockStorage.Setup(_ => _.GetDependencies()).Returns(dependencyManifestEntries);
-            _mockStorage.Setup(_ => _.CreateNewSnapshotPath()).Returns("NewSnapshot");
-            _mockPurger.Setup(_ => _.SetCurrentlyUsedSnapshot(It.IsAny<string>(), _mockLogger.Object));
-
-            _mockInstaller.Setup(
-                _ => _.InstallSnapshot(
-                        dependencyManifestEntries,
-                        "NewSnapshot",
-                        It.IsAny<PowerShell>(),
-                        _mockLogger.Object));
-
-            _mockStorage.Setup(_ => _.SnapshotExists(It.IsAny<string>())).Returns(false);
-
-            var dependencyManager = CreateDependencyManagerWithMocks();
-            dependencyManager.Initialize(_mockLogger.Object);
-            dependencyManager.StartDependencyInstallationIfNeeded(PowerShell.Create(), PowerShell.Create, _mockLogger.Object);
-            dependencyManager.WaitForDependenciesAvailability(() => _mockLogger.Object);
-
-            _mockInstaller.Verify(
-                _ => _.InstallSnapshot(
-                    It.IsAny<IEnumerable<DependencyManifestEntry>>(), It.IsAny<string>(), It.IsAny<PowerShell>(), It.IsAny<ILogger>()),
-                Times.Once());
-
-            _mockInstaller.VerifyNoOtherCalls();
-        }
-
-        [Fact]
         public void StartDependencyInstallationIfNeeded_InstallsSnapshotInForeground_WhenNoAcceptableDependenciesInstalled()
         {
             _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())

--- a/test/Unit/DependencyManagement/DependencyManifestTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManifestTests.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [InlineData("@{ MyModule = '' }")]
         [InlineData("@{ MyModule = ' ' }")]
         [InlineData("@{ MyModule = 'a' }")]
+        [InlineData("@{ MyModule = '1a' }")]
         [InlineData("@{ MyModule = '.' }")]
         [InlineData("@{ MyModule = '1.' }")]
         [InlineData("@{ MyModule = '*' }")]

--- a/test/Unit/DependencyManagement/DependencyManifestTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManifestTests.cs
@@ -68,6 +68,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [InlineData("@{ MyModule = '1.*' }", "MyModule", "1", VersionSpecificationType.MajorVersion)]
         [InlineData("@{ MyModule = '23.*' }", "MyModule", "23", VersionSpecificationType.MajorVersion)]
         [InlineData("@{ MyModule = '456.*' }", "MyModule", "456", VersionSpecificationType.MajorVersion)]
+        [InlineData("@{ MyModule = '0' }", "MyModule", "0", VersionSpecificationType.ExactVersion)]
+        [InlineData("@{ MyModule = '1' }", "MyModule", "1", VersionSpecificationType.ExactVersion)]
+        [InlineData("@{ MyModule = '1.0' }", "MyModule", "1.0", VersionSpecificationType.ExactVersion)]
+        [InlineData("@{ MyModule = '3.4.5' }", "MyModule", "3.4.5", VersionSpecificationType.ExactVersion)]
+        [InlineData("@{ MyModule = '123.45.67.89' }", "MyModule", "123.45.67.89", VersionSpecificationType.ExactVersion)]
+        [InlineData("@{ MyModule = '123.45.67.89-alpha4' }", "MyModule", "123.45.67.89-alpha4", VersionSpecificationType.ExactVersion)]
         public void GetEntriesParsesRequirementsFileWithSingleEntry(
             string content,
             string moduleName,
@@ -110,13 +116,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
         [Theory]
         [InlineData("@{ MyModule = '' }")]
+        [InlineData("@{ MyModule = ' ' }")]
         [InlineData("@{ MyModule = 'a' }")]
         [InlineData("@{ MyModule = '.' }")]
-        [InlineData("@{ MyModule = '1' }")]
         [InlineData("@{ MyModule = '1.' }")]
-        [InlineData("@{ MyModule = '1.0' }")]
-        [InlineData("@{ MyModule = '1.2' }")]
-        [InlineData("@{ MyModule = '2.3.4' }")]
+        [InlineData("@{ MyModule = '*' }")]
+        [InlineData("@{ MyModule = '*.1' }")]
+        [InlineData("@{ MyModule = '1.*.2' }")]
+        [InlineData("@{ MyModule = '1.0.*' }")]
         public void GetEntriesThrowsOnInvalidVersionSpecification(string content)
         {
             CreateRequirementsFile(content);
@@ -124,7 +131,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var manifest = new DependencyManifest(_appRootPath);
 
             var exception = Assert.Throws<ArgumentException>(() => manifest.GetEntries().ToList());
-            Assert.Contains("Version is not in the correct format", exception.Message);
+            Assert.Contains("not in the correct format", exception.Message);
         }
 
         [Theory]

--- a/test/Unit/DependencyManagement/DependencyManifestTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManifestTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             Assert.Single(entries);
             Assert.Equal(moduleName, entries.Single().Name);
             Assert.Equal(versionSpecificationType, entries.Single().VersionSpecificationType);
-            Assert.Equal(majorVersion, entries.Single().MajorVersion);
+            Assert.Equal(majorVersion, entries.Single().VersionSpecification);
         }
 
         [Fact]
@@ -97,15 +97,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             var entryA = entries.Single(entry => entry.Name == "A");
             Assert.Equal(VersionSpecificationType.MajorVersion, entryA.VersionSpecificationType);
-            Assert.Equal("3", entryA.MajorVersion);
+            Assert.Equal("3", entryA.VersionSpecification);
 
             var entryB = entries.Single(entry => entry.Name == "B");
             Assert.Equal(VersionSpecificationType.MajorVersion, entryB.VersionSpecificationType);
-            Assert.Equal("7", entryB.MajorVersion);
+            Assert.Equal("7", entryB.VersionSpecification);
 
             var entryC = entries.Single(entry => entry.Name == "C");
             Assert.Equal(VersionSpecificationType.MajorVersion, entryC.VersionSpecificationType);
-            Assert.Equal("0", entryC.MajorVersion);
+            Assert.Equal("0", entryC.VersionSpecification);
         }
 
         [Theory]

--- a/test/Unit/DependencyManagement/DependencyManifestTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManifestTests.cs
@@ -64,11 +64,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Theory]
-        [InlineData("@{ MyModule = '0.*' }", "MyModule", "0")]
-        [InlineData("@{ MyModule = '1.*' }", "MyModule", "1")]
-        [InlineData("@{ MyModule = '23.*' }", "MyModule", "23")]
-        [InlineData("@{ MyModule = '456.*' }", "MyModule", "456")]
-        public void GetEntriesParsesRequirementsFileWithSingleEntry(string content, string moduleName, string majorVersion)
+        [InlineData("@{ MyModule = '0.*' }", "MyModule", "0", VersionSpecificationType.MajorVersion)]
+        [InlineData("@{ MyModule = '1.*' }", "MyModule", "1", VersionSpecificationType.MajorVersion)]
+        [InlineData("@{ MyModule = '23.*' }", "MyModule", "23", VersionSpecificationType.MajorVersion)]
+        [InlineData("@{ MyModule = '456.*' }", "MyModule", "456", VersionSpecificationType.MajorVersion)]
+        public void GetEntriesParsesRequirementsFileWithSingleEntry(
+            string content,
+            string moduleName,
+            string majorVersion,
+            VersionSpecificationType versionSpecificationType)
         {
             CreateRequirementsFile(content);
 
@@ -77,6 +81,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             Assert.Single(entries);
             Assert.Equal(moduleName, entries.Single().Name);
+            Assert.Equal(versionSpecificationType, entries.Single().VersionSpecificationType);
             Assert.Equal(majorVersion, entries.Single().MajorVersion);
         }
 
@@ -89,9 +94,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var entries = manifest.GetEntries().ToList();
 
             Assert.Equal(3, entries.Count);
-            Assert.Equal("3", entries.Single(entry => entry.Name == "A").MajorVersion);
-            Assert.Equal("7", entries.Single(entry => entry.Name == "B").MajorVersion);
-            Assert.Equal("0", entries.Single(entry => entry.Name == "C").MajorVersion);
+
+            var entryA = entries.Single(entry => entry.Name == "A");
+            Assert.Equal(VersionSpecificationType.MajorVersion, entryA.VersionSpecificationType);
+            Assert.Equal("3", entryA.MajorVersion);
+
+            var entryB = entries.Single(entry => entry.Name == "B");
+            Assert.Equal(VersionSpecificationType.MajorVersion, entryB.VersionSpecificationType);
+            Assert.Equal("7", entryB.MajorVersion);
+
+            var entryC = entries.Single(entry => entry.Name == "C");
+            Assert.Equal(VersionSpecificationType.MajorVersion, entryC.VersionSpecificationType);
+            Assert.Equal("0", entryC.MajorVersion);
         }
 
         [Theory]

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -46,19 +46,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void SavesSpecifiedVersion_WhenExactVersionIsSpecified()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Exact version") };
 
             ExpectSnapshotCreationAndPromotion();
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
-
-            // Assert
 
             _mockModuleProvider.Verify(
                 _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Exact version", _targetPathInstalling),
@@ -72,8 +66,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void SavesLatestPublishedVersion_WhenMajorVersionIsSpecified()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Major version") };
 
@@ -83,12 +75,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
                 .Returns("Latest version");
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
-
-            // Assert
 
             _mockModuleProvider.Verify(
                 _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Latest version", _targetPathInstalling),
@@ -98,19 +86,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void PromotesInstallingSnapshotToInstalledAfterSuccessfullySavingModule()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
             ExpectSnapshotCreationAndPromotion();
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
-
-            // Assert
 
             _mockStorage.Verify(_ => _.CreateInstallingSnapshot(_targetPathInstalled), Times.Once);
             _mockStorage.Verify(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled), Times.Once);
@@ -119,8 +101,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void CleansUpPowerShellRunspaceAfterSuccessfullySavingModule()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
@@ -128,12 +108,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             var dummyPowerShell = PowerShell.Create();
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, dummyPowerShell, _mockLogger.Object);
-
-            // Assert
 
             _mockModuleProvider.Verify(_ => _.Cleanup(dummyPowerShell), Times.Once);
         }
@@ -141,8 +117,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void LogsInstallationStartAndFinish()
         {
-            // Arrange
-
             var manifestEntries =
                 new[]
                 {
@@ -156,12 +130,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             ExpectSnapshotCreationAndPromotion();
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
-            // Assert
             VerifyLoggedOnce(new[] { "Started installing", "A", "Exact A version" });
             VerifyLoggedOnce(new[] { "has been installed", "A", "Exact A version" });
             VerifyLoggedOnce(new[] { "Started installing", "B", "Exact B version" });
@@ -171,8 +142,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void DoesNotSaveModuleIfGetLatestPublishedModuleVersionThrows()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Version") };
 
@@ -190,13 +159,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockModuleProvider.Setup(_ => _.Cleanup(dummyPowerShell));
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             var caughtException = Assert.Throws<InvalidOperationException>(
                 () => installer.InstallSnapshot(manifestEntries, _targetPathInstalled, dummyPowerShell, _mockLogger.Object));
-
-            // Assert
 
             Assert.Contains(injectedException.Message, caughtException.Message);
 
@@ -212,8 +177,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void DoesNotPromoteDependenciesSnapshotIfSaveModuleKeepsThrowing()
         {
-            // Arrange
-
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
@@ -229,13 +192,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.RemoveSnapshot(_targetPathInstalling));
 
-            // Act
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             var thrownException = Assert.Throws<DependencyInstallationException>(
                 () => installer.InstallSnapshot(manifestEntries, _targetPathInstalled, dummyPowerShell, _mockLogger.Object));
-
-            // Assert
 
             Assert.Contains(injectedException.Message, thrownException.Message);
 

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             _targetPathInstalled = DependencySnapshotFolderNameTools.CreateUniqueName();
             _targetPathInstalling = DependencySnapshotFolderNameTools.ConvertInstalledToInstalling(_targetPathInstalled);
-            ExpectSnapshotCreationAndPromotion();
+            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
+            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
         }
 
         [Fact]
@@ -193,12 +194,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         private DependencySnapshotInstaller CreateDependenciesSnapshotInstallerWithMocks()
         {
             return new DependencySnapshotInstaller(_mockModuleProvider.Object, _mockStorage.Object);
-        }
-
-        private void ExpectSnapshotCreationAndPromotion()
-        {
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
         }
 
         private void VerifyLoggedOnce(IEnumerable<string> messageParts)

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             _targetPathInstalled = DependencySnapshotFolderNameTools.CreateUniqueName();
             _targetPathInstalling = DependencySnapshotFolderNameTools.ConvertInstalledToInstalling(_targetPathInstalled);
+            ExpectSnapshotCreationAndPromotion();
         }
 
         [Fact]
@@ -48,8 +49,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Exact version") };
-
-            ExpectSnapshotCreationAndPromotion();
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
@@ -69,8 +68,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Major version") };
 
-            ExpectSnapshotCreationAndPromotion();
-
             _mockModuleProvider.Setup(
                     _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
                 .Returns("Latest version");
@@ -89,8 +86,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
-            ExpectSnapshotCreationAndPromotion();
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
@@ -103,8 +98,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
-
-            ExpectSnapshotCreationAndPromotion();
 
             var dummyPowerShell = PowerShell.Create();
 
@@ -128,8 +121,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     _ => _.GetLatestPublishedModuleVersion(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns("Exact B version");
 
-            ExpectSnapshotCreationAndPromotion();
-
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
@@ -144,8 +135,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Version") };
-
-            ExpectSnapshotCreationAndPromotion();
 
             var dummyPowerShell = PowerShell.Create();
 
@@ -179,8 +168,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
-
-            ExpectSnapshotCreationAndPromotion();
 
             var dummyPowerShell = PowerShell.Create();
 

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
     public class DependencySnapshotInstallerTests
     {
-        private readonly Mock<IModuleProvider> _mockModuleProvider = new Mock<IModuleProvider>(MockBehavior.Strict);
+        private readonly Mock<IModuleProvider> _mockModuleProvider = new Mock<IModuleProvider>();
         private readonly Mock<IDependencyManagerStorage> _mockStorage = new Mock<IDependencyManagerStorage>(MockBehavior.Strict);
         private readonly Mock<ILogger> _mockLogger = new Mock<ILogger>();
 
@@ -180,8 +180,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.RemoveSnapshot(_targetPathInstalling));
 
-            _mockModuleProvider.Setup(_ => _.Cleanup(dummyPowerShell));
-
             // Act
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
@@ -219,18 +217,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Latest version", _targetPathInstalling));
 
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
-            _mockModuleProvider.Setup(_ => _.Cleanup(It.IsAny<PowerShell>()));
 
             // Act
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
-
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
             // Assert
 
             _mockModuleProvider.Verify(
-                _ => _.GetLatestPublishedModuleVersion(It.IsAny<string>(), It.IsAny<string>()),
+                _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Latest version", _targetPathInstalling),
                 Times.Once);
         }
 
@@ -252,15 +248,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Exact version", _targetPathInstalling));
 
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
-            _mockModuleProvider.Setup(_ => _.Cleanup(It.IsAny<PowerShell>()));
 
             // Act
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
-
             installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
             // Assert
+
+            _mockModuleProvider.Verify(
+                _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Exact version", _targetPathInstalling),
+                Times.Once);
 
             _mockModuleProvider.Verify(
                 _ => _.GetLatestPublishedModuleVersion(It.IsAny<string>(), It.IsAny<string>()),

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -202,12 +202,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             // Arrange
 
-            var testDependencyManifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("A", VersionSpecificationType.ExactVersion, "Exact version of A")
-                };
-
             _mockStorage.Setup(
                 _ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
 
@@ -220,7 +214,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Act
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
-            installer.InstallSnapshot(testDependencyManifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
+
+            var manifestEntries =
+                new[]
+                {
+                    new DependencyManifestEntry("A", VersionSpecificationType.ExactVersion, "Exact version of A")
+                };
+
+            installer.InstallSnapshot(manifestEntries, _targetPathInstalled, PowerShell.Create(), _mockLogger.Object);
 
             // Assert
 

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -54,12 +54,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             // Arrange
 
-            _mockStorage.Setup(
-                _ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
-
-            _mockModuleProvider.Setup(
-                _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Exact version", _targetPathInstalling));
-
+            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
 
             // Act
@@ -96,9 +91,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
                 .Returns("Latest version");
 
-            _mockModuleProvider.Setup(
-                _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Latest version", _targetPathInstalling));
-
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
 
             // Act
@@ -125,10 +117,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 };
 
             _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
-
-            _mockModuleProvider.Setup(
-                _ => _.SaveModule(It.IsAny<PowerShell>(), "Module", "Version", _targetPathInstalling));
-
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
 
             // Act
@@ -155,10 +143,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             var dummyPowerShell = PowerShell.Create();
             _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
-
-            _mockModuleProvider.Setup(
-                _ => _.SaveModule(dummyPowerShell, "Module", "Version", _targetPathInstalling));
-
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
 
             // Act

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -46,16 +46,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void SavesSpecifiedVersion_WhenExactVersionIsSpecified()
         {
+            // Arrange
+
             var manifestEntries =
                 new[]
                 {
                     new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Exact version")
                 };
 
-            // Arrange
-
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
+            ExpectSnapshotCreationAndPromotion();
 
             // Act
 
@@ -84,14 +83,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Major version")
                 };
 
-            _mockStorage.Setup(
-                _ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
+            ExpectSnapshotCreationAndPromotion();
 
             _mockModuleProvider.Setup(
                 _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
                 .Returns("Latest version");
-
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(It.IsAny<string>()));
 
             // Act
 
@@ -116,8 +112,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
                 };
 
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
+            ExpectSnapshotCreationAndPromotion();
 
             // Act
 
@@ -141,9 +136,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
                 };
 
+            ExpectSnapshotCreationAndPromotion();
+
             var dummyPowerShell = PowerShell.Create();
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
 
             // Act
 
@@ -171,8 +166,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     _ => _.GetLatestPublishedModuleVersion(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns("Exact B version");
 
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(It.IsAny<string>())).Returns(_targetPathInstalling);
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
+            ExpectSnapshotCreationAndPromotion();
 
             // Act
 
@@ -197,9 +191,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Version")
                 };
 
+            ExpectSnapshotCreationAndPromotion();
+
             var dummyPowerShell = PowerShell.Create();
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled))
-                .Returns(_targetPathInstalling);
 
             var injectedException = new InvalidOperationException("Couldn't get latest published module version");
 
@@ -241,9 +235,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
                 };
 
+            ExpectSnapshotCreationAndPromotion();
+
             var dummyPowerShell = PowerShell.Create();
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled))
-                .Returns(_targetPathInstalling);
 
             var injectedException = new Exception("Couldn't save module");
 
@@ -271,6 +265,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         private DependencySnapshotInstaller CreateDependenciesSnapshotInstallerWithMocks()
         {
             return new DependencySnapshotInstaller(_mockModuleProvider.Object, _mockStorage.Object);
+        }
+
+        private void ExpectSnapshotCreationAndPromotion()
+        {
+            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
+            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
         }
 
         private void VerifyLoggedOnce(IEnumerable<string> messageParts)

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -56,43 +56,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void InstallsDependencySnapshots()
-        {
-            // Arrange
-
-            var dummyPowerShell = PowerShell.Create();
-            _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled))
-                .Returns(_targetPathInstalling);
-
-            foreach (var entry in _testDependencyManifestEntries)
-            {
-                _mockModuleProvider.Setup(
-                        _ => _.GetLatestPublishedModuleVersion(entry.Name, entry.VersionSpecification))
-                    .Returns(_testLatestPublishedModuleVersions[entry.Name]);
-
-                _mockModuleProvider.Setup(
-                    _ => _.SaveModule(dummyPowerShell, entry.Name, _testLatestPublishedModuleVersions[entry.Name], _targetPathInstalling));
-            }
-
-            _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
-            _mockModuleProvider.Setup(_ => _.Cleanup(dummyPowerShell));
-
-            // Act
-
-            var installer = CreateDependenciesSnapshotInstallerWithMocks();
-            installer.InstallSnapshot(_testDependencyManifestEntries, _targetPathInstalled, dummyPowerShell, _mockLogger.Object);
-
-            // Assert
-
-            foreach (var entry in _testDependencyManifestEntries)
-            {
-                _mockModuleProvider.Verify(
-                    _ => _.SaveModule(dummyPowerShell, entry.Name, _testLatestPublishedModuleVersions[entry.Name], _targetPathInstalling),
-                    Times.Once);
-            }
-        }
-
-        [Fact]
         public void DoesNotSaveModuleIfGetLatestPublishedModuleVersionThrows()
         {
             // Arrange

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void PromotesInstallingSnapshotToInstalledAfterSuccessfullySavingModule()
+        public void PromotesInstallingSnapshotToInstalledIfSaveModuleDoesNotThrow()
         {
             var manifestEntries =
                 new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             ExpectSnapshotCreationAndPromotion();
 
             _mockModuleProvider.Setup(
-                _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
+                    _ => _.GetLatestPublishedModuleVersion("Module", "Major version"))
                 .Returns("Latest version");
 
             var installer = CreateDependenciesSnapshotInstallerWithMocks();
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var injectedException = new Exception("Couldn't save module");
 
             _mockModuleProvider.Setup(
-                _ => _.SaveModule(It.IsAny<PowerShell>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                    _ => _.SaveModule(It.IsAny<PowerShell>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(injectedException);
 
             _mockStorage.Setup(_ => _.RemoveSnapshot(_targetPathInstalling));

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void InstallsLatestPublishedVersion_WhenMajorVersionIsSpecified()
+        public void SavesLatestPublishedVersion_WhenMajorVersionIsSpecified()
         {
             // Arrange
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void InstallsSpecifiedVersion_WhenExactVersionIsSpecified()
+        public void SavesSpecifiedVersion_WhenExactVersionIsSpecified()
         {
             var manifestEntries =
                 new[]

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -37,6 +37,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         public void DoesNothingOnConstruction()
         {
             CreateDependenciesSnapshotInstallerWithMocks();
+
+            _mockModuleProvider.VerifyNoOtherCalls();
+            _mockStorage.VerifyNoOtherCalls();
+            _mockLogger.VerifyNoOtherCalls();
         }
 
         [Fact]

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -49,10 +49,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Exact version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Exact version") };
 
             ExpectSnapshotCreationAndPromotion();
 
@@ -78,10 +75,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Major version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Major version") };
 
             ExpectSnapshotCreationAndPromotion();
 
@@ -107,10 +101,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
             ExpectSnapshotCreationAndPromotion();
 
@@ -131,10 +122,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
             ExpectSnapshotCreationAndPromotion();
 
@@ -186,10 +174,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.MajorVersion, "Version") };
 
             ExpectSnapshotCreationAndPromotion();
 
@@ -230,10 +215,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             // Arrange
 
             var manifestEntries =
-                new[]
-                {
-                    new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version")
-                };
+                new[] { new DependencyManifestEntry("Module", VersionSpecificationType.ExactVersion, "Version") };
 
             ExpectSnapshotCreationAndPromotion();
 

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             foreach (var entry in _testDependencyManifestEntries)
             {
                 _mockModuleProvider.Setup(
-                        _ => _.GetLatestPublishedModuleVersion(entry.Name, entry.MajorVersion))
+                        _ => _.GetLatestPublishedModuleVersion(entry.Name, entry.VersionSpecification))
                     .Returns(_testLatestPublishedModuleVersions[entry.Name]);
 
                 _mockModuleProvider.Setup(
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             foreach (var entry in _testDependencyManifestEntries)
             {
                 _mockModuleProvider.Setup(
-                        _ => _.GetLatestPublishedModuleVersion(entry.Name, entry.MajorVersion))
+                        _ => _.GetLatestPublishedModuleVersion(entry.Name, entry.VersionSpecification))
                     .Returns(_testLatestPublishedModuleVersions[entry.Name]);
             }
 

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -259,11 +259,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         {
             _mockLogger.Verify(
                 _ => _.Log(
-                    false,
+                    false, // isUserOnlyLog
                     LogLevel.Trace,
-                    It.Is<string>(
+                    It.Is<string>( // the message should contain every item of messageParts
                         message => messageParts.All(part => message.Contains(part))),
-                    null),
+                    null), // exception
                 Times.Once);
         }
     }

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         private readonly IEnumerable<DependencyManifestEntry> _testDependencyManifestEntries =
             new[]
             {
-                new DependencyManifestEntry("A", "3"),
-                new DependencyManifestEntry("C", "7"),
-                new DependencyManifestEntry("B", "11")
+                new DependencyManifestEntry("A", VersionSpecificationType.MajorVersion, "3"),
+                new DependencyManifestEntry("C", VersionSpecificationType.MajorVersion, "7"),
+                new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
             };
 
         private readonly Dictionary<string, string> _testLatestPublishedModuleVersions =

--- a/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
+++ b/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void ReturnsLatestSnapshotPath_WhenAnyDependencyDoesNotHaveAcceptableVersionInstalled()
+        public void ReturnsLatestSnapshotPath_WhenAllDependenciesHaveAcceptableVersionInstalled()
         {
             // Even though multiple snapshots can be currently installed, only the latest one will be considered
             // (determined by name).
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
-            // No 11.* version for module B detected!
             _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "A", "3")).Returns(new[] { "3.1", "3.3" });
             _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new [] { "11.8.0.2" });
             _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "C", "7")).Returns(new[] { "7.0" });

--- a/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
+++ b/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
@@ -21,6 +21,24 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             };
 
         [Fact]
+        public void ReturnsLatestSnapshotPath_WhenAllDependenciesHaveAcceptableVersionInstalled()
+        {
+            // Even though multiple snapshots can be currently installed, only the latest one will be considered
+            // (determined by name).
+            _mockStorage.Setup(_ => _.GetInstalledSnapshots()).Returns(new[] { "s1", "s3", "s2" });
+
+            _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
+
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "exact version of A")).Returns(true);
+            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "major version of B")).Returns(new [] { "exact version of B" });
+
+            var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
+            var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
+
+            Assert.Equal("s3", result);
+        }
+
+        [Fact]
         public void ReturnsNull_WhenNoInstalledDependencySnapshotsFound()
         {
             _mockStorage.Setup(_ => _.GetInstalledSnapshots()).Returns(new string[0]);
@@ -67,24 +85,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
 
             Assert.Null(result);
-        }
-
-        [Fact]
-        public void ReturnsLatestSnapshotPath_WhenAllDependenciesHaveAcceptableVersionInstalled()
-        {
-            // Even though multiple snapshots can be currently installed, only the latest one will be considered
-            // (determined by name).
-            _mockStorage.Setup(_ => _.GetInstalledSnapshots()).Returns(new[] { "s1", "s3", "s2" });
-
-            _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
-
-            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "exact version of A")).Returns(true);
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "major version of B")).Returns(new [] { "exact version of B" });
-
-            var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
-            var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
-
-            Assert.Equal("s3", result);
         }
     }
 }

--- a/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
+++ b/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
         private readonly DependencyManifestEntry[] _dependencyManifestEntries =
             {
-                new DependencyManifestEntry("A", VersionSpecificationType.MajorVersion, "3"),
-                new DependencyManifestEntry("C", VersionSpecificationType.MajorVersion, "7"),
+                new DependencyManifestEntry("A", VersionSpecificationType.ExactVersion, "3"),
                 new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
             };
 
@@ -33,7 +32,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
-        public void ReturnsNull_WhenAnyDependencyDoesNotHaveAcceptableVersionInstalled()
+        public void ReturnsNull_WhenNoMajorVersionInstalled()
         {
             // Even though multiple snapshots can be currently installed, only the latest one will be considered
             // (determined by name).
@@ -42,9 +41,27 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
             // No 11.* version for module B detected!
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "A", "3")).Returns(new[] { "3.1", "3.3" });
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(true);
             _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new string[0]);
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "C", "7")).Returns(new[] { "7.0" });
+
+            var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
+            var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ReturnsNull_WhenExactModuleVersionIsNotInstalled()
+        {
+            // Even though multiple snapshots can be currently installed, only the latest one will be considered
+            // (determined by name).
+            _mockStorage.Setup(_ => _.GetInstalledSnapshots()).Returns(new[] { "s1", "s3", "s2" });
+
+            _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
+
+            // The specified module A version is not installed
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(false);
+            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new [] { "11.8.0.2" });
 
             var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
@@ -61,9 +78,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "A", "3")).Returns(new[] { "3.1", "3.3" });
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(true);
             _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new [] { "11.8.0.2" });
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "C", "7")).Returns(new[] { "7.0" });
 
             var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();

--- a/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
+++ b/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
         private readonly DependencyManifestEntry[] _dependencyManifestEntries =
             {
-                new DependencyManifestEntry("A", "3"),
-                new DependencyManifestEntry("C", "7"),
-                new DependencyManifestEntry("B", "11")
+                new DependencyManifestEntry("A", VersionSpecificationType.MajorVersion, "3"),
+                new DependencyManifestEntry("C", VersionSpecificationType.MajorVersion, "7"),
+                new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
             };
 
         [Fact]

--- a/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
+++ b/test/Unit/DependencyManagement/InstalledDependenciesLocatorTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
         private readonly DependencyManifestEntry[] _dependencyManifestEntries =
             {
-                new DependencyManifestEntry("A", VersionSpecificationType.ExactVersion, "3"),
-                new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "11")
+                new DependencyManifestEntry("A", VersionSpecificationType.ExactVersion, "exact version of A"),
+                new DependencyManifestEntry("B", VersionSpecificationType.MajorVersion, "major version of B")
             };
 
         [Fact]
@@ -40,9 +40,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
-            // No 11.* version for module B detected!
-            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(true);
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new string[0]);
+            // No version for module B detected!
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "exact version of A")).Returns(true);
+            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "major version of B")).Returns(new string[0]);
 
             var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
@@ -60,8 +60,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
             // The specified module A version is not installed
-            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(false);
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new [] { "11.8.0.2" });
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "exact version of A")).Returns(false);
+            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "major version of B")).Returns(new [] { "exact version of B" });
 
             var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();
@@ -78,8 +78,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
             _mockStorage.Setup(_ => _.GetDependencies()).Returns(_dependencyManifestEntries);
 
-            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "3")).Returns(true);
-            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "11")).Returns(new [] { "11.8.0.2" });
+            _mockStorage.Setup(_ => _.IsModuleVersionInstalled("s3", "A", "exact version of A")).Returns(true);
+            _mockStorage.Setup(_ => _.GetInstalledModuleVersions("s3", "B", "major version of B")).Returns(new [] { "exact version of B" });
 
             var installedDependenciesLocator = new InstalledDependenciesLocator(_mockStorage.Object);
             var result = installedDependenciesLocator.GetPathWithAcceptableDependencyVersionsInstalled();


### PR DESCRIPTION
Allow specifying exact module versions in `requirements.psd1`, in addition to the `<MajorVersion>.*` pattern. Addressing https://github.com/Azure/azure-functions-powershell-worker/issues/256.