### PR TITLE
Issue a warning on PowerShell 6 end-of-life (#540)

### DIFF
--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
         {
             if (!_runspaceInited)
             {
+                Logger.Log(isUserOnlyLog: true, LogLevel.Warning, PowerShellWorkerStrings.PowerShell6EndOfLifeWarning);
+
                 // Register stream events
                 RegisterStreamEvents();
                 // Deploy functions from the function App

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -319,4 +319,7 @@
   <data name="SettingCurrentDirectory" xml:space="preserve">
     <value>Setting current directory to '{0}'.</value>
   </data>
+  <data name="PowerShell6EndOfLifeWarning" xml:space="preserve">
+    <value>The Function app uses PowerShell Core 6. Your Function app is still supported, but this version of PowerShell reached end of life, so it is strongly recommended that you migrate the Function app to PowerShell 7. For more details, see https://aka.ms/functions-powershell-6-to-7.</value>
+  </data>
 </root>

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -344,8 +344,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             s_testLogger.FullLog.Clear();
             NewTestPowerShellManager(s_testLogger);
 
-            Assert.Single(s_testLogger.FullLog);
-            Assert.Equal($"Trace: No 'profile.ps1' is found at the function app root folder: {FunctionLoader.FunctionAppRootPath}.", s_testLogger.FullLog[0]);
+            Assert.Contains($"Trace: No 'profile.ps1' is found at the function app root folder: {FunctionLoader.FunctionAppRootPath}.", s_testLogger.FullLog);
         }
 
         [Fact]


### PR DESCRIPTION
Porting #502 fix from https://github.com/Azure/azure-functions-powershell-worker/pull/540

(cherry picked from commit 3f4a3657f843235a5fbac95a3b2c7f5390c227c9)