### PR TITLE
Fix intermittent durable e2e test failures

### DIFF
--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Azure.Functions.PowerShell.Tests.E2E
@@ -47,7 +47,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             var startTime = DateTime.UtcNow;
 
             // Allow the orchestration to proceed until the first custom status is set
-            await Task.Delay(TimeSpan.FromSeconds(10));
+            await Task.Delay(TimeSpan.FromSeconds(20));
 
             using (var httpClient = new HttpClient())
             {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Azure.Functions.PowerShell.Tests.E2E
@@ -17,6 +17,8 @@ namespace Azure.Functions.PowerShell.Tests.E2E
     public class DurableEndToEndTests
     {
         private readonly FunctionAppFixture _fixture;
+
+        private TimeSpan _orchestrationCompletionTimeout = TimeSpan.FromSeconds(120);
 
         public DurableEndToEndTests(FunctionAppFixture fixture)
         {
@@ -42,7 +44,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             Assert.NotNull(initialResponseBodyObject.terminatePostUri);
             Assert.NotNull(initialResponseBodyObject.rewindPostUri);
 
-            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(90);
             var startTime = DateTime.UtcNow;
 
             // Allow the orchestration to proceed until the first custom status is set
@@ -63,9 +64,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                                 runtimeStatus == "Running" || runtimeStatus == "Pending",
                                 $"Unexpected runtime status: {runtimeStatus}");
 
-                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                             {
-                                Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                             }
 
                             Assert.Equal("Custom status: started", (string)statusResponseBody.customStatus);
@@ -104,7 +105,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
             var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
 
-            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(60);
             var startTime = DateTime.UtcNow;
 
             using var httpClient = new HttpClient();
@@ -116,9 +116,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                 {
                     case HttpStatusCode.Accepted:
                     {
-                        if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                        if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                         {
-                            Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                            Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                         }
 
                         await Task.Delay(TimeSpan.FromSeconds(2));
@@ -184,7 +184,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
             var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
 
-            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(60);
             var startTime = DateTime.UtcNow;
 
             using(var httpClient = new HttpClient())
@@ -196,9 +195,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     {
                         case HttpStatusCode.Accepted:
                         {
-                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                             {
-                                Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                             }
 
                             await Task.Delay(TimeSpan.FromSeconds(2));
@@ -270,7 +269,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
             var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
 
-            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(60);
             var startTime = DateTime.UtcNow;
 
             using(var httpClient = new HttpClient())
@@ -282,9 +280,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     {
                         case HttpStatusCode.Accepted:
                         {
-                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                             {
-                                Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                             }
                             
                             await Task.Delay(TimeSpan.FromSeconds(2));
@@ -328,7 +326,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
             var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
 
-            var orchestrationCompletionTimeout = TimeSpan.FromSeconds(60);
             var startTime = DateTime.UtcNow;
 
             using(var httpClient = new HttpClient())
@@ -340,9 +337,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     {
                         case HttpStatusCode.Accepted:
                         {
-                            if (DateTime.UtcNow > startTime + orchestrationCompletionTimeout)
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                             {
-                                Assert.True(false, $"The orchestration has not completed after {orchestrationCompletionTimeout}");
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                             }
                             
                             await Task.Delay(TimeSpan.FromSeconds(2));

--- a/test/E2E/TestFunctionApp/DurableActivity/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableActivity/run.ps1
@@ -1,7 +1,7 @@
 param($name)
 
 Write-Host "DurableActivity($name) started"
-Start-Sleep -Seconds 5
+Start-Sleep -Seconds 10
 Write-Host "DurableActivity($name) finished"
 
 "Hello $name"


### PR DESCRIPTION
Sometimes Functions run very slowly in the e2e testing environment, so increasing the timeouts