### PR TITLE
Managed Dependencies: handle paginated PSGallery response

### DIFF
--- a/src/DependencyManagement/IPowerShellGallerySearchInvoker.cs
+++ b/src/DependencyManagement/IPowerShellGallerySearchInvoker.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
+{
+    using System;
+    using System.IO;
+
+    internal interface IPowerShellGallerySearchInvoker
+    {
+        Stream Invoke(Uri uri);
+    }
+}

--- a/src/DependencyManagement/PowerShellGallerySearchInvoker.cs
+++ b/src/DependencyManagement/PowerShellGallerySearchInvoker.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
+{
+    using System;
+    using System.IO;
+    using System.Net.Http;
+
+    internal class PowerShellGallerySearchInvoker : IPowerShellGallerySearchInvoker
+    {
+        public Stream Invoke(Uri uri)
+        {
+            var retryCount = 3;
+            while (true)
+            {
+                using (var client = new HttpClient())
+                {
+                    try
+                    {
+                        var response = client.GetAsync(uri).Result;
+
+                        // Throw is not a successful request
+                        response.EnsureSuccessStatusCode();
+
+                        return response.Content.ReadAsStreamAsync().Result;
+                    }
+                    catch (Exception)
+                    {
+                        if (retryCount <= 0)
+                        {
+                            throw;
+                        }
+
+                        retryCount--;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Unit/DependencyManagement/PowerShellGalleryModuleProviderTests.cs
+++ b/test/Unit/DependencyManagement/PowerShellGalleryModuleProviderTests.cs
@@ -320,28 +320,5 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 Assert.Equal("1.2.3.6", actualVersion);
             }
         }
-
-        [Theory]
-        [InlineData("Az", "0", "0.7.0")]
-        [InlineData("Az", "1", "1.8.0")]
-        [InlineData("Az", "2", "2.5.0")]
-        [InlineData("Az", "3", null)]
-        [InlineData("Az.Accounts", "0", null)]
-        [InlineData("Az.Accounts", "1", "1.6.1")]
-        [InlineData("Az.Accounts", "2", null)]
-        [InlineData("dbatools", "0", "0.9.834")]
-        [InlineData("dbatools", "1", "1.0.34")]
-        [InlineData("Pester", "0", null)]
-        [InlineData("Pester", "1", null)]
-        [InlineData("Pester", "2", null)]
-        [InlineData("Pester", "3", "3.4.6")]
-        [InlineData("Pester", "4", "4.8.1")]
-        [InlineData("Pester", "5", null)]
-        public void RetrievesLatestVersion(string moduleName, string majorVersion, string expectedVersion)
-        {
-            var moduleProvider = new PowerShellGalleryModuleProvider();
-            var actualVersion = moduleProvider.GetLatestPublishedModuleVersion(moduleName, majorVersion);
-            Assert.Equal(expectedVersion, actualVersion);
-        }
     }
 }

--- a/test/Unit/DependencyManagement/PowerShellGalleryModuleProviderTests.cs
+++ b/test/Unit/DependencyManagement/PowerShellGalleryModuleProviderTests.cs
@@ -1,0 +1,347 @@
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Moq;
+    using Xunit;
+
+    using PowerShellWorker.DependencyManagement;
+
+    public class PowerShellGalleryModuleProviderTests
+    {
+        private readonly Mock<IPowerShellGallerySearchInvoker> _mockSearchInvoker =
+            new Mock<IPowerShellGallerySearchInvoker>(MockBehavior.Strict);
+
+        [Fact]
+        public void ReturnsNullIfSearchInvokerReturnsNull()
+        {
+            _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(default(Stream));
+            var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+            var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+            Assert.Null(actualVersion);
+        }
+
+        [Fact]
+        public void ReturnsSingleVersion()
+        {
+            const string ResponseText = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.4</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Equal("1.2.3.4", actualVersion);
+            }
+        }
+
+        [Fact]
+        public void FindsLatestVersionRegardlessOfResponseOrder()
+        {
+            const string ResponseText = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.4</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.6</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.5</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Equal("1.2.3.6", actualVersion);
+            }
+        }
+
+        [Fact]
+        public void IgnoresPrereleaseVersions()
+        {
+            const string ResponseText = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.4</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.6</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">true</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.5</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Equal("1.2.3.5", actualVersion);
+            }
+        }
+
+        [Fact]
+        public void IgnoresNotMatchingMajorVersions()
+        {
+            const string ResponseText = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>0.2.3.7</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.5</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.6</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>2.2.3.7</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Equal("1.2.3.6", actualVersion);
+            }
+        }
+
+        [Theory]
+        [InlineData("0.1", "0.2")]
+        [InlineData("0.1", "0.1.0")]
+        [InlineData("0.1", "0.1.1")]
+        [InlineData("0.1.2", "0.2.1")]
+        [InlineData("0.1.0", "0.1.0.1")]
+        [InlineData("0.1.2.3", "0.1.2.4")]
+        [InlineData("0.1.2.4", "0.2.2.3")]
+        public void ComparesVersionsCorrectly(string lowerVersion, string higherVersion)
+        {
+            const string ResponseTextTemplate = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>{0}</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>{1}</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            var responseText = string.Format(ResponseTextTemplate, lowerVersion, higherVersion);
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(responseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "0");
+                Assert.Equal(higherVersion, actualVersion);
+            }
+        }
+
+        [Fact]
+        public void ReturnsNullIfNoVersionFound()
+        {
+            const string ResponseText = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+</feed>";
+
+            using (var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsAny<Uri>())).Returns(responseStream);
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Null(actualVersion);
+            }
+        }
+
+        [Fact]
+        public void FindsLatestVersionAcrossMultiplePages()
+        {
+            const string ResponseText1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <link rel=""next"" href=""https://NextLink1"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.4</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.5</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            const string ResponseText2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <link rel=""next"" href=""https://NextLink2"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.1</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.6</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            const string ResponseText3 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<feed
+    xml:base=""https://www.powershellgallery.com/api/v2""
+    xmlns=""http://www.w3.org/2005/Atom""
+    xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices""
+    xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <link rel=""self"" href=""https://www.powershellgallery.com/api/v2/Packages"" />
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.2</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+  <entry>
+    <m:properties>
+      <d:Version>1.2.3.3</d:Version>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    </m:properties>
+  </entry>
+</feed>";
+
+            using (var responseStream1 = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText1)))
+            using (var responseStream2 = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText2)))
+            using (var responseStream3 = new MemoryStream(Encoding.UTF8.GetBytes(ResponseText3)))
+            {
+                _mockSearchInvoker.Setup(_ => _.Invoke(It.IsNotIn(new Uri("https://NextLink1"), new Uri("https://NextLink2"))))
+                    .Returns(responseStream1);
+
+                _mockSearchInvoker.Setup(_ => _.Invoke(new Uri("https://NextLink1")))
+                    .Returns(responseStream2);
+
+                _mockSearchInvoker.Setup(_ => _.Invoke(new Uri("https://NextLink2")))
+                    .Returns(responseStream3);
+
+                var moduleProvider = new PowerShellGalleryModuleProvider(_mockSearchInvoker.Object);
+                var actualVersion = moduleProvider.GetLatestPublishedModuleVersion("ModuleName", "1");
+                Assert.Equal("1.2.3.6", actualVersion);
+            }
+        }
+
+        [Theory]
+        [InlineData("Az", "0", "0.7.0")]
+        [InlineData("Az", "1", "1.8.0")]
+        [InlineData("Az", "2", "2.5.0")]
+        [InlineData("Az", "3", null)]
+        [InlineData("Az.Accounts", "0", null)]
+        [InlineData("Az.Accounts", "1", "1.6.1")]
+        [InlineData("Az.Accounts", "2", null)]
+        [InlineData("dbatools", "0", "0.9.834")]
+        [InlineData("dbatools", "1", "1.0.34")]
+        [InlineData("Pester", "0", null)]
+        [InlineData("Pester", "1", null)]
+        [InlineData("Pester", "2", null)]
+        [InlineData("Pester", "3", "3.4.6")]
+        [InlineData("Pester", "4", "4.8.1")]
+        [InlineData("Pester", "5", null)]
+        public void RetrievesLatestVersion(string moduleName, string majorVersion, string expectedVersion)
+        {
+            var moduleProvider = new PowerShellGalleryModuleProvider();
+            var actualVersion = moduleProvider.GetLatestPublishedModuleVersion(moduleName, majorVersion);
+            Assert.Equal(expectedVersion, actualVersion);
+        }
+    }
+}


### PR DESCRIPTION
When a module on the PowerShell Gallery contains many (100+) versions, PowerShell Gallery API returns a limited number of entries and a link to the next page. Before this fix, PS Worker would process the first page only, failing to detect the latest version correctly in some cases. This fix makes PS Worker request and process all the subsequent pages.