### PR TITLE
Unpin extension versions in the E2E test app

### DIFF
--- a/test/E2E/TestFunctionApp/extensions.csproj
+++ b/test/E2E/TestFunctionApp/extensions.csproj
@@ -5,10 +5,6 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.8.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The extension references in the E2E test app were recently pinned to specific versions because of an external regression. The issue is resolved now, so I'm reverting this temporary fix.