### PR TITLE
Change PS Worker version to 3

### DIFF
--- a/PowerShellWorker.Common.props
+++ b/PowerShellWorker.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <BuildNumber Condition="$(APPVEYOR) != ''">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition="$(APPVEYOR) == ''">$([System.DateTime]::Now.ToString(`MMdd`))</BuildNumber>
-    <Version>1.0.$(BuildNumber)</Version>
+    <Version>3.0.$(BuildNumber)</Version>
     <PackageTags>PowerShell;AzureFunctions;language;Azure;</PackageTags>
     <PackageLicenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 3.0.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -16,7 +16,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <projectUrl>https://github.com/Azure/azure-functions-powershell-worker</projectUrl>
     <icon>images\Powershell_black_64.png</icon>
     <description>The Azure Function PowerShell Language Worker allows users to write Azure Function Apps using PowerShell. It leverages the PowerShell Core SDK.</description>
-    <releaseNotes># 1.0.0
+    <releaseNotes># 3.0.0
 
     Initial Release</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>


### PR DESCRIPTION
We are planning to release PowerShell Worker for Functions v3 from branches based on the **dev** branch, so setting the worker version to 3 to match Functions version numbers.