### PR TITLE
Extract durable code to a separate folder, add unit tests

### DIFF
--- a/src/Durable/ActivityInvocationTracker.cs
+++ b/src/Durable/ActivityInvocationTracker.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             }
             else
             {
-                context.OrchestrationActionCollector.StopEvent.Set();
+                context.OrchestrationActionCollector.Stop();
                 _waitForStop.WaitOne();
             }
         }

--- a/src/Durable/ActivityInvocationTracker.cs
+++ b/src/Durable/ActivityInvocationTracker.cs
@@ -1,0 +1,54 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using Utility;
+
+    internal class ActivityInvocationTracker
+    {
+        private readonly ManualResetEvent _waitForStop = new ManualResetEvent(initialState: false);
+
+        public void ReplayActivityOrStop(
+            string functionName,
+            object functionInput,
+            OrchestrationContext context,
+            Action<object> output)
+        {
+            context.OrchestrationActionCollector.Add(new CallActivityAction(functionName, functionInput));
+
+            var taskScheduled = context.History.FirstOrDefault(
+                e => e.EventType == HistoryEventType.TaskScheduled &&
+                     e.Name == functionName &&
+                     !e.IsProcessed);
+
+            var taskCompleted = taskScheduled == null
+                ? null
+                : context.History.FirstOrDefault(
+                    e => e.EventType == HistoryEventType.TaskCompleted &&
+                         e.TaskScheduledId == taskScheduled.EventId);
+
+            if (taskCompleted != null)
+            {
+                taskScheduled.IsProcessed = true;
+                taskCompleted.IsProcessed = true;
+                output(TypeExtensions.ConvertFromJson(taskCompleted.Result));
+            }
+            else
+            {
+                context.OrchestrationActionCollector.StopEvent.Set();
+                _waitForStop.WaitOne();
+            }
+        }
+
+        public void Stop()
+        {
+            _waitForStop.Set();
+        }
+    }
+}

