### PR TITLE
v3/ps7 branch setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 |Branch|Status|
 |---|---|
-|master|[![master-build-status][]][master-build-site]|
-|dev|[![dev-build-status][]][dev-build-site]|
+|v3.x/ps7|[![v3.x-ps7-build-status][]][v3.x-ps7-build-site]|
 
 [azure-functions-logo]: https://raw.githubusercontent.com/Azure/azure-functions-cli/master/src/Azure.Functions.Cli/npm/assets/azure-functions-logo-color-raster.png
-[master-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=master&svg=true
-[dev-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=dev&svg=true
-[master-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=master
-[dev-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=dev
+[v3.x-ps7-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=v3.x/ps7&svg=true
+[v3.x-ps7-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=v3.x/ps7
 
 # Azure Functions PowerShell Language Worker
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,7 @@ pull_requests:
 
 branches:
   only:
-  - dev
-  - master
+  - v3.x/ps7
 
 image:
 - Ubuntu

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -5,10 +5,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.Azure.Functions.PowerShellWorker</id>
+    <id>Microsoft.Azure.Functions.PowerShellWorker.PS7</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
-    <title>Azure Function PowerShell Language Worker</title>
+    <title>Azure Function PowerShell Language Worker (PowerShell 7)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Setting up a PowerShell Worker build that will be used for Functions v3 and PowerShell 7.
This PR just sets up a separate build, not actually migrating to PS7 yet.