### PR TITLE
Tolerate read-only managed dependencies files

### DIFF
--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private readonly TimeSpan _oldHeartbeatAgeMargin;
         private readonly int _minNumberOfSnapshotsToKeep;
 
+        private string _currentlyUsedSnapshotPath;
         private Timer _heartbeat;
 
         public DependencySnapshotPurger(
@@ -42,6 +43,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         /// </summary>
         public void SetCurrentlyUsedSnapshot(string path, ILogger logger)
         {
+            _currentlyUsedSnapshotPath = path;
+
             Heartbeat(path, logger);
 
             _heartbeat = new Timer(
@@ -65,6 +68,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             var threshold = DateTime.UtcNow - _heartbeatPeriod - _oldHeartbeatAgeMargin;
 
             var pathSortedByAccessTime = allSnapshotPaths
+                                            .Where(path => string.CompareOrdinal(path, _currentlyUsedSnapshotPath) != 0)
                                             .Select(path => Tuple.Create(path, GetSnapshotAccessTimeUtc(path, logger)))
                                             .OrderBy(entry => entry.Item2)
                                             .ToArray();

--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -112,6 +112,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 {
                     _storage.SetSnapshotAccessTimeToUtcNow(path);
                 }
+                // The files in the snapshot may be read-only in some scenarios, so updating
+                // the timestamp may fail. However, the snapshot can still be used, and
+                // we should not prevent function executions because of that.
+                // So, just log and move on.
                 catch (IOException e)
                 {
                     LogHeartbeatUpdateFailure(logger, path, e);

--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -112,11 +112,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 {
                     _storage.SetSnapshotAccessTimeToUtcNow(path);
                 }
-                catch (IOException)
+                catch (IOException e)
                 {
+                    LogHeartbeatUpdateFailure(logger, path, e);
                 }
-                catch (UnauthorizedAccessException)
+                catch (UnauthorizedAccessException e)
                 {
+                    LogHeartbeatUpdateFailure(logger, path, e);
                 }
             }
         }
@@ -148,6 +150,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private static int GetMinNumberOfSnapshotsToKeep()
         {
             return PowerShellWorkerConfiguration.GetInt("MDMinNumberOfSnapshotsToKeep") ?? 1;
+        }
+
+        private static void LogHeartbeatUpdateFailure(ILogger logger, string path, Exception exception)
+        {
+            var message = string.Format(
+                                PowerShellWorkerStrings.FailedToUpdateManagedDependencySnapshotHeartbeat,
+                                path,
+                                exception.GetType().FullName,
+                                exception.Message);
+
+            logger.Log(isUserOnlyLog: false, LogLevel.Warning, message);
         }
     }
 }

--- a/src/DependencyManagement/DependencySnapshotPurger.cs
+++ b/src/DependencyManagement/DependencySnapshotPurger.cs
@@ -108,7 +108,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
             if (_storage.SnapshotExists(path))
             {
-                _storage.SetSnapshotAccessTimeToUtcNow(path);
+                try
+                {
+                    _storage.SetSnapshotAccessTimeToUtcNow(path);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
             }
         }
 

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -257,7 +257,7 @@
     <value>Updating dependencies folder heartbeat for '{0}''.</value>
   </data>
   <data name="FailedToUpdateManagedDependencySnapshotHeartbeat" xml:space="preserve">
-    <value>Failed to update dependencies folder heartbeat for '{0}'. Exception {1}: '{2}''.</value>
+    <value>Failed to update dependencies folder heartbeat for '{0}'. Exception {1}: '{2}'.</value>
   </data>
   <data name="FailedToInstallDependenciesSnapshot" xml:space="preserve">
     <value>Failed to install dependencies into '{0}' (installation mode: {1}), removing the folder.</value>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -256,6 +256,9 @@
   <data name="UpdatingManagedDependencySnapshotHeartbeat" xml:space="preserve">
     <value>Updating dependencies folder heartbeat for '{0}''.</value>
   </data>
+  <data name="FailedToUpdateManagedDependencySnapshotHeartbeat" xml:space="preserve">
+    <value>Failed to update dependencies folder heartbeat for '{0}'. Exception {1}: '{2}''.</value>
+  </data>
   <data name="FailedToInstallDependenciesSnapshot" xml:space="preserve">
     <value>Failed to install dependencies into '{0}' (installation mode: {1}), removing the folder.</value>
   </data>

--- a/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
@@ -258,14 +258,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _mockStorage.Verify(_ => _.SetSnapshotAccessTimeToUtcNow(It.IsAny<string>()), Times.Never);
         }
 
-        public static IEnumerable<object[]> GetFileAccessExceptions()
-        {
-            yield return new object[] { new IOException("Injected error") };
-            yield return new object[] { new UnauthorizedAccessException("Injected error") };
-        }
-
         [Theory]
-        [MemberData(nameof(GetFileAccessExceptions))]
+        [MemberData(nameof(GetNonFatalFileSystemExceptions))]
         public void Heartbeat_Tolerates_FileAccessFailures(Exception exception)
         {
             const string snapshotPath = "FakeSnapshotPath";

--- a/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
@@ -269,6 +269,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             {
                 purger.Heartbeat("Current", _mockLogger.Object);
             }
+
+            _mockLogger.Verify(
+                _ => _.Log(false, LogLevel.Warning, It.Is<string>(message => message.Contains("IOException")), It.IsAny<Exception>()),
+                Times.AtLeastOnce);
         }
 
         [Fact]
@@ -282,6 +286,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             {
                 purger.Heartbeat("Current", _mockLogger.Object);
             }
+
+            _mockLogger.Verify(
+                _ => _.Log(false, LogLevel.Warning, It.Is<string>(message => message.Contains("UnauthorizedAccessException")), It.IsAny<Exception>()),
+                Times.AtLeastOnce);
         }
 
         [Fact]

--- a/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotPurgerTests.cs
@@ -259,6 +259,32 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
+        public void Heartbeat_Tolerates_IOException()
+        {
+            _mockStorage.Setup(_ => _.SnapshotExists("Current")).Returns(true);
+            _mockStorage.Setup(_ => _.SetSnapshotAccessTimeToUtcNow("Current"))
+                .Throws(new IOException("Injected error"));
+
+            using (var purger = new DependencySnapshotPurger(_mockStorage.Object))
+            {
+                purger.Heartbeat("Current", _mockLogger.Object);
+            }
+        }
+
+        [Fact]
+        public void Heartbeat_Tolerates_UnauthorizedAccessException()
+        {
+            _mockStorage.Setup(_ => _.SnapshotExists("Current")).Returns(true);
+            _mockStorage.Setup(_ => _.SetSnapshotAccessTimeToUtcNow("Current"))
+                .Throws(new UnauthorizedAccessException("Injected error"));
+
+            using (var purger = new DependencySnapshotPurger(_mockStorage.Object))
+            {
+                purger.Heartbeat("Current", _mockLogger.Object);
+            }
+        }
+
+        [Fact]
         public void SetCurrentlyUsedSnapshot_UpdatesCurrentSnapshotAccessTimeImmediately()
         {
             _mockStorage.Setup(_ => _.SnapshotExists("Current")).Returns(true);


### PR DESCRIPTION
Resolves #400:
- When updating the heartbeat (the timestamp on the .used file under a snapshot) fails because the file is read-only, log a warning but proceed.
- Make sure the worker does not purge the currently used snapshot even if the heartbeat has not been updated for long time.

We'll need this fix in `v2.x`, `v3.x/ps6`, and `v3.x/ps7` branches.