--- a/src/Durable/DurableBindings.cs
+++ b/src/Durable/DurableBindings.cs
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+
+    internal static class DurableBindings
+    {
+        private const string OrchestrationClient = "orchestrationClient";
+        private const string OrchestrationTrigger = "orchestrationTrigger";
+        private const string ActivityTrigger = "activityTrigger";
+
+        public static bool IsOrchestrationClient(string bindingType)
+        {
+            return string.Compare(bindingType, OrchestrationClient, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        public static bool IsOrchestrationTrigger(string bindingType)
+        {
+            return string.Compare(bindingType, OrchestrationTrigger, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        public static bool IsActivityTrigger(string bindingType)
+        {
+            return string.Compare(bindingType, ActivityTrigger, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        public static bool CanParameterDeclarationBeOmitted(string bindingType)
+        {
+            // Declaring a function parameter for the orchestration client binding is allowed but not mandatory
+            return IsOrchestrationClient(bindingType);
+        }
+    }
+}

--- a/src/Durable/DurableController.cs
+++ b/src/Durable/DurableController.cs
@@ -1,0 +1,140 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Management.Automation;
+
+    using Newtonsoft.Json;
+    using WebJobs.Script.Grpc.Messages;
+
+    using PowerShellWorker.Utility;
+
+    internal class DurableController
+    {
+        private readonly bool _durableEnabled;
+        private readonly DurableFunctionInfo _durableFunctionInfo;
+        private readonly IPowerShellServices _powerShellServices;
+        private readonly IOrchestrationInvoker _orchestrationInvoker;
+        private OrchestrationBindingInfo _orchestrationBindingInfo;
+
+        public DurableController(
+            DurableFunctionInfo durableDurableFunctionInfo,
+            PowerShell pwsh)
+            : this(
+                Utils.AreDurableFunctionsEnabled(),
+                durableDurableFunctionInfo,
+                new PowerShellServices(pwsh),
+                new OrchestrationInvoker())
+        {
+        }
+
+        internal DurableController(
+            bool durableEnabled,
+            DurableFunctionInfo durableDurableFunctionInfo,
+            IPowerShellServices powerShellServices,
+            IOrchestrationInvoker orchestrationInvoker)
+        {
+            _durableEnabled = durableEnabled;
+            _durableFunctionInfo = durableDurableFunctionInfo;
+            _powerShellServices = powerShellServices;
+            _orchestrationInvoker = orchestrationInvoker;
+        }
+
+        public void BeforeFunctionInvocation(IList<ParameterBinding> inputData)
+        {
+            // If the function is an orchestration client, then we set the OrchestrationClient
+            // in the module context for the 'Start-NewOrchestration' function to use.
+            if (_durableFunctionInfo.IsOrchestrationClient)
+            {
+                ThrowIfDurableNotEnabled();
+
+                var orchestrationClient =
+                    inputData.First(item => item.Name == _durableFunctionInfo.OrchestrationClientBindingName)
+                        .Data.ToObject();
+
+                _powerShellServices.SetOrchestrationClient(orchestrationClient);
+            }
+            else if (_durableFunctionInfo.IsOrchestrationFunction)
+            {
+                ThrowIfDurableNotEnabled();
+
+                _orchestrationBindingInfo = CreateOrchestrationBindingInfo(inputData);
+                _powerShellServices.SetOrchestrationContext(_orchestrationBindingInfo.Context);
+            }
+        }
+
+        public void AfterFunctionInvocation()
+        {
+            _powerShellServices.ClearOrchestrationContext();
+        }
+
+        public bool TryGetInputBindingParameterValue(string bindingName, out object value)
+        {
+            if (_orchestrationInvoker != null
+                && _orchestrationBindingInfo != null
+                && string.CompareOrdinal(bindingName, _orchestrationBindingInfo.ParameterName) == 0)
+            {
+                value = _orchestrationBindingInfo.Context;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public void AddPipelineOutputIfNecessary(Collection<object> pipelineItems, Hashtable result)
+        {
+            var shouldAddPipelineOutput =
+                _durableEnabled && _durableFunctionInfo.Type == DurableFunctionType.ActivityFunction;
+
+            if (shouldAddPipelineOutput)
+            {
+                var returnValue = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(pipelineItems);
+                result.Add(AzFunctionInfo.DollarReturn, returnValue);
+            }
+        }
+
+        public bool TryInvokeOrchestrationFunction(out Hashtable result)
+        {
+            if (!_durableFunctionInfo.IsOrchestrationFunction)
+            {
+                result = null;
+                return false;
+            }
+
+            result = _orchestrationInvoker.Invoke(_orchestrationBindingInfo, _powerShellServices);
+            return true;
+        }
+
+        private static OrchestrationBindingInfo CreateOrchestrationBindingInfo(IList<ParameterBinding> inputData)
+        {
+            // Quote from https://docs.microsoft.com/en-us/azure/azure-functions/durable-functions-bindings:
+            //
+            // "Orchestrator functions should never use any input or output bindings other than the orchestration trigger binding.
+            //  Doing so has the potential to cause problems with the Durable Task extension because those bindings may not obey the single-threading and I/O rules."
+            //
+            // Therefore, it's by design that input data contains only one item, which is the metadata of the orchestration context.
+            var context = inputData[0];
+
+            return new OrchestrationBindingInfo(
+                context.Name,
+                JsonConvert.DeserializeObject<OrchestrationContext>(context.Data.String));
+        }
+
+        private void ThrowIfDurableNotEnabled()
+        {
+            if (!_durableEnabled)
+            {
+                throw new NotImplementedException(PowerShellWorkerStrings.DurableFunctionNotSupported);
+            }
+        }
+    }
+}

--- a/src/Durable/DurableController.cs
+++ b/src/Durable/DurableController.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
     using PowerShellWorker.Utility;
 
+    /// <summary>
+    /// The main entry point for durable functions support.
+    /// </summary>
     internal class DurableController
     {
         private readonly bool _durableEnabled;

--- a/src/Durable/DurableFunctionInfo.cs
+++ b/src/Durable/DurableFunctionInfo.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    internal class DurableFunctionInfo
+    {
+        public DurableFunctionInfo(DurableFunctionType type, string orchestrationClientBindingName)
+        {
+            Type = type;
+            OrchestrationClientBindingName = orchestrationClientBindingName;
+        }
+
+        public bool IsOrchestrationClient => OrchestrationClientBindingName != null;
+
+        public bool IsOrchestrationFunction => Type == DurableFunctionType.OrchestrationFunction;
+
+        public string OrchestrationClientBindingName { get; }
+
+        public DurableFunctionType Type { get; }
+
+        public bool ProvidesForcedDollarReturnValue => Type != DurableFunctionType.None;
+    }
+}

--- a/src/Durable/DurableFunctionInfoFactory.cs
+++ b/src/Durable/DurableFunctionInfoFactory.cs
@@ -1,0 +1,47 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System.Linq;
+
+    using Google.Protobuf.Collections;
+    using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+
+    internal static class DurableFunctionInfoFactory
+    {
+        public static DurableFunctionInfo Create(MapField<string, BindingInfo> bindings)
+        {
+            var clientBinding =
+                bindings.FirstOrDefault(
+                    binding => !string.IsNullOrEmpty(binding.Key)
+                               && binding.Value.Direction == BindingInfo.Types.Direction.In
+                               && DurableBindings.IsOrchestrationClient(binding.Value.Type));
+
+            var durableFunctionType = GetDurableFunctionType(bindings);
+
+            return new DurableFunctionInfo(durableFunctionType, clientBinding.Key);
+        }
+
+        private static DurableFunctionType GetDurableFunctionType(MapField<string, BindingInfo> bindings)
+        {
+            var inputBindings = bindings.Where(binding => binding.Value.Direction == BindingInfo.Types.Direction.In);
+            foreach (var (_, value) in inputBindings)
+            {
+                if (DurableBindings.IsOrchestrationTrigger(value.Type))
+                {
+                    return DurableFunctionType.OrchestrationFunction;
+                }
+
+                if (DurableBindings.IsActivityTrigger(value.Type))
+                {
+                    return DurableFunctionType.ActivityFunction;
+                }
+            }
+
+            return DurableFunctionType.None;
+        }
+    }
+}

--- a/src/Durable/DurableFunctionType.cs
+++ b/src/Durable/DurableFunctionType.cs
@@ -1,0 +1,14 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    internal enum DurableFunctionType
+    {
+        None,
+        OrchestrationFunction,
+        ActivityFunction
+    }
+}

--- a/src/Durable/IOrchestrationInvoker.cs
+++ b/src/Durable/IOrchestrationInvoker.cs
@@ -1,0 +1,14 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System.Collections;
+
+    internal interface IOrchestrationInvoker
+    {
+        Hashtable Invoke(OrchestrationBindingInfo orchestrationBindingInfo, IPowerShellServices pwsh);
+    }
+}

--- a/src/Durable/IPowerShellServices.cs
+++ b/src/Durable/IPowerShellServices.cs
@@ -1,0 +1,27 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Management.Automation;
+
+    internal interface IPowerShellServices
+    {
+        void SetOrchestrationClient(object orchestrationClient);
+
+        void SetOrchestrationContext(OrchestrationContext orchestrationContext);
+
+        void ClearOrchestrationContext();
+
+        IAsyncResult BeginInvoke(PSDataCollection<object> output);
+
+        void EndInvoke(IAsyncResult asyncResult);
+
+        void StopInvoke();
+
+        void ClearStreamsAndCommands();
+    }
+}

--- a/src/Durable/OrchestrationActionCollector.cs
+++ b/src/Durable/OrchestrationActionCollector.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     {
         private readonly List<List<OrchestrationAction>> _actions = new List<List<OrchestrationAction>>();
 
-        public AutoResetEvent StopEvent { get; } = new AutoResetEvent(initialState: false);
+        private readonly AutoResetEvent _stopEvent = new AutoResetEvent(initialState: false);
 
         public void Add(OrchestrationAction action)
         {
@@ -22,11 +22,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         public Tuple<bool, List<List<OrchestrationAction>>> WaitForActions(WaitHandle completionWaitHandle)
         {
-            var waitHandles = new[] { StopEvent, completionWaitHandle };
+            var waitHandles = new[] { _stopEvent, completionWaitHandle };
             var signaledHandleIndex = WaitHandle.WaitAny(waitHandles);
             var signaledHandle = waitHandles[signaledHandleIndex];
-            var shouldStop = ReferenceEquals(signaledHandle, StopEvent);
+            var shouldStop = ReferenceEquals(signaledHandle, _stopEvent);
             return Tuple.Create(shouldStop, _actions);
+        }
+
+        public void Stop()
+        {
+            _stopEvent.Set();
         }
     }
 }

--- a/src/Durable/OrchestrationActionCollector.cs
+++ b/src/Durable/OrchestrationActionCollector.cs
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    internal class OrchestrationActionCollector
+    {
+        private readonly List<List<OrchestrationAction>> _actions = new List<List<OrchestrationAction>>();
+
+        public AutoResetEvent StopEvent { get; } = new AutoResetEvent(initialState: false);
+
+        public void Add(OrchestrationAction action)
+        {
+            _actions.Add(new List<OrchestrationAction> { action });
+        }
+
+        public Tuple<bool, List<List<OrchestrationAction>>> WaitForActions(WaitHandle completionWaitHandle)
+        {
+            var waitHandles = new[] { StopEvent, completionWaitHandle };
+            var signaledHandleIndex = WaitHandle.WaitAny(waitHandles);
+            var signaledHandle = waitHandles[signaledHandleIndex];
+            var shouldStop = ReferenceEquals(signaledHandle, StopEvent);
+            return Tuple.Create(shouldStop, _actions);
+        }
+    }
+}

--- a/src/Durable/OrchestrationBindingInfo.cs
+++ b/src/Durable/OrchestrationBindingInfo.cs
@@ -1,0 +1,20 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    internal class OrchestrationBindingInfo
+    {
+        public OrchestrationBindingInfo(string parameterName, OrchestrationContext context)
+        {
+            ParameterName = parameterName;
+            Context = context;
+        }
+
+        public string ParameterName { get; }
+
+        public OrchestrationContext Context { get; }
+    }
+}

