### PR TITLE
Allow writing null to Function output

### DIFF
--- a/src/Public/Commands/TracePipelineObjectCommand.cs
+++ b/src/Public/Commands/TracePipelineObjectCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Commands
         /// <summary>
         /// The object from pipeline.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        [Parameter(Position = 0, ValueFromPipeline = true)]
         public object InputObject { get; set; }
 
         private static PowerShell s_pwsh;


### PR DESCRIPTION
Allow writing null to Function output by making the InputObject parameter of Trace-PipelineObject optional (which enables passing $null).

Resolves #561, #559, #504 