### PR TITLE
Fix flaky E2E durable tests

### DIFF
--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -147,19 +147,8 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                         {
                             var statusResponseBody = await GetResponseBodyAsync(statusResponse);
                             Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
-                            string path = statusResponseBody.output.ToString();
-                            string lastFolderName = Path.GetDirectoryName(path);
-
-                            if (!Directory.Exists(lastFolderName))
-                            {
-                                Assert.True(false, $@"The directory {lastFolderName} does not exist!
-                                    The system's value for TMP is {System.Environment.GetEnvironmentVariable("TMP", EnvironmentVariableTarget.Machine)}.
-                                    The user's value for TMP is {System.Environment.GetEnvironmentVariable("TMP")}.
-                                    The system's value for TEMP is {System.Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine)}.
-                                    The user's value for TEMP is {System.Environment.GetEnvironmentVariable("TEMP")}");
-                            }
-
-                            string[] lines = System.IO.File.ReadAllLines(path);
+                            string log = statusResponseBody.output.ToString();
+                            string[] lines = log.Split('\n');
 
                             // Expect the format to be as in Case 1
                             var delineatorLines = new int[] { 0, 3, 9 };

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -239,19 +239,8 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                         {
                             var statusResponseBody = await GetResponseBodyAsync(statusResponse);
                             Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
-                            string path = statusResponseBody.output.ToString();
-                            string lastFolderName = Path.GetDirectoryName(path);
-
-                            if (!Directory.Exists(lastFolderName))
-                            {
-                                Assert.True(false, $@"The directory {lastFolderName} does not exist!
-                                    The system's value for TMP is {System.Environment.GetEnvironmentVariable("TMP", EnvironmentVariableTarget.Machine)}.
-                                    The user's value for TMP is {System.Environment.GetEnvironmentVariable("TMP")}.
-                                    The system's value for TEMP is {System.Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine)}.
-                                    The user's value for TEMP is {System.Environment.GetEnvironmentVariable("TEMP")}");
-                            }
-                            
-                            string[] lines = System.IO.File.ReadAllLines(path);
+                            string log = statusResponseBody.output.ToString();
+                            string[] lines = log.Split('\n');
 
                             // Expect the format to be as in Case 1
                             var delineatorLines = new int[] { 0, 2 };

--- a/test/E2E/TestFunctionApp/CurrentUtcDateTimeOrchestrator/run.ps1
+++ b/test/E2E/TestFunctionApp/CurrentUtcDateTimeOrchestrator/run.ps1
@@ -50,7 +50,7 @@ Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 
 Write-Host "CurrentUtcDateTimeOrchestrator: finished."
 
-return $path
+return (Get-Content $path) -join "`n"
 
 <#
 Contents of the file should resemble one of the following two cases:

--- a/test/E2E/TestFunctionApp/DurableTimerOrchestrator/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableTimerOrchestrator/run.ps1
@@ -24,7 +24,7 @@ Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 
 Write-Host "DurableTimerOrchestrator: finished."
 
-return $path
+return (Get-Content $path) -join "`n"
 
 <#
 Contents of the file should resemble the following:


### PR DESCRIPTION
Return the file log content from the function instead of the file name