### PR TITLE
Propagate durable activity failures to orchestrator function

### DIFF
--- a/src/Durable/ActivityFailureException.cs
+++ b/src/Durable/ActivityFailureException.cs
@@ -1,0 +1,30 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member 'member'
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+
+    /// <summary>
+    /// Durable activity failure exception.
+    /// </summary>
+    public class ActivityFailureException : Exception
+    {
+        public ActivityFailureException()
+        {
+        }
+
+        public ActivityFailureException(string message)
+            : base(message)
+        {
+        }
+        public ActivityFailureException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Durable/ActivityInvocationTask.cs
+++ b/src/Durable/ActivityInvocationTask.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             return scheduledHistoryEvent == null
                 ? null
                 : context.History.FirstOrDefault(
-                    e => e.EventType == HistoryEventType.TaskCompleted &&
-                         e.TaskScheduledId == scheduledHistoryEvent.EventId);
+                    e => e.TaskScheduledId == scheduledHistoryEvent.EventId
+                         && (e.EventType == HistoryEventType.TaskCompleted
+                             || e.EventType == HistoryEventType.TaskFailed));
         }
 
         internal override OrchestrationAction CreateOrchestrationAction()

--- a/src/Durable/DurableActivityErrorHandler.cs
+++ b/src/Durable/DurableActivityErrorHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             //   - Exception message
             //   - Error category
             // If you make changes in any of these, make sure they are backward-compatible,
-            // so the existing Functions are not broken.
+            // so the existing Functions are not.
 
             const string ErrorId = "Functions.Durable.ActivityFailure";
             var exception = new ActivityFailureException(errorMessage);

--- a/src/Durable/DurableActivityErrorHandler.cs
+++ b/src/Durable/DurableActivityErrorHandler.cs
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System.Management.Automation;
+
+    internal class DurableActivityErrorHandler
+    {
+        public static void Handle(Cmdlet cmdlet, string errorMessage)
+        {
+            const string ErrorId = "Functions.Durable.ActivityFailure";
+            var exception = new ActivityFailureException(errorMessage);
+            var errorRecord = new ErrorRecord(exception, ErrorId, ErrorCategory.NotSpecified, null);
+            cmdlet.WriteError(errorRecord);
+        }
+    }
+}

--- a/src/Durable/DurableActivityErrorHandler.cs
+++ b/src/Durable/DurableActivityErrorHandler.cs
@@ -5,16 +5,22 @@
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 {
+    using System;
     using System.Management.Automation;
 
     internal class DurableActivityErrorHandler
     {
         public static void Handle(Cmdlet cmdlet, string errorMessage)
         {
+            CreateAndWriteError(errorMessage, cmdlet.WriteError);
+        }
+
+        internal static void CreateAndWriteError(string errorMessage, Action<ErrorRecord> writeError)
+        {
             const string ErrorId = "Functions.Durable.ActivityFailure";
             var exception = new ActivityFailureException(errorMessage);
             var errorRecord = new ErrorRecord(exception, ErrorId, ErrorCategory.NotSpecified, null);
-            cmdlet.WriteError(errorRecord);
+            writeError(errorRecord);
         }
     }
 }

