### PR TITLE
[Durable Functions] Improve usage error handling

### DIFF
--- a/src/Durable/InvokeActivityFunctionCommand.cs
+++ b/src/Durable/InvokeActivityFunctionCommand.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         {
             var privateData = (Hashtable)MyInvocation.MyCommand.Module.PrivateData;
             var context = (OrchestrationContext)privateData[SetFunctionInvocationContextCommand.ContextKey];
-            _activityInvocationTracker.ReplayActivityOrStop(FunctionName, Input, context, NoWait.IsPresent, WriteObject);
+            var loadedFunctions = FunctionLoader.GetLoadedFunctions();
+            _activityInvocationTracker.ReplayActivityOrStop(
+                FunctionName, Input, context, loadedFunctions, NoWait.IsPresent, WriteObject);
         }
 
         protected override void StopProcessing()

--- a/src/FunctionInfo.cs
+++ b/src/FunctionInfo.cs
@@ -145,6 +145,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             OutputBindings = new ReadOnlyDictionary<string, ReadOnlyBindingInfo>(outputBindings);
         }
 
+        // For testing purposes only
+        // TODO: Extract a constructor that just takes the field values directly, and move the RpcFunctionMetadata
+        //       parsing logic to a separate constructor or a factory method. When this is done, the new
+        //       simple constructor can be used for testing instead of this one.
+        internal AzFunctionInfo(string funcName, ReadOnlyDictionary<string, ReadOnlyBindingInfo> inputBindings)
+        {
+            FuncName = funcName;
+            InputBindings = inputBindings;
+        }
+
         private Dictionary<string, PSScriptParamInfo> GetParameters(string scriptFile, string entryPoint, out ScriptBlockAst scriptAst)
         {
             scriptAst = Parser.ParseFile(scriptFile, out _, out ParseError[] errors);
@@ -220,9 +230,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
     public class ReadOnlyBindingInfo
     {
         internal ReadOnlyBindingInfo(BindingInfo bindingInfo)
+            : this(bindingInfo.Type, bindingInfo.Direction)
         {
-            Type = bindingInfo.Type;
-            Direction = bindingInfo.Direction;
+        }
+
+        internal ReadOnlyBindingInfo(string type, BindingInfo.Types.Direction direction)
+        {
+            Type = type;
+            Direction = direction;
         }
 
         /// <summary>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -316,4 +316,10 @@
   <data name="EnvironmentReloadCompleted" xml:space="preserve">
     <value>Environment reload completed in {0} ms.</value>
   </data>
+  <data name="FunctionNotFound" xml:space="preserve">
+    <value>Function '{0}' is not found.</value>
+  </data>
+  <data name="FunctionDoesNotHaveProperActivityFunctionBinding" xml:space="preserve">
+    <value>Function '{0}' does not have an activityTrigger input binding.</value>
+  </data>
 </root>


### PR DESCRIPTION
Throw exceptions with user-friendly messages when trying to invoke a non-existing or an incorrect activity function