### PR TITLE
Improve dependency management logs

### DIFF
--- a/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
+++ b/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
@@ -72,12 +72,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                         _dependencyManifest,
                         nextSnapshotPath,
                         pwsh,
-                        // If the new snapshot turns out to be equivalent to the latest one,
-                        // removing it helps us save storage space and avoid unnecessary worker restarts.
-                        // It is ok to do that during background upgrade because the current
+                        // Background dependency upgrades are optional because the current
                         // worker already has a good enough snapshot, and nothing depends on
-                        // the new snapshot yet.
-                        removeIfEquivalentToLatest: true,
+                        // the new snapshot yet, so installation failures will not affect
+                        // function invocations.
+                        DependencySnapshotInstallationMode.Optional,
                         logger);
                 }
 

--- a/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
+++ b/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
@@ -56,11 +56,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         {
             try
             {
-                logger.Log(
-                    isUserOnlyLog: false,
-                    RpcLog.Types.Level.Trace,
-                    PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
-
                 // Purge before installing a new snapshot, as we may be able to free some space.
                 _purger.Purge(logger);
 

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -215,13 +215,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     _dependenciesFromManifest,
                     _currentSnapshotPath,
                     pwsh,
-                    // Even if the new snapshot turns out to be equivalent to the latest one,
-                    // removing it would not be safe because the current worker already depends
-                    // on it, as it has the path to this snapshot already added to PSModulePath.
-                    // As opposed to the background upgrade case, this snapshot is *required* for
-                    // this worker to run, even though it occupies some space (until the workers
-                    // restart and the redundant snapshots are purged).
-                    removeIfEquivalentToLatest: false,
+                    // As opposed to the background upgrade case, the worker does not have an acceptable
+                    // snapshot to use yet, so the initial snapshot is *required* for this worker to run.
+                    DependencySnapshotInstallationMode.Required,
                     logger);
             }
             catch (Exception e)

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -185,6 +185,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         {
             if (AreAcceptableDependenciesAlreadyInstalled())
             {
+                logger.Log(
+                    isUserOnlyLog: false,
+                    RpcLog.Types.Level.Trace,
+                    PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
+
                 // Background installation: can't use the firstPwsh runspace because it belongs
                 // to the pool used to run functions code, so create a new runspace.
                 _nextSnapshotPath = _backgroundSnapshotMaintainer.InstallAndPurgeSnapshots(pwshFactory, logger);

--- a/src/DependencyManagement/DependencySnapshotInstallationMode.cs
+++ b/src/DependencyManagement/DependencySnapshotInstallationMode.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma warning disable 1591 // "Mixing XML comments for publicly visible type"
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
+{
+    public enum DependencySnapshotInstallationMode
+    {
+        Required,
+        Optional
+    }
+}

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -87,7 +87,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             }
             catch (Exception e)
             {
-                var message = string.Format(PowerShellWorkerStrings.FailedToInstallDependenciesSnapshot, targetPath);
+                var message = string.Format(
+                                PowerShellWorkerStrings.FailedToInstallDependenciesSnapshot,
+                                targetPath,
+                                installationMode);
+
                 logger.Log(isUserOnlyLog: false, LogLevel.Warning, message, e);
                 _storage.RemoveSnapshot(installingPath);
                 throw;

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -48,7 +48,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             logger.Log(
                 isUserOnlyLog: false,
                 LogLevel.Trace,
-                string.Format(PowerShellWorkerStrings.InstallingFunctionAppRequiredModules, installingPath));
+                string.Format(
+                    PowerShellWorkerStrings.InstallingFunctionAppRequiredModules,
+                    installingPath,
+                    installationMode));
 
             try
             {

--- a/src/DependencyManagement/IDependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/IDependencySnapshotInstaller.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             IEnumerable<DependencyManifestEntry> dependencies,
             string targetPath,
             PowerShell pwsh,
-            bool removeIfEquivalentToLatest,
+            DependencySnapshotInstallationMode installationMode,
             ILogger logger);
     }
 }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -269,7 +269,7 @@
     <value>Removing dependency snapshot '{0}' because it is equivalent to '{1}'.</value>
   </data>
   <data name="PromotedDependencySnapshot" xml:space="preserve">
-    <value>Promoted dependency snapshot '{0}' to '{1}'.</value>
+    <value>Promoted dependency snapshot '{0}' to '{1}' (installation mode: {2}).</value>
   </data>
   <data name="LookingForNewerDependencySnapshot" xml:space="preserve">
     <value>Looking for a dependency snapshot newer than {0}.</value>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -200,7 +200,7 @@
     <value>Failed to resolve '{0}' path in App Service.</value>
   </data>
   <data name="InstallingFunctionAppRequiredModules" xml:space="preserve">
-    <value>Installing function app required modules to '{0}'.</value>
+    <value>Installing function app required modules to '{0}' (installation mode: {1}).</value>
   </data>
   <data name="LogConcurrencyUpperBound" xml:space="preserve">
     <value>The enforced concurrency level (pool size limit) is '{0}'.</value>
@@ -257,7 +257,7 @@
     <value>Updating dependencies folder heartbeat for '{0}''.</value>
   </data>
   <data name="FailedToInstallDependenciesSnapshot" xml:space="preserve">
-    <value>Failed to install dependencies into '{0}', removing the folder.</value>
+    <value>Failed to install dependencies into '{0}' (installation mode: {1}), removing the folder.</value>
   </data>
   <data name="TooManyDependencies" xml:space="preserve">
     <value>The number of entries in the '{0}' file is {1}, which exceeds the maximum supported number of entries ({2}).</value>

--- a/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
+++ b/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                         It.IsAny<DependencyManifestEntry[]>(),
                         It.IsAny<string>(),
                         It.IsAny<PowerShell>(),
-                        It.IsAny<bool>(),
+                        It.IsAny<DependencySnapshotInstallationMode>(),
                         It.IsAny<ILogger>()));
 
             using (var dummyPowerShell = PowerShell.Create())
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
                 // ReSharper disable once AccessToDisposedClosure
                 _mockInstaller.Verify(
-                    _ => _.InstallSnapshot(_dependencyManifest, "new snapshot path", dummyPowerShell, true, _mockLogger.Object),
+                    _ => _.InstallSnapshot(_dependencyManifest, "new snapshot path", dummyPowerShell, DependencySnapshotInstallationMode.Optional, _mockLogger.Object),
                     Times.Once);
 
                 _mockPurger.Verify(_ => _.Purge(_mockLogger.Object), Times.Exactly(2));
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                         It.IsAny<DependencyManifestEntry[]>(),
                         It.IsAny<string>(),
                         It.IsAny<PowerShell>(),
