### PR TITLE
[Durable Functions] Enable Durable Functions v1

### DIFF
--- a/docs/durable-experimental-instructions.md
+++ b/docs/durable-experimental-instructions.md
@@ -25,7 +25,7 @@ Start with the sample durable app at `examples/durable/DurableApp`.
 Note:
 
 - Please make sure you are using Azure Functions **v3** runtime. There are no plans to support Durable PowerShell on Azure Functions **v1** or **v2**.
-- Only Durable Functions **2.x** are supported (see [Durable Functions versions overview](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versions)). There is no plan to keep Durable Functions **1.x** support.
+- Only Durable Functions **2.x** will be supported (see [Durable Functions versions overview](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versions)). Technically, the current implementation works with Durable Functions **1.x** as well. However, it may stop working before GA, and there is no plan to support Durable Functions **1.x** officially in any case.
 - Please make sure you are using the sample code version corresponding to the version of the PowerShell Worker. The programming model is still changing, so older or newer samples may not work. So, if you are trying Durable PowerShell on Azure, use the samples tagged with the version of the PowerShell worker deployed to Azure. Alternatively, take the latest PowerShell Worker code from the **dev** branch, and rebuild and run the PowerShell Worker locally.
 - Only a limited number of patterns is enabled at this point:
   - [Function chaining](https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-overview?tabs=csharp#chaining)

--- a/src/Durable/DurableBindings.cs
+++ b/src/Durable/DurableBindings.cs
@@ -13,9 +13,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         private const string OrchestrationTrigger = "orchestrationTrigger";
         private const string ActivityTrigger = "activityTrigger";
 
+        // For Durable v1 only
+        private const string OrchestrationClient = "orchestrationClient";
+
         public static bool IsDurableClient(string bindingType)
         {
-            return string.Compare(bindingType, DurableClient, StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Compare(bindingType, DurableClient, StringComparison.OrdinalIgnoreCase) == 0
+                   || string.Compare(bindingType, OrchestrationClient, StringComparison.OrdinalIgnoreCase) == 0;
         }
 
         public static bool IsOrchestrationTrigger(string bindingType)


### PR DESCRIPTION
Enable Durable Functions v1 support, most likely just temporarily. We want to do it now because DurableTask v2.* is not included in the Functions extension bundles yet, which complicates authoring templates and makes trying this out more difficult. We still have no intention to officially commit to Durable Functions v1 support, and we will probably disable it again when DurableTask v2.* is in the extension bundles.

/cc @anthonychu 