### PR TITLE
v2.x branch setup

### DIFF
--- a/PowerShellWorker.Common.props
+++ b/PowerShellWorker.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <BuildNumber Condition="$(APPVEYOR) != ''">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition="$(APPVEYOR) == ''">$([System.DateTime]::Now.ToString(`MMdd`))</BuildNumber>
-    <Version>1.0.$(BuildNumber)</Version>
+    <Version>2.0.$(BuildNumber)</Version>
     <PackageTags>PowerShell;AzureFunctions;language;Azure;</PackageTags>
     <PackageLicenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with any additional questions or comments.
 
 ### Prereqs
 
-* [.NET 2.1 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
+* [.NET 2.2 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
 
 ### Build
 
@@ -115,12 +115,12 @@ of your test functions app.
 
 Then copy the `publish` directory to `workers`:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.1/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.2/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.2/workers/powershell"
 ```
 
 Then you can start the host but running:
 ```sh
-dotnet ./src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/Microsoft.Azure.WebJobs.Script.WebHost.dll
+dotnet ./src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.2/Microsoft.Azure.WebJobs.Script.WebHost.dll
 ```
 
 > Note: Remember to remove `"AzureWebJobsScriptRoot"`
@@ -142,6 +142,6 @@ That will place a `Microsoft.Azure.Functions.PowerShellWorker.*.nupkg` in:
 
 It pulls the contents of the publish folder in:
 
-`azure-functions-powershell-worker/src/bin/Debug/netcoreapp2.1/publish`
+`azure-functions-powershell-worker/src/bin/Debug/netcoreapp2.2/publish`
 
 if you specify a different Configuration or TargetFramework that will be honored.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 |Branch|Status|
 |---|---|
-|master|[![master-build-status][]][master-build-site]|
-|dev|[![dev-build-status][]][dev-build-site]|
+|v2.x|[![v2.x-build-status][]][v2.x-build-site]|
 
 [azure-functions-logo]: https://raw.githubusercontent.com/Azure/azure-functions-cli/master/src/Azure.Functions.Cli/npm/assets/azure-functions-logo-color-raster.png
-[master-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=master&svg=true
-[dev-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=dev&svg=true
-[master-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=master
-[dev-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=dev
+[v2.x-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=v2.x&svg=true
+[v2.x-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=v2.x
 
 # Azure Functions PowerShell Language Worker
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,7 @@ pull_requests:
 
 branches:
   only:
-  - dev
-  - master
+  - v2.x
 
 image:
 - Ubuntu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 2.0.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -16,7 +16,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <projectUrl>https://github.com/Azure/azure-functions-powershell-worker</projectUrl>
     <icon>images\Powershell_black_64.png</icon>
     <description>The Azure Function PowerShell Language Worker allows users to write Azure Function Apps using PowerShell. It leverages the PowerShell Core SDK.</description>
-    <releaseNotes># 1.0.0
+    <releaseNotes># 2.0.0
 
     Initial Release</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -29,7 +29,7 @@ function Find-Dotnet
             $env:PATH = $LocalDotnetDirPath + [IO.Path]::PathSeparator + $env:PATH
         }
         else {
-            throw "Cannot find the dotnet SDK for .NET Core 2.1. Please specify '-Bootstrap' to install build dependencies."
+            throw "Cannot find the dotnet SDK for .NET Core 2.2. Please specify '-Bootstrap' to install build dependencies."
         }
     }
 }

--- a/tools/protobuf.tools.csproj
+++ b/tools/protobuf.tools.csproj
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <NoBuild>true</NoBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
- Bump the worker major version to 2 to align with Functions runtime releases.
- Enable appveyor on the v2.x branch.
- Make everything refer to .NET Core 2.2.