### PR TITLE
[Durable Functions] Clean up Durable programming model

### DIFF
--- a/docs/designs/PowerShell-AzF-Overall-Design.md
+++ b/docs/designs/PowerShell-AzF-Overall-Design.md
@@ -549,17 +549,17 @@ We had a prototype of Durable Functions in PowerShell worker to enable the '_Fun
 2. Make the orchestrator function able to be stopped at certain point safely.
 3. Make the PowerShell worker able to replay an orchestrator function, namely skipping the actions that are done in previous runs/replays based on the save logs.
 
-They were solved by introducing the new cmdlet "_Invoke-ActivityFunctionAsync_" plus having the worker invoke the orchestrator function with the async PowerShell API.
+They were solved by introducing the new cmdlet "_Invoke-ActivityFunction_" plus having the worker invoke the orchestrator function with the async PowerShell API.
 
 Internally, the worker shares context information with the cmdlet, including _the existing saved logs_ sent from the host about the running orchestrator function and _a wait handler_ - let's call it A - which the cmdlet will set after it triggers an activity function. The async API used to start the orchestrator function returns _another wait handler_ - let's call it B - which will be set when the invocation finishes. Then the invoking thread will call '_WaitHandler.WaitAny_' on those two wait handlers.
 
 - If the call to '_WaitAny_' returns because the wait handler A was set, then that means an activity function was just triggered, and the orchestrator function should be stopped now (it will be triggered again later after the activity function finishes). So, in this case, the invoking thread will stop the orchestrator function that is running asynchronously.
 - If the call to '_WaitAny_' returns because the wait handler B was set, then that means the orchestrator function has run to its completion.
 
-The cmdlet '_Invoke-ActivityFunctionAsync_' has the following syntax, the '_-FunctionName_' being the name of the activity function to invoke and '_-Input_' being the argument to the activity function.
+The cmdlet '_Invoke-ActivityFunction_' has the following syntax, the '_-FunctionName_' being the name of the activity function to invoke and '_-Input_' being the argument to the activity function.
 
 ```powershell
-Invoke-ActivityFunctionAsync [-FunctionName] <string> [[-Input] <Object>] [<CommonParameters>]
+Invoke-ActivityFunction [-FunctionName] <string> [[-Input] <Object>] [<CommonParameters>]
 ```
 
 When it's invoked to trigger an activity function, it first checks the existing logs shared by the worker to see if this invocation of the activity function has already done previously. If so, the cmdlet simply returns the result. If not, the cmdlet will
@@ -568,7 +568,7 @@ When it's invoked to trigger an activity function, it first checks the existing 
 - set the wait handler shared by the worker to notify the worker that the activity function is triggered;
 - wait on a private wait handler that will only be set when the '_StopProcessing_' method of the cmdlet is called. That method gets called only when the pipeline where this cmdlet is running in is being stopped.
 
-The third step is very important in this stop-and-replay model of Durable Functions, because when stopping an invocation that is running asynchronously, we don't want that to interrupt arbitrary code execution that is happening in the pipeline. By having the cmdlet '_Invoke-ActivityFunctionAsync_' wait for '_StopProcessing_' to be called, we know for sure that the pipeline execution pauses at a safe place, ready for being stopped by the invoking thread.
+The third step is very important in this stop-and-replay model of Durable Functions, because when stopping an invocation that is running asynchronously, we don't want that to interrupt arbitrary code execution that is happening in the pipeline. By having the cmdlet '_Invoke-ActivityFunction_' wait for '_StopProcessing_' to be called, we know for sure that the pipeline execution pauses at a safe place, ready for being stopped by the invoking thread.
 
 The following is an example of PowerShell Durable Function that runs in the Function Chaining pattern:
 
@@ -581,9 +581,9 @@ param($context)
 
 $output = @()
 