--- a/src/Durable/OrchestrationContext.cs
+++ b/src/Durable/OrchestrationContext.cs
@@ -7,9 +7,7 @@
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 {
-    using System.Collections.Generic;
     using System.Runtime.Serialization;
-    using System.Threading;
 
     /// <summary>
     /// Represent the context of an execution of an orchestration function.
@@ -32,8 +30,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         [DataMember]
         internal HistoryEvent[] History { get; set; }
 
-        internal AutoResetEvent ActionEvent { get; set; }
-
-        internal List<List<OrchestrationAction>> Actions { get; } = new List<List<OrchestrationAction>>();
+        internal OrchestrationActionCollector OrchestrationActionCollector { get; } = new OrchestrationActionCollector();
     }
 }

--- a/src/Durable/OrchestrationInvoker.cs
+++ b/src/Durable/OrchestrationInvoker.cs
@@ -1,0 +1,56 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Management.Automation;
+
+    using PowerShellWorker.Utility;
+
+    internal class OrchestrationInvoker : IOrchestrationInvoker
+    {
+        public Hashtable Invoke(OrchestrationBindingInfo orchestrationBindingInfo, IPowerShellServices pwsh)
+        {
+            try
+            {
+                var outputBuffer = new PSDataCollection<object>();
+                var asyncResult = pwsh.BeginInvoke(outputBuffer);
+
+                var (shouldStop, actions) =
+                    orchestrationBindingInfo.Context.OrchestrationActionCollector.WaitForActions(asyncResult.AsyncWaitHandle);
+
+                if (shouldStop)
+                {
+                    // The orchestration function should be stopped and restarted
+                    pwsh.StopInvoke();
+                    return CreateOrchestrationResult(isDone: false, actions, output: null);
+                }
+                else
+                {
+                    // The orchestration function completed
+                    pwsh.EndInvoke(asyncResult);
+                    var result = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(outputBuffer);
+                    return CreateOrchestrationResult(isDone: true, actions, output: result);
+                }
+            }
+            finally
+            {
+                pwsh.ClearStreamsAndCommands();
+            }
+        }
+
+        private static Hashtable CreateOrchestrationResult(
+            bool isDone,
+            List<List<OrchestrationAction>> actions,
+            object output)
+        {
+            var orchestrationMessage = new OrchestrationMessage(isDone, actions, output);
+            return new Hashtable { { AzFunctionInfo.DollarReturn, orchestrationMessage } };
+        }
+    }
+}