--- a/src/Durable/DurableActivityErrorHandler.cs
+++ b/src/Durable/DurableActivityErrorHandler.cs
@@ -17,6 +17,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         internal static void CreateAndWriteError(string errorMessage, Action<ErrorRecord> writeError)
         {
+            // This error is supposed to be documented and become a part of the public contract.
+            // When Function authors implement error handling in PowerShell, they may rely on
+            // the structure and the content of this error, specifically:
+            //   - ErrorId
+            //   - Exception type
+            //   - Exception message
+            //   - Error category
+            // If you make changes in any of these, make sure they are backward-compatible,
+            // so the existing Functions are not broken.
+
             const string ErrorId = "Functions.Durable.ActivityFailure";
             var exception = new ActivityFailureException(errorMessage);
             var errorRecord = new ErrorRecord(exception, ErrorId, ErrorCategory.NotSpecified, null);

--- a/src/Durable/DurableActivityErrorHandler.cs
+++ b/src/Durable/DurableActivityErrorHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             //   - Exception message
             //   - Error category
             // If you make changes in any of these, make sure they are backward-compatible,
-            // so the existing Functions are not.
+            // so the existing Functions are not broken.
 
             const string ErrorId = "Functions.Durable.ActivityFailure";
             var exception = new ActivityFailureException(errorMessage);

--- a/src/Durable/HistoryEvent.cs
+++ b/src/Durable/HistoryEvent.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         [DataMember]
         public HistoryEventType EventType { get; set; }
 
+        [DataMember]
+        public string Reason { get; set; }
+
         #endregion
 
         #region Timer_Event_Fields

--- a/src/Durable/InvokeActivityFunctionCommand.cs
+++ b/src/Durable/InvokeActivityFunctionCommand.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
             var task = new ActivityInvocationTask(FunctionName, Input);
             ActivityInvocationTask.ValidateTask(task, loadedFunctions);
-            
+
             _durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
-                task, context, NoWait.IsPresent, WriteObject);
+                task, context, NoWait.IsPresent, WriteObject, failureReason => DurableActivityErrorHandler.Handle(this, failureReason));
         }
 
         protected override void StopProcessing()

--- a/src/Durable/OrchestrationFailureException.cs
+++ b/src/Durable/OrchestrationFailureException.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// OrchestrationFailureException should be propagated back to the Host when an orchestrator function
+    /// throws and does not handle an exception. The Durable Functions extension implementation requires
+    /// this exception message to contain the Json-serialized orchestration replay state after a special marker.
+    /// </summary>
     internal class OrchestrationFailureException : Exception
     {
         public const string OutOfProcDataLabel = "\n\n$OutOfProcData$:";
@@ -24,6 +29,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         private static string FormatOrchestrationFailureMessage(List<OrchestrationAction> actions, Exception exception)
         {
+            // For more details on why this message looks like this, see:
+            // - https://github.com/Azure/azure-functions-durable-js/pull/145
+            // - https://github.com/Azure/azure-functions-durable-extension/pull/1171
             var orchestrationMessage = new OrchestrationMessage(isDone: false, new List<List<OrchestrationAction>> { actions }, output: null, exception.Message);
             var message = $"{exception.Message}{OutOfProcDataLabel}{JsonConvert.SerializeObject(orchestrationMessage)}";
             return message;

--- a/src/Durable/OrchestrationFailureException.cs
+++ b/src/Durable/OrchestrationFailureException.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    internal class OrchestrationFailureException : Exception
+    {
+        public const string OutOfProcDataLabel = "\n\n$OutOfProcData$:";
+
+        public OrchestrationFailureException()
+        {
+        }
+
+        public OrchestrationFailureException(List<OrchestrationAction> actions, Exception innerException)
+            : base(FormatOrchestrationFailureMessage(actions, innerException), innerException)
+        {
+        }
+
+        private static string FormatOrchestrationFailureMessage(List<OrchestrationAction> actions, Exception exception)
+        {
+            var orchestrationMessage = new OrchestrationMessage(isDone: false, new List<List<OrchestrationAction>> { actions }, output: null, exception.Message);
+            var message = $"{exception.Message}{OutOfProcDataLabel}{JsonConvert.SerializeObject(orchestrationMessage)}";
+            return message;
+        }
+    }
+}

--- a/src/Durable/OrchestrationInvoker.cs
+++ b/src/Durable/OrchestrationInvoker.cs
@@ -43,10 +43,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                 }
                 else
                 {
-                    // The orchestration function completed
-                    pwsh.EndInvoke(asyncResult);
-                    var result = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(outputBuffer);
-                    return CreateOrchestrationResult(isDone: true, actions, output: result);
+                    try
+                    {
+                        // The orchestration function completed
+                        pwsh.EndInvoke(asyncResult);
+                        var result = FunctionReturnValueBuilder.CreateReturnValueFromFunctionOutput(outputBuffer);
+                        return CreateOrchestrationResult(isDone: true, actions, output: result);
+                    }
+                    catch (Exception e)
+                    {
+                        // The orchestrator code has thrown an unhandled exception:
+                        // this should be treated as an entire orchestration failure
+                        throw new OrchestrationFailureException(actions, e);
+                    }
                 }
             }
             finally

