### PR TITLE
Reload environment variables on FunctionEnvironmentReloadRequest

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -344,6 +344,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
         internal StreamingMessage ProcessFunctionEnvironmentReloadRequest(StreamingMessage request)
         {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var environmentReloadRequest = request.FunctionEnvironmentReloadRequest;
+            foreach (var (name, value) in environmentReloadRequest.EnvironmentVariables)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+
+            var rpcLogger = new RpcLogger(_msgStream);
+            rpcLogger.SetContext(request.RequestId, null);
+            rpcLogger.Log(isUserOnlyLog: false, LogLevel.Trace, string.Format(PowerShellWorkerStrings.EnvironmentReloadCompleted, stopwatch.ElapsedMilliseconds));
+
             StreamingMessage response = NewStreamingMessageTemplate(
                 request.RequestId,
                 StreamingMessage.ContentOneofCase.FunctionEnvironmentReloadResponse,

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -313,4 +313,7 @@
   <data name="PowerShellVersion" xml:space="preserve">
     <value>PowerShell version: '{0}'.</value>
   </data>
+  <data name="EnvironmentReloadCompleted" xml:space="preserve">
+    <value>Environment reload completed in {0} ms.</value>
+  </data>
 </root>


### PR DESCRIPTION
We need this to enable placeholders for PowerShell functions:
- For placeholder purposes, the Functions Host starts language workers with a generic set of environment variables.
- During specialization, the Functions Host sends a set of environment variables specific for the user app to the language worker, so that it has an opportunity to configure these variables without the need to restart.