### PR TITLE
Return dev branch build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 |Branch|Status|
 |---|---|
+|dev|[![dev-build-status][]][dev-build-site]|
 |v3.x/ps7|[![v3.x-ps7-build-status][]][v3.x-ps7-build-site]|
 
 [azure-functions-logo]: https://raw.githubusercontent.com/Azure/azure-functions-cli/master/src/Azure.Functions.Cli/npm/assets/azure-functions-logo-color-raster.png
+[dev-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=dev&svg=true
+[dev-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=dev
 [v3.x-ps7-build-status]: https://ci.appveyor.com/api/projects/status/github/Azure/azure-functions-powershell-worker?branch=v3.x/ps7&svg=true
 [v3.x-ps7-build-site]: https://ci.appveyor.com/project/appsvc/azure-functions-powershell-worker?branch=v3.x/ps7
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ pull_requests:
 
 branches:
   only:
+  - dev
   - v3.x/ps7
 
 image:


### PR DESCRIPTION
We want to be able to keep `dev` and `v3.x/ps7` branches in sync with each other by using simple fast-forward merges (in the same way as we did with `dev` and `master` before), so we keep the history clean. In order to do that, we'll need to have both `dev` and `v3.x/ps7` builds here.