### PR TITLE
Migrate PowerShell worker to PowerShell 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ On macOS if you installed via `brew`
 
 Copy the result of the `publish` directory into a `powershell` folder under `workers`:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.1/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp3.1/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
 ```
 
 > NOTE: if the powershell folder already exists, you should delete it or debugging won't work.
@@ -118,12 +118,12 @@ of your test functions app.
 
 Then copy the `publish` directory to `workers`:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp2.1/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/netcoreapp3.1/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp3.1/workers/powershell"
 ```
 
 Then you can start the host but running:
 ```sh
-dotnet ./src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/Microsoft.Azure.WebJobs.Script.WebHost.dll
+dotnet ./src/WebJobs.Script.WebHost/bin/Debug/netcoreapp3.1/Microsoft.Azure.WebJobs.Script.WebHost.dll
 ```
 
 > Note: Remember to remove `"AzureWebJobsScriptRoot"`
@@ -145,6 +145,6 @@ That will place a `Microsoft.Azure.Functions.PowerShellWorker.*.nupkg` in:
 
 It pulls the contents of the publish folder in:
 
-`azure-functions-powershell-worker/src/bin/Debug/netcoreapp2.1/publish`
+`azure-functions-powershell-worker/src/bin/Debug/netcoreapp3.1/publish`
 
 if you specify a different Configuration or TargetFramework that will be honored.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Please feel free to leave comments about any of the features and design patterns
 
 ## Overview
 
-PowerShell support for Functions is based on [PowerShell Core 6.1](https://github.com/powershell/powershell),
+PowerShell support for Functions is based on [PowerShell Core 7](https://github.com/powershell/powershell),
 [Functions on Linux](https://blogs.msdn.microsoft.com/appserviceteam/2017/11/15/functions-on-linux-preview/),
-and the [Azure Functions runtime V2](https://docs.microsoft.com/en-us/azure/azure-functions/functions-versions).
+and the [Azure Functions runtime V3](https://docs.microsoft.com/en-us/azure/azure-functions/functions-versions).
 
 ## What's available?
 
@@ -49,7 +49,7 @@ with any additional questions or comments.
 
 ### Prereqs
 
-* [.NET 2.1 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
+* [.NET 3.1 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
 
 ### Build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ branches:
 
 image:
 - Ubuntu
-- Visual Studio 2017
+- Visual Studio 2019
 
 max_jobs: 1
 

--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -35,7 +35,7 @@ steps:
 
 - pwsh: |
       $null = New-Item -Path ./E2ETestArtifacts -ItemType Directory -Force
-      Compress-Archive -Path ./src/bin/Release/netcoreapp2.1/publish/* -DestinationPath ./E2ETestArtifacts/powershellworker.zip -Verbose
+      Compress-Archive -Path ./src/bin/Release/netcoreapp3.1/publish/* -DestinationPath ./E2ETestArtifacts/powershellworker.zip -Verbose
       Compress-Archive -Path ./test/E2E/TestFunctionApp/* -DestinationPath ./E2ETestArtifacts/e2etestspowershell.zip -Verbose
   displayName: 'Create test app zip file'
 

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
@@ -5,7 +5,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\PowerShellWorker.Common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
   <ItemGroup>
     <PackageReference Include="Grpc.Core" Version="1.20.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.2" />
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   <Import Project="..\PowerShellWorker.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <Product>Azure Function PowerShell Language Worker</Product>
     <AssemblyName>Microsoft.Azure.Functions.PowerShellWorker</AssemblyName>

--- a/src/PowerShell/ErrorRecordFormatter.cs
+++ b/src/PowerShell/ErrorRecordFormatter.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         /// </summary>
         public string Format(ErrorRecord errorRecord, int maxSize = 1 * 1024 * 1024)
         {
+            _pwsh.AddScript("$ErrorView = 'NormalView'").InvokeAndClearCommands();
             var errorDetails = _pwsh.AddCommand("Microsoft.PowerShell.Utility\\Out-String")
                                     .AddParameter("InputObject", errorRecord)
                                     .InvokeAndClearCommands<string>();

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,19 +1,19 @@
 @{
     # Modules bundled with the PowerShell Language Worker
     'Microsoft.PowerShell.Archive' = @{
-        Version = '1.2.3.0'
+        Version = '1.2.4.0'
         Target = 'src/Modules'
     }
     'ThreadJob' = @{
-        Version = '1.1.2'
+        Version = '2.0.3'
         Target = 'src/Modules'
     }
     'PowerShellGet' = @{
-        Version = '2.1.3'
+        Version = '2.2.3'
         Target = 'src/Modules'
     }
     'PackageManagement' = @{
-        Version = '1.3.2'
+        Version = '1.4.6'
         Target = 'src/Modules'
     }
 }

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -41,7 +41,7 @@ Write-Host "Copying azure-functions-powershell-worker to Functions Host workers 
 
 $configuration = if ($env:CONFIGURATION) { $env:CONFIGURATION } else { 'Debug' }
 Remove-Item -Recurse -Force -Path "$FUNC_CLI_DIRECTORY/workers/powershell"
-Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp2.1/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
+Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp3.1/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
 
 Write-Host "Staring Functions Host..."
 

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\PowerShellWorker.Common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -7,7 +7,7 @@ using namespace System.Runtime.InteropServices
 
 $IsWindowsEnv = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows)
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
-$MinimalSDKVersion = '2.2.0'
+$MinimalSDKVersion = '3.1.1'
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
 
 function Find-Dotnet
@@ -29,7 +29,7 @@ function Find-Dotnet
             $env:PATH = $LocalDotnetDirPath + [IO.Path]::PathSeparator + $env:PATH
         }
         else {
-            throw "Cannot find the dotnet SDK for .NET Core 2.1. Please specify '-Bootstrap' to install build dependencies."
+            throw "Cannot find the dotnet SDK for .NET Core 3.1. Please specify '-Bootstrap' to install build dependencies."
         }
     }
 }
@@ -49,7 +49,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = 'release',
-        [string]$Version = '2.1.401'
+        [string]$Version = '3.1.101'
     )
 
     try {

--- a/tools/protobuf.tools.csproj
+++ b/tools/protobuf.tools.csproj
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoBuild>true</NoBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Migrate PowerShell worker to PowerShell 7:
- Using PowerShell SDK **v7.0.0-rc.2** for now. We'll move to the GA release as soon as it is available.
- In PowerShell 7, the default error formatting has been intentionally changed, and a new `Get-Error` cmdlet has been introduced. The new cmdlet seems to provide all the details that our custom error formatting code provides (such as call stacks, inner exceptions, etc.), so we should consider aligning with PS7 and removing our custom code, but we'll do it separately. For now, this PR just switches to the PS6-style error formatting.