--- a/src/Durable/OrchestrationMessage.cs
+++ b/src/Durable/OrchestrationMessage.cs
@@ -12,11 +12,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     /// </summary>
     internal class OrchestrationMessage
     {
-        public OrchestrationMessage(bool isDone, List<List<OrchestrationAction>> actions, object output)
+        public OrchestrationMessage(bool isDone, List<List<OrchestrationAction>> actions, object output, string error = null)
         {
             IsDone = isDone;
             Actions = actions;
             Output = output;
+            Error = error;
         }
 
         /// <summary>
@@ -33,5 +34,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         /// The output result of the orchestration function run.
         /// </summary>
         public readonly object Output;
+
+        /// <summary>
+        /// The orchestration error message.
+        /// </summary>
+        public readonly string Error;
     }
 }

--- a/src/Durable/StartDurableExternalEventListener.cs
+++ b/src/Durable/StartDurableExternalEventListener.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             
             var task = new ExternalEventTask(EventName);
             
-            _durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task, context, NoWait.IsPresent, WriteObject);
+            _durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                task, context, NoWait.IsPresent, WriteObject, failureReason => DurableActivityErrorHandler.Handle(this, failureReason));
         }
 
         protected override void StopProcessing()

--- a/src/Durable/StartDurableTimerCommand.cs
+++ b/src/Durable/StartDurableTimerCommand.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             DateTime fireAt = context.CurrentUtcDateTime.Add(Duration);
             var task = new DurableTimerTask(fireAt);
             
-            _durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task, context, NoWait.IsPresent, WriteObject);
+            _durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                task, context, NoWait.IsPresent, WriteObject, failureReason => DurableActivityErrorHandler.Handle(this, failureReason));
         }
 
         protected override void StopProcessing()

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -233,6 +233,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(e));
                     throw;
                 }