--- a/src/Durable/PowerShellServices.cs
+++ b/src/Durable/PowerShellServices.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
     internal class PowerShellServices : IPowerShellServices
     {
+        private const string SetFunctionInvocationContextCommand =
+            "Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext";
+
         private readonly PowerShell _pwsh;
         private bool _hasSetOrchestrationContext = false;
 
@@ -21,7 +24,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         public void SetOrchestrationClient(object orchestrationClient)
         {
-            _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+            _pwsh.AddCommand(SetFunctionInvocationContextCommand)
                 .AddParameter("OrchestrationClient", orchestrationClient)
                 .InvokeAndClearCommands();
 
@@ -30,7 +33,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         public void SetOrchestrationContext(OrchestrationContext orchestrationContext)
         {
-            _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+            _pwsh.AddCommand(SetFunctionInvocationContextCommand)
                 .AddParameter("OrchestrationContext", orchestrationContext)
                 .InvokeAndClearCommands();
 
@@ -41,7 +44,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         {
             if (_hasSetOrchestrationContext)
             {
-                _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+                _pwsh.AddCommand(SetFunctionInvocationContextCommand)
                     .AddParameter("Clear", true)
                     .InvokeAndClearCommands();
             }

--- a/src/Durable/PowerShellServices.cs
+++ b/src/Durable/PowerShellServices.cs
@@ -1,0 +1,71 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Management.Automation;
+    using PowerShell;
+
+    internal class PowerShellServices : IPowerShellServices
+    {
+        private readonly PowerShell _pwsh;
+        private bool _hasSetOrchestrationContext = false;
+
+        public PowerShellServices(PowerShell pwsh)
+        {
+            _pwsh = pwsh;
+        }
+
+        public void SetOrchestrationClient(object orchestrationClient)
+        {
+            _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+                .AddParameter("OrchestrationClient", orchestrationClient)
+                .InvokeAndClearCommands();
+
+            _hasSetOrchestrationContext = true;
+        }
+
+        public void SetOrchestrationContext(OrchestrationContext orchestrationContext)
+        {
+            _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+                .AddParameter("OrchestrationContext", orchestrationContext)
+                .InvokeAndClearCommands();
+
+            _hasSetOrchestrationContext = true;
+        }
+
+        public void ClearOrchestrationContext()
+        {
+            if (_hasSetOrchestrationContext)
+            {
+                _pwsh.AddCommand("Microsoft.Azure.Functions.PowerShellWorker\\Set-FunctionInvocationContext")
+                    .AddParameter("Clear", true)
+                    .InvokeAndClearCommands();
+            }
+        }
+
+        public IAsyncResult BeginInvoke(PSDataCollection<object> output)
+        {
+            return _pwsh.BeginInvoke<object, object>(input: null, output);
+        }
+
+        public void EndInvoke(IAsyncResult asyncResult)
+        {
+            _pwsh.EndInvoke(asyncResult);
+        }
+
+        public void StopInvoke()
+        {
+            _pwsh.Stop();
+        }
+
+        public void ClearStreamsAndCommands()
+        {
+            _pwsh.Streams.ClearStreams();
+            _pwsh.Commands.Clear();
+        }
+    }
+}

--- a/src/Utility/FunctionReturnValueBuilder.cs
+++ b/src/Utility/FunctionReturnValueBuilder.cs
@@ -1,0 +1,23 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    internal static class FunctionReturnValueBuilder
+    {
+        public static object CreateReturnValueFromFunctionOutput(IList<object> pipelineItems)
+        {
+            if (pipelineItems == null || pipelineItems.Count <= 0)
+            {
+                return null;
+            }
+
+            return pipelineItems.Count == 1 ? pipelineItems[0] : pipelineItems.ToArray();
+        }
+    }
+}

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading.Tasks;
 
 using CommandLine;
-using Microsoft.Azure.Functions.PowerShellWorker.PowerShell;
 using Microsoft.Azure.Functions.PowerShellWorker.Messaging;
 using Microsoft.Azure.Functions.PowerShellWorker.Utility;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;

--- a/test/Unit/DependencyManagement/NewerDependencySnapshotDetectorTests.cs
+++ b/test/Unit/DependencyManagement/NewerDependencySnapshotDetectorTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
     using Xunit;
 
     using PowerShellWorker.DependencyManagement;
-    using Utility;
+    using PowerShellWorker.Utility;
 
     public class NewerDependencySnapshotDetectorTests
     {

--- a/test/Unit/Durable/ActivityInvocationTrackerTests.cs
+++ b/test/Unit/Durable/ActivityInvocationTrackerTests.cs
@@ -1,0 +1,167 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+    using Xunit;
+
+    public class ActivityInvocationTrackerTests
+    {
+        private const string FunctionName = "function name";
+        private const string FunctionInput = "function input";
+        private const string InvocationResult = "Invocation result";
+        private const string InvocationResultJson = "\"Invocation result\"";
+
+        [Theory]
+        [InlineData(true, false, true)]
+        public void ReplayActivityOrStop_ReplaysActivity_WhenHistoryContainsUnprocessedCompletionEvent(
+            bool scheduled, bool processed, bool completed)
+        {
+            var history = CreateHistory(scheduled: scheduled, processed: processed, completed: completed, output: InvocationResultJson);
+            var orchestrationContext = new OrchestrationContext { History = history };
+
+            var activityInvocationTracker = new ActivityInvocationTracker();
+            activityInvocationTracker.ReplayActivityOrStop(FunctionName, FunctionInput, orchestrationContext, output => { Assert.Equal(InvocationResult, output); });
+
+            VerifyCallActivityActionAdded(orchestrationContext);
+        }
+
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, false)]
+        [InlineData(true, true, true)]
+        public void ReplayActivityOrStop_Stops_WhenHistoryDoesNotContainUnprocessedCompletionEvent(
+            bool scheduled, bool processed, bool completed)
+        {
+            var history = CreateHistory(scheduled: scheduled, processed: processed, completed: completed, output: InvocationResultJson);
+            var orchestrationContext = new OrchestrationContext { History = history };
+
+            var activityInvocationTracker = new ActivityInvocationTracker();
+
+            // In the actual usage, Stop is supposed to be invoked from another thread.
+            // However, in order to simplify this test and avoid spawning threads,
+            // waiting for them, and handling potentially undeterministic behavior,
+            // we cheat a little and invoke Stop _before_ invoking ReplayActivityOrStop,
+            // just to let ReplayActivityOrStop finish soon.
+            // The fact that ReplayActivityOrStop _actually_ blocks until Stop is invoked
+            // is verified by another test (WaitsForStopIfNotCompletedAndNotProcessed).
+            activityInvocationTracker.Stop();
+
+            activityInvocationTracker.ReplayActivityOrStop(FunctionName, FunctionInput, orchestrationContext, _ => { Assert.True(false, "Unexpected output"); });
+
+            VerifyCallActivityActionAdded(orchestrationContext);
+
+            if (scheduled && completed && !processed)
+            {
+                VerifyHistoryEventsMarkedAsProcessed(history);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public void WaitsForStopIfNotCompletedAndNotProcessed(bool completedAndNotProcessed, bool expectedWaitForStop)
+        {
+            var activityInvocationTracker = new ActivityInvocationTracker();
+
+            var history = completedAndNotProcessed
+                            ? CreateHistory(scheduled: true, processed: false, completed: true, output: InvocationResultJson)
+                            : CreateHistory(scheduled: false, processed: false, completed: false, output: InvocationResultJson);
+
+            var orchestrationContext = new OrchestrationContext { History = history };
+
+            var delayBeforeStopping = TimeSpan.FromSeconds(1);
+            var stopwatch = new Stopwatch();
+
+            // ReplayActivityOrStop call may block until Stop is invoked from another thread.
+            var thread = new Thread(() =>
+                                    {
+                                        Thread.Sleep(delayBeforeStopping);
+                                        activityInvocationTracker.Stop();
+                                    });
+            thread.Start();
+
+            stopwatch.Start();
+            activityInvocationTracker.ReplayActivityOrStop(FunctionName, FunctionInput, orchestrationContext, _ => { });
+            stopwatch.Stop();
+
+            // Check if ReplayActivityOrStop was actually blocked
+            if (expectedWaitForStop)
+            {
+                Assert.True(stopwatch.ElapsedMilliseconds > delayBeforeStopping.TotalMilliseconds * 0.8);
+            }
+            else
+            {
+                Assert.True(stopwatch.ElapsedMilliseconds < delayBeforeStopping.TotalMilliseconds * 0.2);
+            }
+
+            thread.Join();
+        }
+
+        private static HistoryEvent[] CreateHistory(bool scheduled, bool processed, bool completed, string output)
+        {
+            var history = new List<HistoryEvent>();
+
+            const int taskScheduledEventId = 1;
+
+            if (scheduled)
+            {
+                history.Add(
+                    new HistoryEvent
+                    {
+                        EventType = HistoryEventType.TaskScheduled,
+                        EventId = taskScheduledEventId,
+                        Name = FunctionName,
+                        IsProcessed = processed
+                    });
+            }
+
+            if (completed)
+            {
+                history.Add(
+                    new HistoryEvent
+                    {
+                        EventType = HistoryEventType.TaskCompleted,
+                        TaskScheduledId = taskScheduledEventId,
+                        Result = output
+                    });
+            }
+
+            return history.ToArray();
+        }
+
+        private static void VerifyCallActivityActionAdded(OrchestrationContext orchestrationContext)
+        {
+            var actions = GetCollectedActions(orchestrationContext);
+            var action = (CallActivityAction) actions.Single().Single();
+            Assert.Equal(FunctionName, action.FunctionName);
+            Assert.Equal(FunctionInput, action.Input);
+        }
+
+        private static List<List<OrchestrationAction>> GetCollectedActions(OrchestrationContext orchestrationContext)
+        {
+            var (_, actions) = orchestrationContext.OrchestrationActionCollector.WaitForActions(new ManualResetEvent(true));
+            return actions;
+        }
+
+        private static void VerifyHistoryEventsMarkedAsProcessed(IEnumerable<HistoryEvent> history)
+        {
+            foreach (var historyEvent in history)
+            {
+                Assert.True(historyEvent.IsProcessed);
+            }
+        }
+    }
+}

--- a/test/Unit/Durable/DurableControllerTests.cs
+++ b/test/Unit/Durable/DurableControllerTests.cs
@@ -1,0 +1,259 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+    using Microsoft.Azure.Functions.PowerShellWorker.Utility;
+    using Newtonsoft.Json;
+
+    using Moq;
+    using Xunit;
+
+    public class DurableControllerTests
+    {
+        private readonly Mock<IPowerShellServices> _mockPowerShellServices = new Mock<IPowerShellServices>(MockBehavior.Strict);
+        private readonly Mock<IOrchestrationInvoker> _mockOrchestrationInvoker = new Mock<IOrchestrationInvoker>(MockBehavior.Strict);
+
+        [Fact]
+        public void BeforeFunctionInvocation_SetsOrchestrationClient_ForOrchestrationClientFunction()
+        {
+            var durableController = CreateDurableController(DurableFunctionType.None, "OrchestrationClientBindingName");
+
+            var orchestrationClient = new { FakeClientProperty = "FakeClientPropertyValue" };
+            var inputData = new[]
+            {
+                CreateParameterBinding("AnotherParameter", "IgnoredValue"),
+                CreateParameterBinding("OrchestrationClientBindingName", orchestrationClient),
+                CreateParameterBinding("YetAnotherParameter", "IgnoredValue")
+            };
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationClient(It.IsAny<object>()));
+
+            durableController.BeforeFunctionInvocation(inputData);
+
+            _mockPowerShellServices.Verify(
+                _ => _.SetOrchestrationClient(
+                    It.Is<object>(c => (string)((Hashtable)c)["FakeClientProperty"] == orchestrationClient.FakeClientProperty)),
+                Times.Once);
+        }
+
+        [Fact]
+        public void BeforeFunctionInvocation_SetsOrchestrationContext_ForOrchestrationFunction()
+        {
+            var durableController = CreateDurableController(DurableFunctionType.OrchestrationFunction);
+
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+            var inputData = new[]
+            {
+                CreateParameterBinding("ParameterName", orchestrationContext)
+            };
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(It.IsAny<OrchestrationContext>()));
+
+            durableController.BeforeFunctionInvocation(inputData);
+
+            _mockPowerShellServices.Verify(
+                _ => _.SetOrchestrationContext(
+                    It.Is<OrchestrationContext>(c => c.InstanceId == orchestrationContext.InstanceId)),
+                Times.Once);
+        }
+
+        [Fact]
+        public void BeforeFunctionInvocation_Throws_OnOrchestrationFunctionWithoutContextParameter()
+        {
+            var durableController = CreateDurableController(DurableFunctionType.OrchestrationFunction);
+            var inputData = new ParameterBinding[0];
+
+            Assert.ThrowsAny<ArgumentException>(() => durableController.BeforeFunctionInvocation(inputData));
+        }
+
+        [Theory]
+        [InlineData(DurableFunctionType.None)]
+        [InlineData(DurableFunctionType.ActivityFunction)]
+        internal void BeforeFunctionInvocation_DoesNothing_ForNonOrchestrationFunction(DurableFunctionType durableFunctionType)
+        {
+            var durableController = CreateDurableController(durableFunctionType);
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+
+            var inputData = new[]
+            {
+                // Even if a parameter similar to orchestration context is passed:
+                CreateParameterBinding("ParameterName", orchestrationContext)
+            };
+
+            durableController.BeforeFunctionInvocation(inputData);
+        }
+
+        [Theory]
+        [InlineData(DurableFunctionType.None)]
+        [InlineData(DurableFunctionType.ActivityFunction)]
+        [InlineData(DurableFunctionType.OrchestrationFunction)]
+        internal void AfterFunctionInvocation_ClearsOrchestrationContext(DurableFunctionType durableFunctionType)
+        {
+            var durableController = CreateDurableController(durableFunctionType);
+            _mockPowerShellServices.Setup(_ => _.ClearOrchestrationContext());
+
+            durableController.AfterFunctionInvocation();
+
+            _mockPowerShellServices.Verify(_ => _.ClearOrchestrationContext(), Times.Once);
+        }
+
+        [Fact]
+        public void TryGetInputBindingParameterValue_RetrievesOrchestrationContextParameter_ForOrchestrationFunction()
+        {
+            var durableController = CreateDurableController(DurableFunctionType.OrchestrationFunction);
+
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+            const string contextParameterName = "ParameterName";
+            var inputData = new[]
+            {
+                CreateParameterBinding(contextParameterName, orchestrationContext)
+            };
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(It.IsAny<OrchestrationContext>()));
+            durableController.BeforeFunctionInvocation(inputData);
+
+            Assert.True(durableController.TryGetInputBindingParameterValue(contextParameterName, out var value));
+            Assert.Equal(orchestrationContext.InstanceId, ((OrchestrationContext)value).InstanceId);
+        }
+
+        [Theory]
+        [InlineData(DurableFunctionType.None)]
+        [InlineData(DurableFunctionType.ActivityFunction)]
+        internal void TryGetInputBindingParameterValue_RetrievesNothing_ForNonOrchestrationFunction(DurableFunctionType durableFunctionType)
+        {
+            var durableController = CreateDurableController(durableFunctionType);
+
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+            const string contextParameterName = "ParameterName";
+            var inputData = new[]
+            {
+                CreateParameterBinding(contextParameterName, orchestrationContext)
+            };
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(It.IsAny<OrchestrationContext>()));
+            durableController.BeforeFunctionInvocation(inputData);
+
+            Assert.False(durableController.TryGetInputBindingParameterValue(contextParameterName, out var value));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryInvokeOrchestrationFunction_InvokesOrchestrationFunction()
+        {
+            var contextParameterName = "ParameterName";
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+            var inputData = new[] { CreateParameterBinding(contextParameterName, orchestrationContext) };
+
+            var durableController = CreateDurableController(DurableFunctionType.OrchestrationFunction);
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(It.IsAny<OrchestrationContext>()));
+            durableController.BeforeFunctionInvocation(inputData);
+
+            var expectedResult = new Hashtable();
+            _mockOrchestrationInvoker.Setup(
+                _ => _.Invoke(It.IsAny<OrchestrationBindingInfo>(), It.IsAny<IPowerShellServices>()))
+                .Returns(expectedResult);
+
+            var invoked = durableController.TryInvokeOrchestrationFunction(out var actualResult);
+            Assert.True(invoked);
+            Assert.Same(expectedResult, actualResult);
+
+            _mockOrchestrationInvoker.Verify(
+                _ => _.Invoke(
+                    It.Is<OrchestrationBindingInfo>(
+                        bindingInfo => bindingInfo.Context.InstanceId == orchestrationContext.InstanceId
+                                       && bindingInfo.ParameterName == contextParameterName),
+                    _mockPowerShellServices.Object),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(DurableFunctionType.None)]
+        [InlineData(DurableFunctionType.ActivityFunction)]
+        internal void TryInvokeOrchestrationFunction_DoesNotInvokeNonOrchestrationFunction(DurableFunctionType durableFunctionType)
+        {
+            var contextParameterName = "ParameterName";
+            var orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
+            var inputData = new[] { CreateParameterBinding(contextParameterName, orchestrationContext) };
+
+            var durableController = CreateDurableController(durableFunctionType);
+
+            _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(It.IsAny<OrchestrationContext>()));
+            durableController.BeforeFunctionInvocation(inputData);
+
+            var invoked = durableController.TryInvokeOrchestrationFunction(out var actualResult);
+            Assert.False(invoked);
+            Assert.Null(actualResult);
+        }
+
+        [Fact]
+        public void AddPipelineOutputIfNecessary_AddsDollarReturn_ForActivityFunction()
+        {
+            var durableController = CreateDurableController(DurableFunctionType.ActivityFunction);
+
+            var pipelineItems = new Collection<object> { "Item1", "Item2", "Item3" };
+            var result = new Hashtable { { "FieldA", "ValueA" }, { "FieldB", "ValueB" } };
+            var originalResultCount = result.Count;
+
+            durableController.AddPipelineOutputIfNecessary(pipelineItems, result);
+
+            Assert.Equal(originalResultCount + 1, result.Count);
+
+            var dollarReturnValue = result[AzFunctionInfo.DollarReturn];
+
+            Assert.Equal(
+                (IEnumerable<object>)dollarReturnValue,
+                FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(pipelineItems));
+        }
+
+        [Theory]
+        [InlineData(DurableFunctionType.None)]
+        [InlineData(DurableFunctionType.OrchestrationFunction)]
+        internal void AddPipelineOutputIfNecessary_DoesNotAddDollarReturn_ForNonActivityFunction(DurableFunctionType durableFunctionType)
+        {
+            var durableController = CreateDurableController(durableFunctionType);
+
+            var pipelineItems = new Collection<object> { "Item1", "Item2", "Item3" };
+            var result = new Hashtable { { "FieldA", "ValueA" }, { "FieldB", "ValueB" } };
+
+            durableController.AddPipelineOutputIfNecessary(pipelineItems, result);
+
+            Assert.False(result.ContainsKey(AzFunctionInfo.DollarReturn));
+        }
+
+        private DurableController CreateDurableController(
+            DurableFunctionType durableFunctionType,
+            string orchestrationClientBindingName = null)
+        {
+            var durableFunctionInfo = new DurableFunctionInfo(durableFunctionType, orchestrationClientBindingName);
+
+            return new DurableController(
+                            durableEnabled: true,
+                            durableFunctionInfo,
+                            _mockPowerShellServices.Object,
+                            _mockOrchestrationInvoker.Object);
+        }
+
+        private static ParameterBinding CreateParameterBinding(string parameterName, object value)
+        {
+            return new ParameterBinding
+            {
+                Name = parameterName,
+                Data = new TypedData
+                {
+                    String = JsonConvert.SerializeObject(value)
+                }
+            };
+        }
+    }
+}

