### PR TITLE
Fix Azure Pipeline builds

### DIFF
--- a/PowerShellWorker.Common.props
+++ b/PowerShellWorker.Common.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BuildNumber Condition="$(APPVEYOR) != ''">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
-    <BuildNumber Condition="$(APPVEYOR) == ''">$([System.DateTime]::Now.ToString(`MMdd`))</BuildNumber>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <Version>3.0.$(BuildNumber)</Version>
     <PackageTags>PowerShell;AzureFunctions;language;Azure;</PackageTags>
     <PackageLicenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/master/LICENSE</PackageLicenseUrl>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pool:
 
 variables:
   Configuration: Release
+  buildNumber: $[ counter('build', 400) ] # Start higher than our AppVeyor versions. Every build (pr or branch) will increment.
 
 steps:
 - pwsh: ./build.ps1 -NoBuild -Bootstrap
@@ -19,8 +20,8 @@ steps:
 
 - pwsh: |
       $ErrorActionPreference = "Stop"
-      ./build.ps1 -Clean -Configuration Release
-  displayName: './build.ps1 -Clean -Configuration Release'
+      ./build.ps1 -Clean -Configuration Release -BuildNumber "$(buildNumber)"
+  displayName: 'Build worker code'
 
 - pwsh: ./build.ps1 -NoBuild -Test
   displayName: 'Running UnitTest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ steps:
   displayName: 'Copy package to ArtifactStagingDirectory'
 
 - task: NuGetCommand@2
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   inputs:
     command: 'push'
     packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'

--- a/build.ps1
+++ b/build.ps1
@@ -19,7 +19,10 @@ param(
     $NoBuild,
 
     [string]
-    $Configuration = "Debug"
+    $Configuration = "Debug",
+
+    [string]
+    $BuildNumber = '0'
 )
 
 #Requires -Version 6.0
@@ -83,8 +86,8 @@ if(!$NoBuild.IsPresent) {
     Get-WebFile -Url 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1' `
         -OutFile "$PSScriptRoot/src/Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1" 
 
-    dotnet publish -c $Configuration $PSScriptRoot
-    dotnet pack -c $Configuration "$PSScriptRoot/package"
+    dotnet publish -c $Configuration "/p:BuildNumber=$BuildNumber" $PSScriptRoot
+    dotnet pack -c $Configuration "/p:BuildNumber=$BuildNumber" "$PSScriptRoot/package"
 }
 
 # Test step


### PR DESCRIPTION
* Skip publishing NuGet on pull requests
* Use BuildNumber from Azure Pipelines instead of Appveyor