+                catch (OrchestrationFailureException e)
+                {
+                    if (e.InnerException is IContainsErrorRecord inner)
+                    {
+                        Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(inner));
+                    }
+                    throw;
+                }
             }
             finally
             {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -109,7 +109,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                 {
                     case HttpStatusCode.Accepted:
                     {
-                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                        if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
                         {
                             Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
                         }

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -87,6 +87,55 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             }
         }
 
+        [Fact]
+        public async Task ActivityExceptionIsPropagatedThroughOrchestrator()
+        {
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorWithException");
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
+            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
+            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
+
+            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(60);
+            var startTime = DateTime.UtcNow;
+
+            using var httpClient = new HttpClient();
+
+            while (true)
+            {
+                var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
+                switch (statusResponse.StatusCode)
+                {
+                    case HttpStatusCode.Accepted:
+                    {
+                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                        {
+                            Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                        }
+
+                        await Task.Delay(TimeSpan.FromSeconds(2));
+                        break;
+                    }
+
+                    case HttpStatusCode.OK:
+                    {
+                        var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                        Assert.Equal("Failed", (string)statusResponseBody.runtimeStatus);
+                        var output = statusResponseBody.output.ToString();
+                        Assert.Contains("Orchestrator function 'DurableOrchestratorWithException' failed", output);
+                        Assert.Contains("Activity function 'DurableActivityWithException' failed", output);
+                        Assert.Contains("Intentional exception (Name)", output);
+                        return;
+                    }
+
+                    default:
+                        Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                        break;
+                }
+            }
+        }
+
         /*
             Verifies that the Durable execution model correctly replays the same collection of CurrentUtcDateTimes.
             The orchestrator writes CurrentUtcDateTime values to a temporary file. File contents are expected to

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -66,7 +66,7 @@ if (-not $UseCoreToolsBuildFromIntegrationTests.IsPresent)
     Copy-Item -Recurse -Force "$PSScriptRoot/../../src/bin/$configuration/netcoreapp$NETCOREAPP_VERSION/publish/worker.config.json" "$FUNC_CLI_DIRECTORY/workers/powershell"
 }
 
-Write-Host "Staring Functions Host..."
+Write-Host "Starting Functions Host..."
 
 $Env:FUNCTIONS_WORKER_RUNTIME = "powershell"
 $Env:FUNCTIONS_WORKER_RUNTIME_VERSION = $POWERSHELL_VERSION

--- a/test/E2E/TestFunctionApp/DurableActivityWithException/function.json
+++ b/test/E2E/TestFunctionApp/DurableActivityWithException/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableActivityWithException/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableActivityWithException/run.ps1
@@ -1,0 +1,3 @@
+param($name)
+
+throw "Intentional exception ($name)"

--- a/test/E2E/TestFunctionApp/DurableClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClient/run.ps1
@@ -6,7 +6,9 @@ Write-Host "DurableClient started"
 
 $ErrorActionPreference = 'Stop'
 
-$InstanceId = Start-NewOrchestration -FunctionName 'DurableOrchestrator' -InputObject 'Hello'
+$FunctionName = $Request.Query.FunctionName ?? 'DurableOrchestrator'
+
+$InstanceId = Start-NewOrchestration -FunctionName $FunctionName -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/test/E2E/TestFunctionApp/DurableOrchestratorWithException/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorWithException/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorWithException/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorWithException/run.ps1
@@ -1,0 +1,9 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+Invoke-ActivityFunction -FunctionName 'DurableActivityWithException' -Input 'Name' -ErrorAction Stop
+
+'This should not be returned'

--- a/test/Unit/Durable/CurrentUtcDateTimeTests.cs
+++ b/test/Unit/Durable/CurrentUtcDateTimeTests.cs
@@ -101,7 +101,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                 DurableTestUtilities.EmulateStop(durableTaskHandler);
             }
 
-            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(new ActivityInvocationTask(FunctionName, FunctionInput), context, noWait: false, output => allOutput.Add(output));
+            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                new ActivityInvocationTask(FunctionName, FunctionInput), context, noWait: false,
+                output: output => allOutput.Add(output), onFailure: _ => { });
             if (completed)
             {
                 Assert.Equal(_restartTime, context.CurrentUtcDateTime);
@@ -146,7 +148,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             var allOutput = new List<object>();
             var durableTaskHandler = new DurableTaskHandler();
 
-            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(new ActivityInvocationTask(FunctionName, FunctionInput), context, noWait: false, output => allOutput.Add(output));
+            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                new ActivityInvocationTask(FunctionName, FunctionInput), context, noWait: false,
+                output: output => allOutput.Add(output), onFailure: _ => { });
 
             Assert.Equal(_startTime, context.CurrentUtcDateTime);
             var shouldNotHitEvent = context.History.First(

--- a/test/Unit/Durable/DurableActivityErrorHandlerTests.cs
+++ b/test/Unit/Durable/DurableActivityErrorHandlerTests.cs
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System.Management.Automation;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+    using Xunit;
+
+    public class DurableActivityErrorHandlerTests
+    {
+        [Fact]
+        public void WritesCorrectError()
+        {
+            const string ErrorMessage = "My error message";
+
+            var errorWritten = false;
+            DurableActivityErrorHandler.CreateAndWriteError(
+                ErrorMessage,
+                errorRecord => {
+                    errorWritten = true;
+                    Assert.Equal("Functions.Durable.ActivityFailure", errorRecord.FullyQualifiedErrorId);
+                    Assert.IsType<ActivityFailureException>(errorRecord.Exception);
+                    Assert.Equal(ErrorMessage, errorRecord.Exception.Message);
+                    Assert.Equal(ErrorCategory.NotSpecified, errorRecord.CategoryInfo.Category);
+                    Assert.Null(errorRecord.TargetObject);
+                });
+
+            Assert.True(errorWritten);
+        }
+    }
+}

--- a/test/Unit/Durable/DurableTimerTaskTests.cs
+++ b/test/Unit/Durable/DurableTimerTaskTests.cs
@@ -41,7 +41,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                 expectedWaitForStop: expectedWaitForStop,
                 () =>
                 {
-                    durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: new DurableTimerTask(_fireAt), context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); });
+                    durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                        task: new DurableTimerTask(_fireAt), context: context, noWait: false,
+                        output: _ => { Assert.True(false, "Unexpected output"); },
+                        onFailure: _ => { });
                 });
         }
 
@@ -67,12 +70,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             if (!timerCreated || !timerFired)
             {
                 DurableTestUtilities.EmulateStop(durableTaskHandler);
-                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: task, context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); });
+                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                    task: task, context: context, noWait: false,
+                    output: _ => { Assert.True(false, "Unexpected output"); },
+                    onFailure: _ => { });
                 Assert.Equal(_startTime, context.CurrentUtcDateTime);
             }
             else
             {
-                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: task, context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); });
+                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: task, context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); }, errorMessage => { });
                 Assert.Equal(_restartTime, context.CurrentUtcDateTime);
             }
             VerifyCreateDurableTimerActionAdded(context, _fireAt);
@@ -92,11 +98,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             var durableTaskHandler = new DurableTaskHandler();
 
             for (int i = 0; i < 2; i++) {
-                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: new DurableTimerTask(_fireAt), context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); });
+                durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                    task: new DurableTimerTask(_fireAt), context: context, noWait: false,
+                    output: _ => { Assert.True(false, "Unexpected output"); },
+                    onFailure: _ => { });
                 Assert.Equal(_restartTime, context.CurrentUtcDateTime);
             }
 
-            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: new DurableTimerTask(_fireAt), context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); });
+            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                task: new DurableTimerTask(_fireAt), context: context, noWait: false,
+                output: _ => { Assert.True(false, "Unexpected output"); },
+                onFailure: _ => { });
             Assert.Equal(_shouldNotHitTime, context.CurrentUtcDateTime);
         }
 
@@ -120,7 +132,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                 DurableTestUtilities.EmulateStop(durableTaskHandler);
             }
             
-            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: new DurableTimerTask(_fireAt), context: context, noWait: false, _ => { Assert.True(false, "Unexpected output"); } );
+            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                task: new DurableTimerTask(_fireAt), context: context, noWait: false,
+                output: _ => { Assert.True(false, "Unexpected output"); }, onFailure: _ => { });
             VerifyCreateDurableTimerActionAdded(context, _fireAt);
         }
 
@@ -133,7 +147,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
 
             var durableTaskHandler = new DurableTaskHandler();
 
-            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(task: new DurableTimerTask(_fireAt), context: context, noWait: true, output => { allOutput.Add((DurableTimerTask)output); });
+            durableTaskHandler.StopAndInitiateDurableTaskOrReplay(
+                task: new DurableTimerTask(_fireAt), context: context, noWait: true,
+                output: output => { allOutput.Add((DurableTimerTask)output); },
+                onFailure: _ => { });
             Assert.Equal(_fireAt, allOutput.Single().FireAt);
             VerifyCreateDurableTimerActionAdded(context, _fireAt);
         }

--- a/test/Unit/Durable/OrchestrationFailureExceptionTests.cs
+++ b/test/Unit/Durable/OrchestrationFailureExceptionTests.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class OrchestrationFailureExceptionTests
+    {
+        private readonly Exception _innerException = new Exception("Inner exception message");
+
+        [Fact]
+        public void MessageContainsInnerExceptionMessage()
+        {
+            var e = new OrchestrationFailureException(new List<OrchestrationAction>(), _innerException);
+
+            var labelPos = e.Message.IndexOf(OrchestrationFailureException.OutOfProcDataLabel);
+            Assert.Equal(_innerException.Message, e.Message.Substring(0, labelPos));
+        }
+
+        [Fact]
+        public void MessageContainsSerializedOrchestrationMessage()
+        {
+            var actions = new List<OrchestrationAction> {
+                    new CallActivityAction("activity1", "input1"),
+                    new CallActivityAction("activity2", "input2")
+                };
+
+            var e = new OrchestrationFailureException(actions, _innerException);
+
+            var labelPos = e.Message.IndexOf(OrchestrationFailureException.OutOfProcDataLabel);
+            var startPos = labelPos + OrchestrationFailureException.OutOfProcDataLabel.Length;
+            var serialized = e.Message[startPos..];
+            dynamic orchestrationMessage = JsonConvert.DeserializeObject(serialized);
+            Assert.False((bool)orchestrationMessage.IsDone);
+            Assert.Null(orchestrationMessage.Output.Value);
+            Assert.Equal(_innerException.Message, (string)orchestrationMessage.Error);
+            var deserializedActions = (IEnumerable<dynamic>)((IEnumerable<dynamic>)orchestrationMessage.Actions).Single();
+            Assert.Equal(actions.Count(), deserializedActions.Count());
+            for (var i = 0; i < actions.Count(); i++)
+            {
+                AssertEqualAction((OrchestrationAction)actions[i], deserializedActions.ElementAt(i));
+            }
+        }
+
+        private static void AssertEqualAction(OrchestrationAction expected, dynamic actual)
+        {
+            Assert.Equal(((CallActivityAction)expected).FunctionName, (string)actual.FunctionName);
+            Assert.Equal(((CallActivityAction)expected).Input, (string)actual.Input);
+        }
+    }
+}

--- a/test/Unit/Durable/OrchestrationInvokerTests.cs
+++ b/test/Unit/Durable/OrchestrationInvokerTests.cs
@@ -122,6 +122,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             Assert.Null(returnOrchestrationMessage.Output);
         }
 
+        [Fact]
+        public void WrapsExceptionIntoOrchestrationFailureException()
+        {
+            Exception originalException = new Exception("Original exception");
+            _mockPowerShellServices.Setup(_ => _.EndInvoke(It.IsAny<IAsyncResult>())).Throws(originalException);
+
+            var output = new[] { "item1", "item2" };
+
+            var thrownException = Assert.Throws<OrchestrationFailureException>(() => InvokeOrchestration(completed: true, output));
+            Assert.Same(originalException, thrownException.InnerException);
+        }
+
         private Hashtable InvokeOrchestration(bool completed, PSDataCollection<object> output = null)
         {
             return DurableTestUtilities.InvokeOrchestration(_orchestrationInvoker, _orchestrationBindingInfo, _mockPowerShellServices, completed, output);


### PR DESCRIPTION
Resolves #572 

There are two problems to solve here:

1. Make `Invoke-ActivityFunction` report an error on activity failure. This part is simple: `TaskFailed` events are recorded in the orchestration history, so we just make `Invoke-ActivityFunction` write an error (`ActivityFailureException`) to the Error stream. By default, this is treated as a non-terminating error in PowerShell, but the orchestrator function author can use either `$ErrorActionPreference = 'Stop'` or `-ErrorAction Stop` to convert it to an exception, if desired.

2. Unfortunately, completing (1) is not enough: throwing this exception from the orchestrator function leads to errors complaining about non-deterministic orchestrator behavior because of certain implementation quirks affecting out-of-proc language workers. This PR follows the approach taken by the JavaScript Durable implementation (https://github.com/Azure/azure-functions-durable-js/pull/145): the orchestration replay state is embedded into the exception message after the `$OutOfProcData$` marker.