### PR TITLE
Warm up PowerShell Worker before receiving function load request

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -199,8 +199,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // Setup the FunctionApp root path and module path.
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath);
 
-                    LogPowerShellVersion(rpcLogger, _firstPwshInstance);
-
                     _firstPwshInstance.AddCommand("Set-Content")
                         .AddParameter("Path", "env:PSModulePath")
                         .AddParameter("Value", FunctionLoader.FunctionModulePath)
@@ -495,12 +493,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             {
                 response.ReturnValue = results[AzFunctionInfo.DollarReturn].ToTypedData();
             }
-        }
-
-        private static void LogPowerShellVersion(RpcLogger rpcLogger, System.Management.Automation.PowerShell pwsh)
-        {
-            var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, Utils.GetPowerShellVersion(pwsh));
-            rpcLogger.Log(isUserOnlyLog: false, LogLevel.Information, message);
         }
 
         #endregion

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
             }
 
-            _firstPwshInstance.AddCommand("Set-Content")
+            _firstPwshInstance.AddCommand("Microsoft.PowerShell.Management\\Set-Content")
                 .AddParameter("Path", "env:PSModulePath")
                 .AddParameter("Value", FunctionLoader.FunctionModulePath)
                 .InvokeAndClearCommands();

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -196,19 +196,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     _dependencyManager = new DependencyManager(request.FunctionLoadRequest.Metadata.Directory, logger: rpcLogger);
                     var managedDependenciesPath = _dependencyManager.Initialize(request, rpcLogger);
 
-                    // Setup the FunctionApp root path and module path.
-                    FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath);
-
-
-                    if (FunctionLoader.FunctionAppRootPath == null)
-                    {
-                        throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
-                    }
-
-                    _firstPwshInstance.AddCommand("Set-Content")
-                        .AddParameter("Path", "env:PSModulePath")
-                        .AddParameter("Value", FunctionLoader.FunctionModulePath)
-                        .InvokeAndClearCommands();
+                    SetupAppRootPathAndModulePath(functionLoadRequest, managedDependenciesPath);
 
                     _powershellPool.Initialize(_firstPwshInstance);
 
@@ -499,6 +487,21 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             {
                 response.ReturnValue = results[AzFunctionInfo.DollarReturn].ToTypedData();
             }
+        }
+
+        private void SetupAppRootPathAndModulePath(FunctionLoadRequest functionLoadRequest, string managedDependenciesPath)
+        {
+            FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath);
+
+            if (FunctionLoader.FunctionAppRootPath == null)
+            {
+                throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
+            }
+
+            _firstPwshInstance.AddCommand("Set-Content")
+                .AddParameter("Path", "env:PSModulePath")
+                .AddParameter("Value", FunctionLoader.FunctionModulePath)
+                .InvokeAndClearCommands();
         }
 
         #endregion

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -19,7 +19,6 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 namespace Microsoft.Azure.Functions.PowerShellWorker
 {
     using System.Diagnostics;
-    using System.IO;
     using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
 
     internal class RequestProcessor

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -200,6 +200,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath);
 
                     LogPowerShellVersion(rpcLogger, _firstPwshInstance);
+
+                    _firstPwshInstance.AddCommand("Set-Content")
+                        .AddParameter("Path", "env:PSModulePath")
+                        .AddParameter("Value", FunctionLoader.FunctionModulePath)
+                        .InvokeAndClearCommands();
+
                     _powershellPool.Initialize(_firstPwshInstance);
 
                     // Start the download asynchronously if needed.

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -199,6 +199,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     // Setup the FunctionApp root path and module path.
                     FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath);
 
