### PR TITLE
Make E2E tests run on Functions V3 runtime

### DIFF
--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -3,6 +3,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.	
 #
 
+$FUNC_RUNTIME_VERSION = '3'
+
 $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
 if ($IsWindows) {
     $FUNC_EXE_NAME = "func.exe"
@@ -16,7 +18,7 @@ if ($IsWindows) {
     }
 }
 
-$FUNC_CLI_DOWNLOAD_URL = "https://functionsclibuilds.blob.core.windows.net/builds/2/latest/Azure.Functions.Cli.$os-$arch.zip"
+$FUNC_CLI_DOWNLOAD_URL = "https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest/Azure.Functions.Cli.$os-$arch.zip"
 $FUNC_CLI_DIRECTORY = Join-Path $PSScriptRoot 'Azure.Functions.Cli'
 
 Write-Host 'Deleting Functions Core Tools if exists...'
@@ -25,7 +27,7 @@ Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
 
 if (-not $env:CORE_TOOLS_URL)
 {
-    $env:CORE_TOOLS_URL = 'https://functionsclibuilds.blob.core.windows.net/builds/2/latest'
+    $env:CORE_TOOLS_URL = 'https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest'
 }
 
 $version = Invoke-RestMethod -Uri "$env:CORE_TOOLS_URL/version.txt"

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -27,7 +27,7 @@ Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
 
 if (-not $env:CORE_TOOLS_URL)
 {
-    $env:CORE_TOOLS_URL = 'https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest'
+    $env:CORE_TOOLS_URL = "https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest"
 }
 
 $version = Invoke-RestMethod -Uri "$env:CORE_TOOLS_URL/version.txt"

--- a/test/E2E/TestFunctionApp/extensions.csproj
+++ b/test/E2E/TestFunctionApp/extensions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<WarningsAsErrors></WarningsAsErrors>
+	<DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.8.2" />
+  </ItemGroup>
+</Project>

--- a/test/E2E/TestFunctionApp/local.settings.json
+++ b/test/E2E/TestFunctionApp/local.settings.json
@@ -3,6 +3,7 @@
   "Values": {
     "AzureWebJobsEventHubSender":"",
     "AzureWebJobsCosmosDBConnectionString":"",
+    "AzureWebJobsFeatureFlags": "AllowSynchronousIO",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "PSWorkerEnableExperimentalDurableFunctions": "true"
   }


### PR DESCRIPTION
We'll need to propagate this change to both `v3.x/ps7` and `v3.x/ps6` branches.