--- a/test/Unit/Durable/DurableFunctionInfoFactoryTests.cs
+++ b/test/Unit/Durable/DurableFunctionInfoFactoryTests.cs
@@ -1,0 +1,160 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using Google.Protobuf.Collections;
+    using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+
+    using Xunit;
+
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+
+    public class DurableFunctionInfoFactoryTests
+    {
+        [Fact]
+        public void ContainsOrchestrationClientName()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    "TestBindingName",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "orchestrationClient" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.True(durableFunctionInfo.IsOrchestrationClient);
+            Assert.Equal("TestBindingName", durableFunctionInfo.OrchestrationClientBindingName);
+        }
+
+        [Fact]
+        public void ContainsFirstInputOrchestrationClientName()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    "Binding1",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "anotherBindingType" }
+                },
+                {
+                    "Binding2",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.Out, Type = "orchestrationClient" }
+                },
+                {
+                    "Binding3",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.Inout, Type = "orchestrationClient" }
+                },
+                {
+                    "Binding4",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "orchestrationClient" }
+                },
+                {
+                    "Binding5",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "yetAnotherBindingType" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.True(durableFunctionInfo.IsOrchestrationClient);
+            Assert.Equal("Binding4", durableFunctionInfo.OrchestrationClientBindingName);
+        }
+
+        [Fact]
+        public void ContainsNoOrchestrationClientNameIfNoBindings()
+        {
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(new MapField<string, BindingInfo>());
+
+            Assert.False(durableFunctionInfo.IsOrchestrationClient);
+            Assert.Null(durableFunctionInfo.OrchestrationClientBindingName);
+        }
+
+        [Fact]
+        public void ContainsNoOrchestrationClientNameIfNoInputOrchestrationClientBindings()
+        {
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(new MapField<string, BindingInfo>());
+
+            Assert.False(durableFunctionInfo.IsOrchestrationClient);
+            Assert.Null(durableFunctionInfo.OrchestrationClientBindingName);
+        }
+
+        [Fact]
+        public void ContainsNoOrchestrationClientNameIfBindingNameIsEmpty()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    string.Empty,
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "orchestrationClient" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.False(durableFunctionInfo.IsOrchestrationClient);
+            Assert.Null(durableFunctionInfo.OrchestrationClientBindingName);
+        }
+
+        [Fact]
+        public void TypeIsOrchestrationIfOrchestrationTriggerInputBindingFound()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    "TestBindingName",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "orchestrationTrigger" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.Equal(DurableFunctionType.OrchestrationFunction, durableFunctionInfo.Type);
+        }
+
+        [Fact]
+        public void TypeIsActivityIfActivityTriggerInputBindingFound()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    "TestBindingName",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "activityTrigger" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.Equal(DurableFunctionType.ActivityFunction, durableFunctionInfo.Type);
+        }
+
+        [Fact]
+        public void TypeIsNoneIfNoOrchestrationOrActivityTriggerFound()
+        {
+            var bindings = new MapField<string, BindingInfo>
+            {
+                {
+                    "Binding1",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.In, Type = "orchestrationClient" }
+                },
+                {
+                    // orchestrationTrigger, but not Direction.In
+                    "Binging2",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.Out, Type = "orchestrationTrigger" }
+                },
+                {
+                    // activityTrigger, but not Direction.In
+                    "Binging3",
+                    new BindingInfo { Direction = BindingInfo.Types.Direction.Out, Type = "activityTrigger" }
+                }
+            };
+
+            var durableFunctionInfo = DurableFunctionInfoFactory.Create(bindings);
+
+            Assert.Equal(DurableFunctionType.None, durableFunctionInfo.Type);
+        }
+    }
+}

