### PR TITLE
Implemented "RpcHttpBodyOnly" capability

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -96,6 +96,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 StreamingMessage.ContentOneofCase.WorkerInitResponse,
                 out StatusResult status);
 
+            response.WorkerInitResponse.Capabilities.Add("RpcHttpBodyOnly", "true");
+
             // If the environment variable is set, spin up the custom named pipe server.
             // This is typically used for debugging. It will throw a friendly exception if the
             // pipe name is not a valid pipename.

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -54,15 +54,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             if (rpcHttp.Body != null)
             {
                 httpRequestContext.Body = rpcHttp.Body.ToObject();
-            }
 
-            if (rpcHttp.RawBody != null)
-            {
-                object rawBody = rpcHttp.RawBody.DataCase == TypedData.DataOneofCase.String
-                    ? rpcHttp.RawBody.String
-                    : rpcHttp.RawBody.ToObject();
-
-                httpRequestContext.RawBody = rawBody;
+                httpRequestContext.RawBody = rpcHttp.Body.DataCase == TypedData.DataOneofCase.String
+                                                ? rpcHttp.Body.String
+                                                : rpcHttp.Body.ToObject();
             }
 
             return httpRequestContext;

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -6,12 +6,11 @@
 using System;
 using System.Collections;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
+using System.Text;
 
 using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
-using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.PowerShell.Commands;
 using Newtonsoft.Json.Linq;
 
@@ -54,10 +53,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             if (rpcHttp.Body != null)
             {
                 httpRequestContext.Body = rpcHttp.Body.ToObject();
-
-                httpRequestContext.RawBody = rpcHttp.Body.DataCase == TypedData.DataOneofCase.String
-                                                ? rpcHttp.Body.String
-                                                : rpcHttp.Body.ToObject();
+                httpRequestContext.RawBody = GetRawBody(rpcHttp.Body);
             }
 
             return httpRequestContext;
@@ -91,6 +87,21 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     return null;
                 default:
                     return new InvalidOperationException("DataCase was not set.");
+            }
+        }
+
+        private static object GetRawBody(TypedData rpcHttpBody)
+        {
+            switch (rpcHttpBody.DataCase)
+            {
+                case TypedData.DataOneofCase.String:
+                    return rpcHttpBody.String;
+
+                case TypedData.DataOneofCase.Bytes:
+                    return Encoding.UTF8.GetString(rpcHttpBody.Bytes.ToByteArray());
+
+                default:
+                    return rpcHttpBody.ToObject();
             }
         }
 

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -109,14 +109,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 }
             };
 
-            var expected = new HttpRequestContext
-            {
-                Method = method,
-                Url = url,
-                Body = data,
-                RawBody = data
-            };
-
             var httpRequestContext = (HttpRequestContext)input.ToObject();
 
             Assert.Equal(httpRequestContext.Method, method);

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -8,9 +8,9 @@ using System.Collections;
 using System.IO;
 using System.Net;
 using System.Management.Automation;
+using System.Text;
 
 using Google.Protobuf;
-using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Newtonsoft.Json;
@@ -90,7 +90,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var method = "Get";
             var url = "https://example.com";
             var data = "Hello World";
-            var rawData = "{\"Foo\":\"Bar\"}";
+
+            // RawBody from the input object is not used anymore
+            // (see the "RpcHttpBodyOnly" capability for more details).
+            var rawData = "does not matter";
 
             var input = new TypedData
             {
@@ -111,17 +114,60 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
             var httpRequestContext = (HttpRequestContext)input.ToObject();
 
-            Assert.Equal(httpRequestContext.Method, method);
-            Assert.Equal(httpRequestContext.Url, url);
-            Assert.Equal(httpRequestContext.Body, data);
-
-            // RawBody from the input object is not used anymore
-            // (see the "RpcHttpBodyOnly" capability for more details).
-            Assert.Equal(httpRequestContext.RawBody, data);
-
+            Assert.Equal(method, httpRequestContext.Method);
+            Assert.Equal(url, httpRequestContext.Url);
+            Assert.Equal(data, httpRequestContext.Body);
             Assert.Empty(httpRequestContext.Headers);
             Assert.Empty(httpRequestContext.Params);
             Assert.Empty(httpRequestContext.Query);
+        }
+
+        [Fact]
+        public void TestTypedDataToObjectHttpRequestContextBodyData_String()
+        {
+            var data = "Hello World";
+
+            var input = new TypedData
+            {
+                Http = new RpcHttp
+                {
+                    Method = "Get",
+                    Url = "https://example.com",
+                    Body = new TypedData
+                    {
+                        String = data
+                    }
+                }
+            };
+
+            var httpRequestContext = (HttpRequestContext)input.ToObject();
+
+            Assert.Equal(data, httpRequestContext.Body);
+            Assert.Equal(data, httpRequestContext.RawBody);
+        }
+
+        [Fact]
+        public void TestTypedDataToObjectHttpRequestContextBodyData_Bytes()
+        {
+            var data = "Hello World";
+
+            var input = new TypedData
+            {
+                Http = new RpcHttp
+                {
+                    Method = "Get",
+                    Url = "https://example.com",
+                    Body = new TypedData
+                    {
+                        Bytes = ByteString.CopyFromUtf8(data)
+                    }
+                }
+            };
+
+            var httpRequestContext = (HttpRequestContext)input.ToObject();
+
+            Assert.Equal(Encoding.UTF8.GetBytes(data), httpRequestContext.Body);
+            Assert.Equal(data, httpRequestContext.RawBody);
         }
 
         [Fact]

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -114,7 +114,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(httpRequestContext.Method, method);
             Assert.Equal(httpRequestContext.Url, url);
             Assert.Equal(httpRequestContext.Body, data);
-            Assert.Equal(httpRequestContext.RawBody, rawData);
+
+            // RawBody from the input object is not used anymore
+            // (see the "RpcHttpBodyOnly" capability for more details).
+            Assert.Equal(httpRequestContext.RawBody, data);
+
             Assert.Empty(httpRequestContext.Headers);
             Assert.Empty(httpRequestContext.Params);
             Assert.Empty(httpRequestContext.Query);


### PR DESCRIPTION
Resolving issue https://github.com/Azure/azure-functions-powershell-worker/issues/292.

The goal is to reduce data duplication in function invocation requests, which will reduce the I/O volume between the host and the PS worker, and potentially allow larger request payloads.