-$output += Invoke-ActivityFunctionAsync -FunctionName "E1_SayHello" -Input "Tokyo"
-$output += Invoke-ActivityFunctionAsync -FunctionName "E1_SayHello" -Input "Seattle"
-$output += Invoke-ActivityFunctionAsync -FunctionName "E1_SayHello" -Input "London"
+$output += Invoke-ActivityFunction -FunctionName "E1_SayHello" -Input "Tokyo"
+$output += Invoke-ActivityFunction -FunctionName "E1_SayHello" -Input "Seattle"
+$output += Invoke-ActivityFunction -FunctionName "E1_SayHello" -Input "London"
 
 return $output
 ```

--- a/examples/durable/FunctionChainingApp/HttpTrigger/function.json
+++ b/examples/durable/FunctionChainingApp/HttpTrigger/function.json
@@ -18,11 +18,6 @@
     {
       "name": "starter",
       "type": "orchestrationClient",
-      "direction": "out"
-    },    
-    {
-      "name": "orchestrationClientIn",
-      "type": "orchestrationClient",
       "direction": "in"
     }    
   ]

--- a/examples/durable/FunctionChainingApp/HttpTrigger/run.ps1
+++ b/examples/durable/FunctionChainingApp/HttpTrigger/run.ps1
@@ -1,17 +1,13 @@
 using namespace System.Net
 
-param($Request, $TriggerMetadata, $orchestrationClientIn)
+param($Request, $TriggerMetadata)
 
 Write-Host "HttpTrigger started"
 
 $InstanceId = Start-NewOrchestration -FunctionName 'MyOrchestrator' -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse `
-                -Request $Request `
-                -OrchestrationClientData $orchestrationClientIn `
-                -InstanceId $InstanceId
-
+$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "HttpTrigger completed"

--- a/examples/durable/FunctionChainingApp/MyOrchestrator/run.ps1
+++ b/examples/durable/FunctionChainingApp/MyOrchestrator/run.ps1
@@ -6,9 +6,9 @@ Write-Host "MyOrchestrator: started. Input: $($Context.Input)"
 
 $output = @()
 
-$output += Invoke-ActivityFunctionAsync -FunctionName "SayHello" -Input "Tokyo"
-$output += Invoke-ActivityFunctionAsync -FunctionName "SayHello" -Input "Seattle" -Verbose
-$output += Invoke-ActivityFunctionAsync -FunctionName "SayHello" -Input "London" -Verbose
+$output += Invoke-ActivityFunction -FunctionName "SayHello" -Input "Tokyo"
+$output += Invoke-ActivityFunction -FunctionName "SayHello" -Input "Seattle"
+$output += Invoke-ActivityFunction -FunctionName "SayHello" -Input "London"
 
 Write-Host "MyOrchestrator: finished."
 

--- a/examples/durable/FunctionChainingApp/requirements.psd1
+++ b/examples/durable/FunctionChainingApp/requirements.psd1
@@ -1,0 +1,5 @@
+# This file enables modules to be automatically managed by the Functions service.
+# See https://aka.ms/functionsmanageddependency for additional information.
+#
+@{
+}

--- a/examples/durable/LongRunningHttpApp/HttpTrigger/function.json
+++ b/examples/durable/LongRunningHttpApp/HttpTrigger/function.json
@@ -18,11 +18,6 @@
     {
       "name": "starter",
       "type": "orchestrationClient",
-      "direction": "out"
-    },    
-    {
-      "name": "orchestrationClientIn",
-      "type": "orchestrationClient",
       "direction": "in"
     }    
   ]

--- a/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
+++ b/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
@@ -1,18 +1,13 @@
 using namespace System.Net
 
-param($Request, $TriggerMetadata, $orchestrationClientIn)
+param($Request, $TriggerMetadata)
 
 Write-Host "HttpTrigger started"
 
 $InstanceId = Start-NewOrchestration -FunctionName 'MyOrchestrator' -InputObject $Request.Query
