### PR TITLE
Move PS7 worker to a version-specific subfolder

### DIFF
--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -26,7 +26,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell" />
+    <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>
 </package>

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -27,6 +27,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </metadata>
   <files>
     <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7" />
+    <file src="..\src\bin\$configuration$\$targetFramework$\publish\worker.config.json" target="contentFiles\any\any\workers\powershell" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>
 </package>

--- a/src/worker.config.json
+++ b/src/worker.config.json
@@ -3,6 +3,9 @@
         "language":"powershell",
         "extensions":[".ps1", ".psm1"],
         "defaultExecutablePath":"dotnet",
-        "defaultWorkerPath":"Microsoft.Azure.Functions.PowerShellWorker.dll"
+        "defaultWorkerPath":"%FUNCTIONS_WORKER_RUNTIME_VERSION%/Microsoft.Azure.Functions.PowerShellWorker.dll",
+        "supportedRuntimeVersions":["6", "7"],
+        "defaultRuntimeVersion":"6",
+        "sanitizeRuntimeVersion":"\\d+"
     }
 }

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -4,6 +4,8 @@
 #
 
 $FUNC_RUNTIME_VERSION = '3'
+$NETCOREAPP_VERSION = '3.1'
+$POWERSHELL_VERSION = '7'
 
 $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
 if ($IsWindows) {
@@ -43,11 +45,13 @@ Write-Host "Copying azure-functions-powershell-worker to Functions Host workers 
 
 $configuration = if ($env:CONFIGURATION) { $env:CONFIGURATION } else { 'Debug' }
 Remove-Item -Recurse -Force -Path "$FUNC_CLI_DIRECTORY/workers/powershell"
-Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp3.1/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell"
+Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp$NETCOREAPP_VERSION/publish/" "$FUNC_CLI_DIRECTORY/workers/powershell/$POWERSHELL_VERSION"
+Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp$NETCOREAPP_VERSION/publish/worker.config.json" "$FUNC_CLI_DIRECTORY/workers/powershell"
 
 Write-Host "Staring Functions Host..."
 
 $Env:FUNCTIONS_WORKER_RUNTIME = "powershell"
+$Env:FUNCTIONS_WORKER_RUNTIME_VERSION = $POWERSHELL_VERSION
 $Env:AZURE_FUNCTIONS_ENVIRONMENT = "development"
 $Env:Path = "$Env:Path$([System.IO.Path]::PathSeparator)$FUNC_CLI_DIRECTORY"
 $funcExePath = Join-Path $FUNC_CLI_DIRECTORY $FUNC_EXE_NAME


### PR DESCRIPTION
We'll need a similar change on the `v3.x/ps6` branch.