### PR TITLE
Update yml pipeline to publish the test results as well as the package generated from the build 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,32 +31,24 @@ steps:
     AzureWebJobsStorage: $(AzureWebJobsStorage)
     AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
     AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
-    AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)    
+    AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
     FUNCTIONS_WORKER_RUNTIME : "powershell"
   displayName: 'Running E2ETest'
 
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: 'VSTest'
+    testResultsFiles: '**/*.trx'
+    failTaskOnFailedTests: true
+  condition: succeededOrFailed()
+  displayName: 'Publish tests results'
+
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)/testResults'
-    Contents: '*.trx'
+    SourceFolder: '$(System.DefaultWorkingDirectory)/package'
+    Contents: '**/*.nupkg'
     TargetFolder: '$(Build.ArtifactStagingDirectory)'
-  displayName: 'Copying test result file for artifacts'
-  
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'drop'
-    publishLocation: 'Container'
-  displayName: 'Publishing build and test result artifacts'
-
-- pwsh: |
-      $sourcePath  = (ls package/**/*/Microsoft.Azure.Functions.PowerShellWorker*.nupkg).FullName
-      if (-not (test-path $sourcePath))
-      {
-        throw 'Unable to find Microsoft.Azure.Functions.PowerShellWorker*.nupkg at ./package'
-      }
-      Copy-Item -Path $sourcePath -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-  displayName: 'Copy package to ArtifactStagingDirectory'
+  displayName: 'Copy package to artifacts directory'
 
 - pwsh: |
     $uploadPackage = $null
@@ -86,3 +78,11 @@ steps:
     nuGetFeedType: 'internal'
     publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df'
     allowPackageConflicts: true
+  displayName: 'Push NuGet package to the AzureFunctionsPreRelease feed'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'
+  displayName: 'Publish build artifacts'


### PR DESCRIPTION
This PR contain the following changes:

* Added a task to publish the tests result to Azure DevOps. Now, the test results can be seen in the `Tests` tab like shown below:
![image](https://user-images.githubusercontent.com/12720858/100664045-f7347880-330b-11eb-9eb6-64d9006f659d.png)

* Added a task to publish the nupkg package generated in the build. This artifact is now available in the run `Summary` tab
![image](https://user-images.githubusercontent.com/12720858/100664248-34006f80-330c-11eb-9f49-ee2fa3a64205.png)
