### PR TITLE
Log PowerShell version

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -198,6 +198,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
                     // and the dependency manager (used to download dependent modules if needed).
                     var pwsh = Utils.NewPwshInstance();
+                    LogPowerShellVersion(rpcLogger, pwsh);
                     _powershellPool.Initialize(pwsh);
 
                     // Start the download asynchronously if needed.
@@ -490,6 +491,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 default:
                     throw new InvalidOperationException("Unreachable code.");
             }
+        }
+
+        private static void LogPowerShellVersion(RpcLogger rpcLogger, System.Management.Automation.PowerShell pwsh)
+        {
+            var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, Utils.GetPowerShellVersion(pwsh));
+            rpcLogger.Log(isUserOnlyLog: false, LogLevel.Information, message);
         }
 
         #endregion

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -6,8 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
@@ -221,6 +221,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         internal static bool AreDurableFunctionsEnabled()
         {
             return PowerShellWorkerConfiguration.GetBoolean("PSWorkerEnableExperimentalDurableFunctions") ?? false;
+        }
+
+        internal static string GetPowerShellVersion(PowerShell pwsh)
+        {
+            const string versionTableVariableName = "PSVersionTable";
+            const string versionPropertyName = "PSVersion";
+
+            var versionTableVariable = GetGlobalVariables(pwsh).First(v => string.CompareOrdinal(v.Name, versionTableVariableName) == 0);
+            var versionTable = (PSVersionHashTable)versionTableVariable.Value;
+            return versionTable[versionPropertyName].ToString();
         }
     }
 }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -307,4 +307,7 @@
   <data name="CommandNotFoundException_Exception" xml:space="preserve">
     <value>CommandNotFoundException detected (exception).</value>
   </data>
+  <data name="PowerShellVersion" xml:space="preserve">
+    <value>PowerShell version: '{0}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
We'll need this in both `v3.x/ps6` and `v3.x/ps7` branches. It is not strictly necessary in v2, so I will _not_ propagate it to the `v2.x` branch at this point.