--- a/test/Unit/Durable/OrchestrationInvokerTests.cs
+++ b/test/Unit/Durable/OrchestrationInvokerTests.cs
@@ -1,0 +1,168 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Management.Automation;
+    using System.Threading;
+
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+
+    using Moq;
+    using Xunit;
+
+    public class OrchestrationInvokerTests
+    {
+        readonly OrchestrationInvoker _orchestrationInvoker = new OrchestrationInvoker();
+
+        readonly OrchestrationBindingInfo _orchestrationBindingInfo = new OrchestrationBindingInfo(
+                                                                        "ContextParameterName",
+                                                                        new OrchestrationContext());
+
+        private readonly Mock<IPowerShellServices> _mockPowerShellServices = new Mock<IPowerShellServices>();
+
+        [Fact]
+        public void InvocationRunsToCompletionIfNotStopped()
+        {
+            var invocationAsyncResult = CreateInvocationResult(completed: true);
+            ExpectBeginInvoke(invocationAsyncResult);
+
+            _orchestrationInvoker.Invoke(_orchestrationBindingInfo, _mockPowerShellServices.Object);
+
+            _mockPowerShellServices.Verify(_ => _.BeginInvoke(It.IsAny<PSDataCollection<object>>()), Times.Once);
+            _mockPowerShellServices.Verify(_ => _.EndInvoke(invocationAsyncResult), Times.Once);
+            _mockPowerShellServices.Verify(_ => _.ClearStreamsAndCommands(), Times.Once);
+            _mockPowerShellServices.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void InvocationStopsOnStopEvent()
+        {
+            InvokeOrchestration(completed: false);
+
+            _mockPowerShellServices.Verify(_ => _.BeginInvoke(It.IsAny<PSDataCollection<object>>()), Times.Once);
+            _mockPowerShellServices.Verify(_ => _.StopInvoke(), Times.Once);
+            _mockPowerShellServices.Verify(_ => _.ClearStreamsAndCommands(), Times.Once);
+            _mockPowerShellServices.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ConsiderOrchestrationDoneWhenNotStopped()
+        {
+            var result = InvokeOrchestration(completed: true);
+
+            Assert.Single(result);
+            var returnOrchestrationMessage = (OrchestrationMessage)result["$return"];
+            Assert.True(returnOrchestrationMessage.IsDone);
+        }
+
+        [Fact]
+        public void ConsiderOrchestrationNotDoneWhenStopped()
+        {
+            var result = InvokeOrchestration(completed: false);
+
+            Assert.Single(result);
+            var returnOrchestrationMessage = (OrchestrationMessage)result["$return"];
+            Assert.False(returnOrchestrationMessage.IsDone);
+        }
+
+        [Theory]
+        [InlineData(true, 0)]
+        [InlineData(true, 1)]
+        [InlineData(true, 5)]
+        [InlineData(false, 0)]
+        [InlineData(false, 1)]
+        [InlineData(false, 5)]
+        public void ReturnsOrchestrationActions(bool completed, int actionCount)
+        {
+            var actions = Enumerable.Range(0, actionCount)
+                            .Select(i => new CallActivityAction($"activity{i}", $"input{i}"))
+                            .ToArray();
+
+            foreach (var action in actions)
+            {
+                _orchestrationBindingInfo.Context.OrchestrationActionCollector.Add(action);
+            }
+
+            var result = InvokeOrchestration(completed);
+
+            Assert.Single(result);
+            var returnOrchestrationMessage = (OrchestrationMessage)result["$return"];
+            Assert.Equal(actions.Length, returnOrchestrationMessage.Actions.Count);
+            Assert.All(returnOrchestrationMessage.Actions, actionEntry => Assert.Single(actionEntry));
+            Assert.Equal(actions, returnOrchestrationMessage.Actions.SelectMany(x => x));
+        }
+
+        [Fact]
+        public void ReturnsInvocationOutputWhenCompleted()
+        {
+            var output = new[] { "item1", "item2" };
+            var result = InvokeOrchestration(completed: true, output);
+
+            Assert.Single(result);
+            var returnOrchestrationMessage = (OrchestrationMessage)result["$return"];
+            Assert.Equal(output, returnOrchestrationMessage.Output);
+        }
+
+        [Fact]
+        public void ReturnsNoInvocationOutputWhenStopped()
+        {
+            var output = new[] { "item1", "item2" };
+            var result = InvokeOrchestration(completed: false, output);
+
+            Assert.Single(result);
+            var returnOrchestrationMessage = (OrchestrationMessage)result["$return"];
+            Assert.Null(returnOrchestrationMessage.Output);
+        }
+
+        private Hashtable InvokeOrchestration(bool completed, PSDataCollection<object> output = null)
+        {
+            var invocationAsyncResult = CreateInvocationResult(completed);
+            ExpectBeginInvoke(invocationAsyncResult, output);
+            if (!completed)
+            {
+                SignalToStopInvocation();
+            }
+
+            var result = _orchestrationInvoker.Invoke(_orchestrationBindingInfo, _mockPowerShellServices.Object);
+            return result;
+        }
+
+        private static IAsyncResult CreateInvocationResult(bool completed)
+        {
+            var completionEvent = new AutoResetEvent(initialState: completed);
+            var result = new Mock<IAsyncResult>();
+            result.Setup(_ => _.AsyncWaitHandle).Returns(completionEvent);
+            return result.Object;
+        }
+
+        private void ExpectBeginInvoke(IAsyncResult invocationAsyncResult, PSDataCollection<object> output = null)
+        {
+            _mockPowerShellServices
+                .Setup(_ => _.BeginInvoke(It.IsAny<PSDataCollection<object>>()))
+                .Returns(
+                    (PSDataCollection<object> outputBuffer) =>
+                    {
+                        if (output != null)
+                        {
+                            foreach (var item in output)
+                            {
+                                outputBuffer.Add(item);
+                            }
+                        }
+
+                        return invocationAsyncResult;
+                    });
+        }
+
+        private void SignalToStopInvocation()
+        {
+            _orchestrationBindingInfo.Context.OrchestrationActionCollector.StopEvent.Set();
+        }
+    }
+}

--- a/test/Unit/Durable/OrchestrationInvokerTests.cs
+++ b/test/Unit/Durable/OrchestrationInvokerTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
 
         private void SignalToStopInvocation()
         {
-            _orchestrationBindingInfo.Context.OrchestrationActionCollector.StopEvent.Set();
+            _orchestrationBindingInfo.Context.OrchestrationActionCollector.Stop();
         }
     }
 }

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0-rc.3" />

