### PR TITLE
Fix orchestration termination

### DIFF
--- a/src/Durable/DurableTaskHandler.cs
+++ b/src/Durable/DurableTaskHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                             break;
                     }
                 }
-                else if (scheduledHistoryEvent == null)
+                else
                 {
                     InitiateAndWaitForStop(context);
                 }

--- a/test/Unit/Durable/ActivityInvocationTaskTests.cs
+++ b/test/Unit/Durable/ActivityInvocationTaskTests.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -64,7 +64,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
 
         [Theory]
         [InlineData(false, false)]
-        [InlineData(false, true)]
         [InlineData(true, false)]
         public void StopAndInitiateDurableTaskOrReplay_OutputsNothing_IfActivityNotCompleted(
             bool scheduled, bool completed)

--- a/test/Unit/Durable/ActivityInvocationTaskTests.cs
+++ b/test/Unit/Durable/ActivityInvocationTaskTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -84,14 +84,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         }
 
         [Theory]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        public void StopAndInitiateDurableTaskOrReplay_WaitsForStop_IfActivityNotCompleted(bool scheduledAndCompleted, bool expectedWaitForStop)
+        [InlineData(false, false, true)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, false)]
+        public void StopAndInitiateDurableTaskOrReplay_WaitsForStop_IfActivityNotCompleted(bool scheduled, bool completed, bool expectedWaitForStop)
         {
             var durableTaskHandler = new DurableTaskHandler();
 
             var history = CreateHistory(
-                scheduled: scheduledAndCompleted, completed: scheduledAndCompleted, failed: false, output: InvocationResultJson);
+                scheduled: scheduled, completed: completed, failed: false, output: InvocationResultJson);
 
             var orchestrationContext = new OrchestrationContext { History = history };
 


### PR DESCRIPTION
Resolves #575 

When the durable extension receives a termination signal, it invokes the orchestrator, which replays execution until the activity that is still running. In the execution history, this activity is marked as _scheduled_ but not _completed._ As a result, we need to stop the orchestrator, in exactly the same way as when the activity has not been scheduled yet.