### PR TITLE
Update pipeline trigger to only include `releases/*` branches

### DIFF
--- a/azure-pipelines-e2e-integration-tests.yml
+++ b/azure-pipelines-e2e-integration-tests.yml
@@ -3,6 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+trigger:
+- releases/*
+
 pool:
     vmImage: 'vs2017-win2016'
 


### PR DESCRIPTION
Update pipeline trigger to only include `releases/*` branches.