### PR TITLE
Use int.MaxValue for gRPC message size limit

### DIFF
--- a/src/Messaging/MessagingStream.cs
+++ b/src/Messaging/MessagingStream.cs
@@ -17,8 +17,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Messaging
         private readonly AsyncDuplexStreamingCall<StreamingMessage, StreamingMessage> _call;
         private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-        internal MessagingStream(string host, int port, int maxMessageLength)
+        internal MessagingStream(string host, int port)
         {
+            const int maxMessageLength = int.MaxValue;
+
             var channelOptions = new []
             {
                 new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxMessageLength),

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 .WithParsed(ops => arguments = ops)
                 .WithNotParsed(err => Environment.Exit(1));
 
-            var msgStream = new MessagingStream(arguments.Host, arguments.Port, arguments.MaxMessageLength);
+            var msgStream = new MessagingStream(arguments.Host, arguments.Port);
             var requestProcessor = new RequestProcessor(msgStream);
 
             // Send StartStream message
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         [Option("requestId", Required = true, HelpText = "Request ID used for gRPC communication with the Host.")]
         public string RequestId { get; set; }
 
-        [Option("grpcMaxMessageLength", Required = true, HelpText = "gRPC Maximum message size.")]
+        [Option("grpcMaxMessageLength", Required = false, HelpText = "[Deprecated and ignored] gRPC Maximum message size.")]
         public int MaxMessageLength { get; set; }
     }
 }


### PR DESCRIPTION
Use int.MaxValue for gRPC message size limit instead of grpcMaxMessageLength command line argument.

Resolves #423 