### PR TITLE
Log CommandNotFoundException raised by function code

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 {
                     if (e is CommandNotFoundException commandNotFound)
                     {
-                        _logger.Log(isUserOnlyLog: false, LogLevel.Warning, "Command not found");
+                        _logger.Log(isUserOnlyLog: false, LogLevel.Warning, PowerShellWorkerStrings.CommandNotFoundException_Exception);
                     }
 
                     Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(e));

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -253,6 +253,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
                 catch (RuntimeException e)
                 {
+                    if (e is CommandNotFoundException commandNotFound)
+                    {
+                        _logger.Log(isUserOnlyLog: false, LogLevel.Warning, "Command not found");
+                    }
+
                     Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(e));
                     throw;
                 }

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                 }
                 catch (RuntimeException e)
                 {
-                    if (e is CommandNotFoundException commandNotFound)
+                    if (e.ErrorRecord.FullyQualifiedErrorId == "CommandNotFoundException")
                     {
                         _logger.Log(isUserOnlyLog: false, LogLevel.Warning, PowerShellWorkerStrings.CommandNotFoundException_Exception);
                     }

--- a/src/PowerShell/StreamHandler.cs
+++ b/src/PowerShell/StreamHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             {
                 if (record.FullyQualifiedErrorId == "CommandNotFoundException")
                 {
-                    _logger.Log(isUserOnlyLog: false, LogLevel.Warning, "Command not found");
+                    _logger.Log(isUserOnlyLog: false, LogLevel.Warning, PowerShellWorkerStrings.CommandNotFoundException_Error);
                 }
 
                 _logger.Log(isUserOnlyLog: true, LogLevel.Error, $"ERROR: {_errorRecordFormatter.Format(record)}", record.Exception);

--- a/src/PowerShell/StreamHandler.cs
+++ b/src/PowerShell/StreamHandler.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if(e.ItemAdded is ErrorRecord record)
             {
+                if (record.FullyQualifiedErrorId == "CommandNotFoundException")
+                {
+                    _logger.Log(isUserOnlyLog: false, LogLevel.Warning, "Command not found");
+                }
+
                 _logger.Log(isUserOnlyLog: true, LogLevel.Error, $"ERROR: {_errorRecordFormatter.Format(record)}", record.Exception);
             }
         }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -298,4 +298,10 @@
   <data name="FailedToEnumerateDependencySnapshotContent" xml:space="preserve">
     <value>Failed to enumerate dependency snapshot '{0}' content: {1}</value>
   </data>
+  <data name="CommandNotFoundException_Error" xml:space="preserve">
+    <value>CommandNotFoundException detected (error).</value>
+  </data>
+  <data name="CommandNotFoundException_Exception" xml:space="preserve">
+    <value>CommandNotFoundException detected (exception).</value>
+  </data>
 </root>


### PR DESCRIPTION
Log just the fact of encountering CommandNotFoundException without any further detail, for monitoring purposes.