--- a/test/Unit/Utility/FunctionReturnValueBuilderTests.cs
+++ b/test/Unit/Utility/FunctionReturnValueBuilderTests.cs
@@ -1,0 +1,39 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Utility
+{
+    using PowerShellWorker.Utility;
+    using Xunit;
+
+    public class FunctionReturnValueBuilderTests
+    {
+        [Fact]
+        public void ReturnsNullOnNull()
+        {
+            Assert.Null(FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(null));
+        }
+
+        [Fact]
+        public void ReturnsSingleItemWhenPipelineContainsSingleItem()
+        {
+            var pipelineItems = new[] { new object() };
+            var returnValue = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(pipelineItems);
+            Assert.Same(pipelineItems[0], returnValue);
+        }
+
+        [Fact]
+        public void ReturnsNewArrayWhenPipelineContainsMultipleItems()
+        {
+            var pipelineItems = new[] { new object(), new object() };
+            var returnValue = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(pipelineItems);
+            Assert.IsType<object[]>(returnValue);
+            Assert.NotSame(pipelineItems, returnValue);
+            Assert.Same(pipelineItems[0], ((object[])returnValue)[0]);
+            Assert.Same(pipelineItems[1], ((object[])returnValue)[1]);
+            Assert.Equal(pipelineItems.Length, ((object[])returnValue).Length);
+        }
+    }
+}


### PR DESCRIPTION
This refactoring has two goals:
- extract all the durable-related code to a separate folder/namespace;
- cover durable-related code with unit tests.

No _intended_ behavior changes.