### PR TITLE
Fix sanitizeRuntimeVersionRegex entry in worker config

### DIFF
--- a/src/worker.config.json
+++ b/src/worker.config.json
@@ -6,6 +6,6 @@
         "defaultWorkerPath":"%FUNCTIONS_WORKER_RUNTIME_VERSION%/Microsoft.Azure.Functions.PowerShellWorker.dll",
         "supportedRuntimeVersions":["6", "7"],
         "defaultRuntimeVersion":"6",
-        "sanitizeRuntimeVersion":"\\d+"
+        "sanitizeRuntimeVersionRegex":"\\d+"
     }
 }


### PR DESCRIPTION
The `sanitizeRuntimeVersion` property has been renamed to `sanitizeRuntimeVersionRegex` in the Functions Host code, so fixing it in the worker config as well.