+
+                    if (FunctionLoader.FunctionAppRootPath == null)
+                    {
+                        throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
+                    }
+
                     _firstPwshInstance.AddCommand("Set-Content")
                         .AddParameter("Path", "env:PSModulePath")
                         .AddParameter("Value", FunctionLoader.FunctionModulePath)

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -37,11 +37,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         {
             if (s_iss == null)
             {
-                if (FunctionLoader.FunctionAppRootPath == null)
-                {
-                    throw new InvalidOperationException(PowerShellWorkerStrings.FunctionAppRootNotResolved);
-                }
-
                 s_iss = InitialSessionState.CreateDefault();
 
                 if (!AreDurableFunctionsEnabled())
@@ -51,11 +46,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                     s_iss.ThreadOptions = PSThreadOptions.UseCurrentThread;
                 }
 
-                s_iss.EnvironmentVariables.Add(
-                    new SessionStateVariableEntry(
-                        "PSModulePath",
-                        FunctionLoader.FunctionModulePath,
-                        description: null));
+                if (FunctionLoader.FunctionAppRootPath != null)
+                {
+                    s_iss.EnvironmentVariables.Add(
+                        new SessionStateVariableEntry(
+                            "PSModulePath",
+                            FunctionLoader.FunctionModulePath,
+                            description: null));
+                }
 
                 // Setting the execution policy on macOS and Linux throws an exception so only update it on Windows
                 if(Platform.IsWindows)

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         // Warm up the PowerShell instance so that the subsequent function load and invocation requests are faster
         private static void WarmUpPowerShell(System.Management.Automation.PowerShell firstPowerShellInstance)
         {
-            // We just need this name to be unique, so that it does not coincide with an actual function
+            // It turns out that creating/removing a function warms up the session enough.
+            // We just need this name to be unique, so that it does not coincide with an actual function.
             const string DummyFunctionName = "DummyFunction-71b09c92-6bce-42d0-aba1-7b985b8c3563";
 
             firstPowerShellInstance.AddCommand("New-Item")

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // We just need this name to be unique, so that it does not coincide with an actual function.
             const string DummyFunctionName = "DummyFunction-71b09c92-6bce-42d0-aba1-7b985b8c3563";
 
-            firstPowerShellInstance.AddCommand("New-Item")
+            firstPowerShellInstance.AddCommand("Microsoft.PowerShell.Management\\New-Item")
                 .AddParameter("Path", "Function:")
                 .AddParameter("Name", DummyFunctionName)
                 .AddParameter("Value", ScriptBlock.Create(string.Empty))
                 .InvokeAndClearCommands();
 
-            firstPowerShellInstance.AddCommand("Remove-Item")
+            firstPowerShellInstance.AddCommand("Microsoft.PowerShell.Management\\Remove-Item")
                 .AddParameter("Path", $"Function:{DummyFunctionName}")
                 .InvokeAndClearCommands();
         }

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         // Warm up the PowerShell instance so that the subsequent function load and invocation requests are faster
         private static void WarmUpPowerShell(System.Management.Automation.PowerShell firstPowerShellInstance)
         {
-            // It turns out that creating/removing a function warms up the session enough.
+            // It turns out that creating/removing a function warms up the runspace enough.
             // We just need this name to be unique, so that it does not coincide with an actual function.
             const string DummyFunctionName = "DummyFunction-71b09c92-6bce-42d0-aba1-7b985b8c3563";
 

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -34,8 +34,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 .WithParsed(ops => arguments = ops)
                 .WithNotParsed(err => Environment.Exit(1));
 
+            // Create the very first Runspace so the debugger has the target to attach to.
+            // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
+            // and the dependency manager (used to download dependent modules if needed).
+            var pwsh = Utils.NewPwshInstance();
+
             var msgStream = new MessagingStream(arguments.Host, arguments.Port);
-            var requestProcessor = new RequestProcessor(msgStream);
+            var requestProcessor = new RequestProcessor(msgStream, pwsh);
 
             // Send StartStream message
             var startedMessage = new StreamingMessage() {

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -37,10 +37,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // Create the very first Runspace so the debugger has the target to attach to.
             // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
             // and the dependency manager (used to download dependent modules if needed).
-            var pwsh = Utils.NewPwshInstance();
+            var firstPowerShellInstance = Utils.NewPwshInstance();
+            LogPowerShellVersion(firstPowerShellInstance);
 
             var msgStream = new MessagingStream(arguments.Host, arguments.Port);
-            var requestProcessor = new RequestProcessor(msgStream, pwsh);
+            var requestProcessor = new RequestProcessor(msgStream, firstPowerShellInstance);
 
             // Send StartStream message
             var startedMessage = new StreamingMessage() {
@@ -50,6 +51,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
             msgStream.Write(startedMessage);
             await requestProcessor.ProcessRequestLoop();
+        }
+
+        private static void LogPowerShellVersion(System.Management.Automation.PowerShell pwsh)
+        {
+            var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, Utils.GetPowerShellVersion(pwsh));
+            RpcLogger.WriteSystemLog(LogLevel.Information, message);
         }
     }
 


### PR DESCRIPTION
Resolves #485

- The first PowerShell instance creation is moved to `Worker.Main`, and it is now performed immediately after starting the process, not waiting for the function load request. It is important to remember that at this point we cannot initialize `$env:PSModulePath` because the app root path is not resolved yet. So, for the first PowerShell instance, this step is deferred until the function load request and performed in `RequestProcessor.SetupAppRootPathAndModulePath`. For all the subsequent PowerShell instances, `$env:PSModulePath` comes from the initial session state, as before.
- Handling the function load request involves creating a PowerShell function from a script file (see `PowerShellManager.DeployAzFunctionToRunspace`), and this takes hundreds of milliseconds even for a short script when performed for the first time. However, the subsequent invocations are significantly faster. So, creating and removing a dummy function proactively saves noticeable time on the function load request (see `Worker.WarmUpPowerShell`).

This reduces cold start time by about 4 seconds (measured on App Service plan, S1 instance):

Stage | Before the change (ms) | After the change (ms)
--- | --- | ---
Function load request | 3700 | 200
First function invocation request | 2200 | 1700
**Total** | **5900** | **1900**