### PR TITLE
Update module versions to match PS v6.2.2

### DIFF
--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,7 +1,7 @@
 @{
     # Modules bundled with the PowerShell Language Worker
     'Microsoft.PowerShell.Archive' = @{
-        Version = '1.1.0.0'
+        Version = '1.2.3.0'
         Target = 'src/Modules'
     }
     'ThreadJob' = @{
@@ -9,11 +9,11 @@
         Target = 'src/Modules'
     }
     'PowerShellGet' = @{
-        Version = '1.6.7'
+        Version = '2.1.3'
         Target = 'src/Modules'
     }
     'PackageManagement' = @{
-        Version = '1.1.7.0'
+        Version = '1.3.2'
         Target = 'src/Modules'
     }
 }


### PR DESCRIPTION
Updating module versions to match the versions shipped with PS v6.2.2: https://github.com/PowerShell/PowerShell/blob/v6.2.2/src/Modules/PSGalleryModules.csproj