-                        It.IsAny<bool>(),
+                        It.IsAny<DependencySnapshotInstallationMode>(),
                         It.IsAny<ILogger>()))
                 .Throws(injectedException);
 

--- a/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
+++ b/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
@@ -71,14 +71,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
                 _mockPurger.Verify(_ => _.Purge(_mockLogger.Object), Times.Exactly(2));
             }
-
-            _mockLogger.Verify(
-                _ => _.Log(
-                    false,
-                    LogLevel.Trace,
-                    It.Is<string>(message => message.Contains(PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled)),
-                    It.IsAny<Exception>()),
-                Times.Once);
         }
 
         [Fact]
@@ -97,14 +89,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
                 _mockPurger.Verify(_ => _.Purge(_mockLogger.Object), Times.Once);
             }
-
-            _mockLogger.Verify(
-                _ => _.Log(
-                    false,
-                    LogLevel.Trace,
-                    It.Is<string>(message => message.Contains(PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled)),
-                    It.IsAny<Exception>()),
-                Times.Once);
         }
 
         [Fact]

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                         Assert.Contains(currentAttempt, relevantLogs[index]);
                     }
 
-                    Assert.Matches("Warning: Failed to install dependencies into '(.+?)', removing the folder", relevantLogs[4]);
+                    Assert.Matches("Warning: Failed to install dependencies into '(.+?)'", relevantLogs[4]);
 
                     // Lastly, DependencyError should get set after unsuccessfully retrying 3 times.
                     Assert.NotNull(dependencyError);

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -184,6 +184,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     _ => _.InstallAndPurgeSnapshots(powerShellFactory, _mockLogger.Object),
                     Times.Once);
             }
+
+            _mockLogger.Verify(
+                _ => _.Log(
+                    false,
+                    LogLevel.Trace,
+                    It.Is<string>(message => message.Contains(PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled)),
+                    It.IsAny<Exception>()),
+                Times.Once);
         }
 
         [Fact]

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                         "NewSnapshot",
                         // Must run on the same runspace
                         It.Is<PowerShell>(powerShell => ReferenceEquals(firstPowerShellRunspace, powerShell)),
-                        false, // removeIfEquivalentToLatest
+                        DependencySnapshotInstallationMode.Required,
                         _mockLogger.Object));
 
             _mockStorage.Setup(_ => _.SnapshotExists("NewSnapshot")).Returns(false);
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                         "NewSnapshot",
                         // Must run on the same runspace
                         It.Is<PowerShell>(powerShell => ReferenceEquals(firstPowerShellRunspace, powerShell)),
-                        false, // removeIfEquivalentToLatest
+                        DependencySnapshotInstallationMode.Required,
                         _mockLogger.Object));
 
             _mockStorage.Setup(_ => _.SnapshotExists("NewSnapshot")).Returns(false);
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                             It.IsAny<IEnumerable<DependencyManifestEntry>>(),
                             It.IsAny<string>(),
                             It.IsAny<PowerShell>(),
-                            It.IsAny<bool>(),
+                            It.IsAny<DependencySnapshotInstallationMode>(),
                             It.IsAny<ILogger>()))
                     .Throws(injectedException);
 
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                     It.IsAny<IEnumerable<DependencyManifestEntry>>(),
                     It.IsAny<string>(),
                     It.IsAny<PowerShell>(),
-                    It.IsAny<bool>(),
+                    It.IsAny<DependencySnapshotInstallationMode>(),
                     It.IsAny<ILogger>()),
                 Times.Once());
 


### PR DESCRIPTION
Improve dependency management logs:
- For every dependency snapshot installation start, success, or failure event, log the installation mode as well ("Required" vs. "Optional").
- Log AcceptableFunctionAppDependenciesAlreadyInstalled just once on worker start, no need to repeat it later.