-
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse `
-                -Request $Request `
-                -OrchestrationClientData $orchestrationClientIn `
-                -InstanceId $InstanceId
-
+$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "HttpTrigger completed"

--- a/examples/durable/LongRunningHttpApp/MyOrchestrator/run.ps1
+++ b/examples/durable/LongRunningHttpApp/MyOrchestrator/run.ps1
@@ -2,7 +2,7 @@ param($Context)
 
 Write-Host "MyOrchestrator: started. Input: $($Context.Input)"
 
-$activityResult = Invoke-ActivityFunctionAsync -FunctionName "LongRunningActivity" -Input $Context.Input
+$activityResult = Invoke-ActivityFunction -FunctionName "LongRunningActivity" -Input $Context.Input
 Write-Host "MyOrchestrator: Returned from LongRunningActivity: '$activityResult'"
 
 Write-Host "MyOrchestrator: finished."

--- a/examples/durable/LongRunningHttpApp/requirements.psd1
+++ b/examples/durable/LongRunningHttpApp/requirements.psd1
@@ -1,0 +1,5 @@
+# This file enables modules to be automatically managed by the Functions service.
+# See https://aka.ms/functionsmanageddependency for additional information.
+#
+@{
+}

--- a/src/Durable/InvokeActivityFunctionCommand.cs
+++ b/src/Durable/InvokeActivityFunctionCommand.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 
     /// <summary>
-    /// Invoke a function asynchronously.
+    /// Invoke an activity function.
     /// </summary>
-    [Cmdlet("Invoke", "ActivityFunctionAsync")]
+    [Cmdlet("Invoke", "ActivityFunction")]
     public class InvokeActivityFunctionCommand : PSCmdlet
     {
         /// <summary>

--- a/src/Durable/SetFunctionInvocationContext.cs
+++ b/src/Durable/SetFunctionInvocationContext.cs
@@ -17,16 +17,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     public class SetFunctionInvocationContextCommand : PSCmdlet
     {
         internal const string ContextKey = "OrchestrationContext";
-        private const string StarterKey = "OrchestrationStarter";
+        private const string OrchestrationClientKey = "OrchestrationClient";
 
         [Parameter(Mandatory = true, ParameterSetName = ContextKey)]
         public OrchestrationContext OrchestrationContext { get; set; }
 
         /// <summary>
-        /// The orchestration client output binding name.
+        /// The orchestration client.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = StarterKey)]
-        public string OrchestrationStarter { get; set; }
+        [Parameter(Mandatory = true, ParameterSetName = OrchestrationClientKey)]
+        public object OrchestrationClient { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = "Clear")]
         public SwitchParameter Clear { get; set; }
@@ -40,15 +40,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     privateData[ContextKey] = OrchestrationContext;
                     break;
 
-                case StarterKey:
-                    privateData[StarterKey] = OrchestrationStarter;
+                case OrchestrationClientKey:
+                    privateData[OrchestrationClientKey] = OrchestrationClient;
                     break;
 
                 default:
                     if (Clear.IsPresent)
                     {
                         privateData.Remove(ContextKey);
-                        privateData.Remove(StarterKey);
+                        privateData.Remove(OrchestrationClientKey);
                     }
                     break;
             }

--- a/src/FunctionInfo.cs
+++ b/src/FunctionInfo.cs
@@ -96,20 +96,22 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     Type = GetAzFunctionType(bindingInfo);
                     inputBindings.Add(bindingName, bindingInfo);
 
+                    var isOrchestrationClient = string.Compare(bindingInfo.Type, OrchestrationClient, StringComparison.OrdinalIgnoreCase) == 0;
+                    if (isOrchestrationClient)
+                    {
+                        OrchestrationClientBindingName = bindingName;
+                    }
+
                     // If the input binding name is in the set, we remove it;
                     // otherwise, the binding name is missing from the params.
-                    if (!parametersCopy.Remove(bindingName))
+                    if (!parametersCopy.Remove(bindingName)
+                        && !isOrchestrationClient) // but don't require a parameter declaration for orchestration client
                     {
                         inputsMissingFromParams.Add(bindingName);
                     }
                 }
                 else if (bindingInfo.Direction == BindingInfo.Types.Direction.Out)
                 {
-                    if (bindingInfo.Type == OrchestrationClient)
-                    {
-                        OrchestrationClientBindingName = bindingName;
-                    }
-                    
                     outputBindings.Add(bindingName, bindingInfo);
                 }
                 else

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -51,7 +51,7 @@ NestedModules = @('Microsoft.Azure.Functions.PowerShellWorker.psm1', 'Microsoft.
 FunctionsToExport = @('Start-NewOrchestration', 'New-OrchestrationCheckStatusResponse')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @('Push-OutputBinding', 'Get-OutputBinding', 'Trace-PipelineObject', 'Set-FunctionInvocationContext', 'Invoke-ActivityFunctionAsync')
+CmdletsToExport = @('Push-OutputBinding', 'Get-OutputBinding', 'Trace-PipelineObject', 'Set-FunctionInvocationContext', 'Invoke-ActivityFunction')
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -11,7 +11,9 @@ function CheckIfDurableFunctionsEnabled {
 
 function GetOrchestrationClientFromModulePrivateData {
     $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData
-    $PrivateData['OrchestrationClient']
+    if ($PrivateData) {
+        $PrivateData['OrchestrationClient']
+    }
 }
 
 <#

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -9,20 +9,25 @@ function CheckIfDurableFunctionsEnabled {
 	}
 }
 
+function GetOrchestrationClientFromModulePrivateData {
+    $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData
+    $PrivateData['OrchestrationClient']
+}
+
 <#
 .SYNOPSIS
     Start an orchestration Azure Function.
 .DESCRIPTION
     Start an orchestration Azure Function with the given function name and input value.
-    It requires an output binding of the type 'orchestrationClient' is defined for the caller Azure Function.
-    If no such output binding is defined, this function throws an exception.
 .EXAMPLE
-    PS > Start-NewOrchestration -FunctionName starter -InputObject "input value for the orchestration function"
+    PS > Start-NewOrchestration -OrchestrationClient Starter -FunctionName OrchestratorFunction -InputObject "input value for the orchestration function"
     Return the instance id of the new orchestration.
 .PARAMETER FunctionName
     The name of the orchestration Azure Function you want to start.
 .PARAMETER InputObject
     The input value that will be passed to the orchestration Azure Function.
+.PARAMETER OrchestrationClient
+    The orchestration client object.
 #>
 function Start-NewOrchestration {
     [CmdletBinding()]
@@ -37,34 +42,31 @@ function Start-NewOrchestration {
         [Parameter(
             Position=2,
             ValueFromPipelineByPropertyName=$true)]
-        [object] $InputObject
+        [object] $InputObject,
+
+		[Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [object] $OrchestrationClient
     )
 
-	CheckIfDurableFunctionsEnabled
-
-    $privateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData
-    if ($privateData -is [hashtable])
-    {
-        $starterName = $privateData["OrchestrationStarter"]
-    }
-
-    if ($null -ne $starterName)
-    {
-        $instanceId = (New-Guid).Guid
-        $value = ,@{
-            FunctionName = $FunctionName
-            Input = $InputObject
-            InstanceId = $instanceId
+    CheckIfDurableFunctionsEnabled
+    
+    if ($null -eq $OrchestrationClient) {
+        $OrchestrationClient = GetOrchestrationClientFromModulePrivateData
+        if ($null -eq $OrchestrationClient) {
+            throw "Cannot start an orchestration function. No binding of the type 'orchestrationClient' was defined."
         }
+    }
 
-        $value = ConvertTo-Json -InputObject $value -Depth 10 -Compress
-        Push-OutputBinding -Name $starterName -Value $value
-        return $instanceId
-    }
-    else
-    {
-        throw "Cannot start an orchestration function. No output binding of the type 'orchestrationClient' was defined."
-    }
+    $InstanceId = (New-Guid).Guid
+
+    $UriTemplate = $OrchestrationClient.creationUrls.createNewInstancePostUri
+    $Uri = $UriTemplate.Replace('{functionName}', $FunctionName).Replace('[/{instanceId}]', "/$InstanceId")
+    $Body = $InputObject | ConvertTo-Json -Compress
+              
+    $null = Invoke-RestMethod -Uri $Uri -Method 'POST' -ContentType 'application/json' -Body $Body
+    
+    return $instanceId
 }
 
 function IsValidUrl([uri]$Url) {
@@ -79,16 +81,39 @@ function GetUrlOrigin([uri]$Url) {
     $fixedOriginUrl.ToString()
 }
 
-function New-OrchestrationCheckStatusResponse($Request, $OrchestrationClientData, $InstanceId) {
+function New-OrchestrationCheckStatusResponse {
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Mandatory=$true,
+            ValueFromPipelineByPropertyName=$true)]
+        [object] $Request,
+
+        [Parameter(
+            Mandatory=$true,
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $InstanceId,
+
+		[Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [object] $OrchestrationClient
+    )
     
 	CheckIfDurableFunctionsEnabled
+
+    if ($null -eq $OrchestrationClient) {
+        $OrchestrationClient = GetOrchestrationClientFromModulePrivateData
+        if ($null -eq $OrchestrationClient) {
+            throw "Cannot create orchestration check status response. No binding of the type 'orchestrationClient' was defined."
+        }
+    }
 
     [uri]$requestUrl = $Request.Url
     $requestHasValidUrl = IsValidUrl $requestUrl
     $requestUrlOrigin = GetUrlOrigin $requestUrl
     
     $httpManagementPayload = @{ }
-    foreach ($entry in $OrchestrationClientData.managementUrls.GetEnumerator()) {
+    foreach ($entry in $OrchestrationClient.managementUrls.GetEnumerator()) {
         $value = $entry.Value
     
         if ($requestHasValidUrl -and (IsValidUrl $value)) {
@@ -96,7 +121,7 @@ function New-OrchestrationCheckStatusResponse($Request, $OrchestrationClientData
             $value = $value.Replace($dataOrigin, $requestUrlOrigin)
         }
       
-        $value = $value.Replace($OrchestrationClientData.managementUrls.id, $InstanceId)
+        $value = $value.Replace($OrchestrationClient.managementUrls.id, $InstanceId)
         $httpManagementPayload.Add($entry.Name, $value)
     }
     

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -42,7 +42,7 @@ function Start-NewOrchestration {
         [string] $FunctionName,
 
         [Parameter(
-            Position=2,
+            Position=1,
             ValueFromPipelineByPropertyName=$true)]
         [object] $InputObject,
 

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -213,12 +213,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
             {
                 if (Utils.AreDurableFunctionsEnabled())
                 {
-                    // If the function has a output binding of the 'orchestrationClient' type, then we set the binding name
-                    // in the module context for the 'Start-NewOrchestration' function to use.
+                    // If the function has a binding of the 'orchestrationClient' type, then we set
+                    // the OrchestrationClient in the module context for the 'Start-NewOrchestration' function to use.
                     if (!string.IsNullOrEmpty(functionInfo.OrchestrationClientBindingName))
                     {
+                        var orchestrationClient =
+                            inputData.First(item => item.Name == functionInfo.OrchestrationClientBindingName).Data.ToObject();
+
                         _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
-                            .AddParameter("OrchestrationStarter", functionInfo.OrchestrationClientBindingName)
+                            .AddParameter("OrchestrationClient", orchestrationClient)
                             .InvokeAndClearCommands();
                         hasSetInvocationContext = true;
                     }


### PR DESCRIPTION
Clean up Durable programming model:

- Expect `orchestrationClient` to be an input binding instead of an output binding, for consistency with other languages.
- Rename `Invoke-ActivityFunctionAsync` to `Invoke-ActivityFunction`.
- Don't require orchestration client data to be explicitly passed as a parameter.
- Tolerate different casing of `orchestrationClient` in function.json.