### PR TITLE
[Durable Functions] Enable Durable Functions by default

### DIFF
--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -29,7 +29,6 @@ steps:
     AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
     AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
     FUNCTIONS_WORKER_RUNTIME : "powershell"
-    PSWorkerEnableExperimentalDurableFunctions: "true"
   continueOnError: true
   displayName: 'Running E2ETest'
 

--- a/azure-pipelines-2.yml
+++ b/azure-pipelines-2.yml
@@ -24,7 +24,6 @@ steps:
     AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
     FUNCTIONS_WORKER_RUNTIME : "powershell"
     FunctionAppUrl: $(FunctionAppUrl)
-    PSWorkerEnableExperimentalDurableFunctions: "true"
   continueOnError: true
   displayName: 'Running E2ETest'
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,6 @@ steps:
     AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
     AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)    
     FUNCTIONS_WORKER_RUNTIME : "powershell"
-    PSWorkerEnableExperimentalDurableFunctions: "true"
   displayName: 'Running E2ETest'
 
 - task: CopyFiles@2

--- a/docs/durable-experimental-instructions.md
+++ b/docs/durable-experimental-instructions.md
@@ -58,8 +58,7 @@ Set the following app settings (if running on Azure) or just use the sample loca
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "AllowSynchronousIO",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "PSWorkerInProcConcurrencyUpperBound": 10,
-    "PSWorkerEnableExperimentalDurableFunctions": "true"
+    "PSWorkerInProcConcurrencyUpperBound": 10
   }
 }
 ```
@@ -68,7 +67,6 @@ Set the following app settings (if running on Azure) or just use the sample loca
 - `AzureWebJobsFeatureFlags` must contain `AllowSynchronousIO`. Don't ask.
 - `FUNCTIONS_WORKER_RUNTIME` must be set to `powershell`.
 - You may need to adjust `PSWorkerInProcConcurrencyUpperBound` to increase [concurrency](https://docs.microsoft.com/azure/azure-functions/functions-reference-powershell#concurrency) for the Fan-out/Fan-in pattern.
-- `PSWorkerEnableExperimentalDurableFunctions` is a feature flag that enables PowerShell Durable Functions. It is turned off by default for now.
 
 ## 5. Starting the app
 

--- a/examples/durable/DurableApp/local.settings.json
+++ b/examples/durable/DurableApp/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "AllowSynchronousIO",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "PSWorkerInProcConcurrencyUpperBound": 10,
-    "PSWorkerEnableExperimentalDurableFunctions": "true"
+    "PSWorkerInProcConcurrencyUpperBound": 10
   }
 }

--- a/src/Durable/DurableController.cs
+++ b/src/Durable/DurableController.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         {
             if (!_durableEnabled)
             {
-                throw new NotImplementedException(PowerShellWorkerStrings.DurableFunctionNotSupported);
+                throw new NotImplementedException(PowerShellWorkerStrings.DurableFunctionsDisabled);
             }
         }
     }

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -6,7 +6,7 @@
 function CheckIfDurableFunctionsEnabled {
     if (($null -ne $env:PSWorkerEnableExperimentalDurableFunctions) -and
             (-not [bool]::Parse($env:PSWorkerEnableExperimentalDurableFunctions))) {
-		throw 'Durable function is not yet supported for PowerShell.'
+		throw 'PowerShell Durable Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable)Durable PowerShell Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable).'
 	}
 }
 

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -4,7 +4,8 @@
 #
 
 function CheckIfDurableFunctionsEnabled {
-	if (-not [bool]$env:PSWorkerEnableExperimentalDurableFunctions) {
+    if (($null -ne $env:PSWorkerEnableExperimentalDurableFunctions) -and
+            (-not [bool]::Parse($env:PSWorkerEnableExperimentalDurableFunctions))) {
 		throw 'Durable function is not yet supported for PowerShell.'
 	}
 }

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -6,7 +6,7 @@
 function CheckIfDurableFunctionsEnabled {
     if (($null -ne $env:PSWorkerEnableExperimentalDurableFunctions) -and
             (-not [bool]::Parse($env:PSWorkerEnableExperimentalDurableFunctions))) {
-		throw 'PowerShell Durable Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable)Durable PowerShell Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable).'
+		throw 'PowerShell Durable Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable).'
 	}
 }
 

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
 
         internal static bool AreDurableFunctionsEnabled()
         {
-            return PowerShellWorkerConfiguration.GetBoolean("PSWorkerEnableExperimentalDurableFunctions") ?? false;
+            return PowerShellWorkerConfiguration.GetBoolean("PSWorkerEnableExperimentalDurableFunctions") ?? true;
         }
 
         internal static string GetPowerShellVersion(PowerShell pwsh)

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -160,8 +160,8 @@
   <data name="UnsupportedMessage" xml:space="preserve">
     <value>Unsupported message type: {0}.</value>
   </data>
-  <data name="DurableFunctionNotSupported" xml:space="preserve">
-    <value>Durable function is not yet supported for PowerShell.</value>
+  <data name="DurableFunctionsDisabled" xml:space="preserve">
+    <value>Durable PowerShell Functions are disabled (check the PSWorkerEnableExperimentalDurableFunctions environment variable).</value>
   </data>
   <data name="FailToConvertToHttpResponseContext" xml:space="preserve">
     <value>The given value for the 'http' output binding '{0}' cannot be converted to the type 'HttpResponseContext'. The conversion failed with the following error: {1}</value>

--- a/test/E2E/TestFunctionApp/local.settings.json
+++ b/test/E2E/TestFunctionApp/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsEventHubSender":"",
     "AzureWebJobsCosmosDBConnectionString":"",
     "AzureWebJobsFeatureFlags": "AllowSynchronousIO",
-    "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "PSWorkerEnableExperimentalDurableFunctions": "true"
+    "FUNCTIONS_WORKER_RUNTIME": "powershell"
   }
 }


### PR DESCRIPTION
Assume that Durable Functions are enabled by default, don't require the `PSWorkerEnableExperimentalDurableFunctions` app setting.

Not removing `PSWorkerEnableExperimentalDurableFunctions` completely yet, so that we have a way to disable durable functions is something goes wrong. Just changing the default for now.