### PR TITLE
Rename Durable commands

### DIFF
--- a/examples/durable/DurableApp/CustomStatusOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/CustomStatusOrchestrator/run.ps1
@@ -7,13 +7,13 @@ Write-Host 'CustomStatusOrchestrator: started.'
 $output = @()
 
 Set-DurableCustomStatus -CustomStatus 'Processing Tokyo'
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'Tokyo'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'Tokyo'
 
 Set-DurableCustomStatus -CustomStatus @{ ProgressMessage = 'Processing Seattle'; Stage = 2 }
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'Seattle'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'Seattle'
 
 Set-DurableCustomStatus -CustomStatus @('Processing London', 'Last stage')
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'London'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'London'
 
 Set-DurableCustomStatus 'Processing completed'
 

--- a/examples/durable/DurableApp/FanOutFanInOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/FanOutFanInOrchestrator/run.ps1
@@ -6,7 +6,7 @@ Write-Host 'FanOutFanInOrchestrator: started.'
 
 $parallelTasks =
     foreach ($Name in 'Tokyo', 'Seattle', 'London') {
-        Invoke-ActivityFunction -FunctionName 'SayHello' -Input $Name -NoWait
+        Invoke-DurableActivity -FunctionName 'SayHello' -Input $Name -NoWait
     }
 
 $output = Wait-DurableTask -Task $parallelTasks

--- a/examples/durable/DurableApp/FunctionChainingOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/FunctionChainingOrchestrator/run.ps1
@@ -6,9 +6,9 @@ Write-Host 'FunctionChainingOrchestrator: started.'
 
 $output = @()
 
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'Tokyo'
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'Seattle'
-$output += Invoke-ActivityFunction -FunctionName 'SayHello' -Input 'London'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'Tokyo'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'Seattle'
+$output += Invoke-DurableActivity -FunctionName 'SayHello' -Input 'London'
 
 Write-Host 'FunctionChainingOrchestrator: finished.'
 

--- a/examples/durable/DurableApp/FunctionChainingWithRetriesOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/FunctionChainingWithRetriesOrchestrator/run.ps1
@@ -10,8 +10,8 @@ $retryOptions = New-DurableRetryOptions `
                     -FirstRetryInterval (New-Timespan -Seconds 1) `
                     -MaxNumberOfAttempts 7
 
-$output += Invoke-ActivityFunction -FunctionName 'FlakyActivity' -Input 'Tokyo' -RetryOptions $retryOptions
-$output += Invoke-ActivityFunction -FunctionName 'FlakyActivity' -Input 'Seattle' -RetryOptions $retryOptions
-$output += Invoke-ActivityFunction -FunctionName 'FlakyActivity' -Input 'London' -RetryOptions $retryOptions
+$output += Invoke-DurableActivity -FunctionName 'FlakyActivity' -Input 'Tokyo' -RetryOptions $retryOptions
+$output += Invoke-DurableActivity -FunctionName 'FlakyActivity' -Input 'Seattle' -RetryOptions $retryOptions
+$output += Invoke-DurableActivity -FunctionName 'FlakyActivity' -Input 'London' -RetryOptions $retryOptions
 
 $output

--- a/examples/durable/DurableApp/HttpStart/run.ps1
+++ b/examples/durable/DurableApp/HttpStart/run.ps1
@@ -4,7 +4,7 @@ param($Request, $TriggerMetadata)
 
 Write-Host 'HttpStart started'
 
-$InstanceId = Start-NewOrchestration -FunctionName $Request.Params.FunctionName -InputObject $Request.Query.Input
+$InstanceId = Start-DurableOrchestration -FunctionName $Request.Params.FunctionName -InputObject $Request.Query.Input
 Write-Host "Started orchestration $($Request.Params.FunctionName) with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/examples/durable/DurableApp/HttpStart/run.ps1
+++ b/examples/durable/DurableApp/HttpStart/run.ps1
@@ -7,7 +7,7 @@ Write-Host 'HttpStart started'
 $InstanceId = Start-NewOrchestration -FunctionName $Request.Params.FunctionName -InputObject $Request.Query.Input
 Write-Host "Started orchestration $($Request.Params.FunctionName) with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host 'HttpStart completed'

--- a/examples/durable/DurableApp/HumanInteractionOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/HumanInteractionOrchestrator/run.ps1
@@ -10,7 +10,7 @@ $duration = New-TimeSpan -Seconds $Context.Input.Duration
 $managerId = $Context.Input.ManagerId
 $skipManagerId = $Context.Input.SkipManagerId
 
-$output += Invoke-ActivityFunction -FunctionName "RequestApproval" -Input $managerId
+$output += Invoke-DurableActivity -FunctionName "RequestApproval" -Input $managerId
 
 $durableTimeoutEvent = Start-DurableTimer -Duration $duration -NoWait
 $approvalEvent = Start-DurableExternalEventListener -EventName "ApprovalEvent" -NoWait
@@ -19,10 +19,10 @@ $firstEvent = Wait-DurableTask -Task @($approvalEvent, $durableTimeoutEvent) -An
 
 if ($approvalEvent -eq $firstEvent) {
     Stop-DurableTimerTask -Task $durableTimeoutEvent
-    $output += Invoke-ActivityFunction -FunctionName "ProcessApproval" -Input $approvalEvent
+    $output += Invoke-DurableActivity -FunctionName "ProcessApproval" -Input $approvalEvent
 }
 else {
-    $output += Invoke-ActivityFunction -FunctionName "EscalateApproval" -Input $skipManagerId
+    $output += Invoke-DurableActivity -FunctionName "EscalateApproval" -Input $skipManagerId
 }
 
 Write-Host 'HumanInteractionOrchestrator: finished.'

--- a/examples/durable/DurableApp/HumanInteractionStart/run.ps1
+++ b/examples/durable/DurableApp/HumanInteractionStart/run.ps1
@@ -9,7 +9,7 @@ $OrchestratorInputs = @{ Duration = 45; ManagerId = 1; SkipManagerId = 2 }
 $InstanceId = Start-NewOrchestration -FunctionName 'HumanInteractionOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host 'HumanInteractionStart completed'

--- a/examples/durable/DurableApp/HumanInteractionStart/run.ps1
+++ b/examples/durable/DurableApp/HumanInteractionStart/run.ps1
@@ -6,7 +6,7 @@ Write-Host 'HumanInteractionStart started'
 
 $OrchestratorInputs = @{ Duration = 45; ManagerId = 1; SkipManagerId = 2 }
 
-$InstanceId = Start-NewOrchestration -FunctionName 'HumanInteractionOrchestrator' -InputObject $OrchestratorInputs
+$InstanceId = Start-DurableOrchestration -FunctionName 'HumanInteractionOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/examples/durable/DurableApp/MonitorOrchestrator/run.ps1
+++ b/examples/durable/DurableApp/MonitorOrchestrator/run.ps1
@@ -12,10 +12,10 @@ $pollingInterval = New-TimeSpan -Seconds $Context.Input.PollingInterval
 $expiryTime = $Context.Input.ExpiryTime
 
 while ($Context.CurrentUtcDateTime -lt $expiryTime) {
-    $jobStatus = Invoke-ActivityFunction -FunctionName 'GetJobStatus' -Input $jobId
+    $jobStatus = Invoke-DurableActivity -FunctionName 'GetJobStatus' -Input $jobId
     if ($jobStatus -eq "Completed") {
         # Perform an action when a condition is met.
-        $output += Invoke-ActivityFunction -FunctionName 'SendAlert' -Input $machineId
+        $output += Invoke-DurableActivity -FunctionName 'SendAlert' -Input $machineId
         break
     }
 

--- a/examples/durable/DurableApp/MonitorStart/run.ps1
+++ b/examples/durable/DurableApp/MonitorStart/run.ps1
@@ -9,7 +9,7 @@ $OrchestratorInputs = @{ JobId = 1; MachineId = 1; PollingInterval = 10; ExpiryT
 $InstanceId = Start-NewOrchestration -FunctionName 'MonitorOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host 'MonitorStart completed'

--- a/examples/durable/DurableApp/MonitorStart/run.ps1
+++ b/examples/durable/DurableApp/MonitorStart/run.ps1
@@ -6,7 +6,7 @@ Write-Host 'MonitorStart started'
 
 $OrchestratorInputs = @{ JobId = 1; MachineId = 1; PollingInterval = 10; ExpiryTime = (Get-Date).ToUniversalTime().AddSeconds(60) }
 
-$InstanceId = Start-NewOrchestration -FunctionName 'MonitorOrchestrator' -InputObject $OrchestratorInputs
+$InstanceId = Start-DurableOrchestration -FunctionName 'MonitorOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
+++ b/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
@@ -7,7 +7,7 @@ Write-Host "HttpTrigger started"
 $InstanceId = Start-NewOrchestration -FunctionName 'MyOrchestrator' -InputObject $Request.Query
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "HttpTrigger completed"

--- a/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
+++ b/examples/durable/LongRunningHttpApp/HttpTrigger/run.ps1
@@ -4,7 +4,7 @@ param($Request, $TriggerMetadata)
 
 Write-Host "HttpTrigger started"
 
-$InstanceId = Start-NewOrchestration -FunctionName 'MyOrchestrator' -InputObject $Request.Query
+$InstanceId = Start-DurableOrchestration -FunctionName 'MyOrchestrator' -InputObject $Request.Query
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/examples/durable/LongRunningHttpApp/MyOrchestrator/run.ps1
+++ b/examples/durable/LongRunningHttpApp/MyOrchestrator/run.ps1
@@ -2,7 +2,7 @@ param($Context)
 
 Write-Host "MyOrchestrator: started. Input: $($Context.Input)"
 
-$activityResult = Invoke-ActivityFunction -FunctionName "LongRunningActivity" -Input $Context.Input
+$activityResult = Invoke-DurableActivity -FunctionName "LongRunningActivity" -Input $Context.Input
 Write-Host "MyOrchestrator: Returned from LongRunningActivity: '$activityResult'"
 
 Write-Host "MyOrchestrator: finished."

--- a/src/Durable/Commands/InvokeDurableActivityCommand.cs
+++ b/src/Durable/Commands/InvokeDurableActivityCommand.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Commands
     using Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks;
 
     /// <summary>
-    /// Invoke an activity function.
+    /// Invoke a durable activity.
     /// </summary>
-    [Cmdlet("Invoke", "ActivityFunction")]
-    public class InvokeActivityFunctionCommand : PSCmdlet
+    [Cmdlet("Invoke", "DurableActivity")]
+    public class InvokeDurableActivityCommand : PSCmdlet
     {
         /// <summary>
         /// Gets and sets the activity function name.

--- a/src/Durable/DurableController.cs
+++ b/src/Durable/DurableController.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         public void BeforeFunctionInvocation(IList<ParameterBinding> inputData)
         {
             // If the function is an orchestration client, then we set the DurableClient
-            // in the module context for the 'Start-NewOrchestration' function to use.
+            // in the module context for the 'Start-DurableOrchestration' function to use.
             if (_durableFunctionInfo.IsDurableClient)
             {
                 var durableClient =

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -74,6 +74,7 @@ VariablesToExport = @()
 AliasesToExport = @(
     'Invoke-ActivityFunction',
     'New-OrchestrationCheckStatusResponse',
+    'Start-NewOrchestration',
     'Wait-ActivityFunction')
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -73,6 +73,7 @@ VariablesToExport = @()
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = @(
     'Invoke-ActivityFunction',
+    'New-OrchestrationCheckStatusResponse',
     'Wait-ActivityFunction')
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -72,6 +72,7 @@ VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = @(
+    'Invoke-ActivityFunction',
     'Wait-ActivityFunction')
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -57,7 +57,7 @@ FunctionsToExport = @(
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(
     'Get-OutputBinding',
-    'Invoke-ActivityFunction',
+    'Invoke-DurableActivity',
     'Push-OutputBinding',
     'Set-DurableCustomStatus',
     'Set-FunctionInvocationContext',

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -50,7 +50,7 @@ NestedModules = @('Microsoft.Azure.Functions.PowerShellWorker.psm1', 'Microsoft.
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
     'New-DurableRetryOptions',
-    'New-OrchestrationCheckStatusResponse',
+    'New-DurableOrchestrationCheckStatusResponse',
     'Send-DurableExternalEvent',
     'Start-NewOrchestration')
 

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -52,7 +52,7 @@ FunctionsToExport = @(
     'New-DurableRetryOptions',
     'New-DurableOrchestrationCheckStatusResponse',
     'Send-DurableExternalEvent',
-    'Start-NewOrchestration')
+    'Start-DurableOrchestration')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -5,6 +5,7 @@
 
 # Set aliases for cmdlets to export
 Set-Alias -Name Wait-ActivityFunction -Value Wait-DurableTask
+New-Alias -Name Invoke-ActivityFunction -Value Invoke-DurableActivity
 
 function GetDurableClientFromModulePrivateData {
     $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -7,6 +7,7 @@
 Set-Alias -Name Wait-ActivityFunction -Value Wait-DurableTask
 Set-Alias -Name Invoke-ActivityFunction -Value Invoke-DurableActivity
 Set-Alias -Name New-OrchestrationCheckStatusResponse -Value New-DurableOrchestrationCheckStatusResponse
+Set-Alias -Name Start-NewOrchestration -Value Start-DurableOrchestration
 
 function GetDurableClientFromModulePrivateData {
     $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -24,7 +24,7 @@ function GetDurableClientFromModulePrivateData {
 .DESCRIPTION
     Start an orchestration Azure Function with the given function name and input value.
 .EXAMPLE
-    PS > Start-NewOrchestration -DurableClient Starter -FunctionName OrchestratorFunction -InputObject "input value for the orchestration function"
+    PS > Start-DurableOrchestration -DurableClient Starter -FunctionName OrchestratorFunction -InputObject "input value for the orchestration function"
     Return the instance id of the new orchestration.
 .PARAMETER FunctionName
     The name of the orchestration Azure Function you want to start.
@@ -33,7 +33,7 @@ function GetDurableClientFromModulePrivateData {
 .PARAMETER DurableClient
     The orchestration client object.
 #>
-function Start-NewOrchestration {
+function Start-DurableOrchestration {
     [CmdletBinding()]
     param(
         [Parameter(

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -79,7 +79,7 @@ function GetUrlOrigin([uri]$Url) {
     $fixedOriginUrl.ToString()
 }
 
-function New-OrchestrationCheckStatusResponse {
+function New-DurableOrchestrationCheckStatusResponse {
     [CmdletBinding()]
     param(
         [Parameter(

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -5,7 +5,8 @@
 
 # Set aliases for cmdlets to export
 Set-Alias -Name Wait-ActivityFunction -Value Wait-DurableTask
-New-Alias -Name Invoke-ActivityFunction -Value Invoke-DurableActivity
+Set-Alias -Name Invoke-ActivityFunction -Value Invoke-DurableActivity
+Set-Alias -Name New-OrchestrationCheckStatusResponse -Value New-DurableOrchestrationCheckStatusResponse
 
 function GetDurableClientFromModulePrivateData {
     $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData

--- a/test/E2E/TestFunctionApp/CurrentUtcDateTimeClient/run.ps1
+++ b/test/E2E/TestFunctionApp/CurrentUtcDateTimeClient/run.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 $InstanceId = Start-NewOrchestration -FunctionName 'CurrentUtcDateTimeOrchestrator' -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "CurrentUtcDateTimeClient completed"

--- a/test/E2E/TestFunctionApp/CurrentUtcDateTimeClient/run.ps1
+++ b/test/E2E/TestFunctionApp/CurrentUtcDateTimeClient/run.ps1
@@ -6,7 +6,7 @@ Write-Host "CurrentUtcDateTimeClient started"
 
 $ErrorActionPreference = 'Stop'
 
-$InstanceId = Start-NewOrchestration -FunctionName 'CurrentUtcDateTimeOrchestrator' -InputObject 'Hello'
+$InstanceId = Start-DurableOrchestration -FunctionName 'CurrentUtcDateTimeOrchestrator' -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/test/E2E/TestFunctionApp/CurrentUtcDateTimeOrchestrator/run.ps1
+++ b/test/E2E/TestFunctionApp/CurrentUtcDateTimeOrchestrator/run.ps1
@@ -25,7 +25,7 @@ Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 
 # Checks that CurrentUtcDateTime updates following a completed activity function
-$activityResults += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "Tokyo"
+$activityResults += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Tokyo"
 # <Timestamp2>
 Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 
@@ -33,11 +33,11 @@ Write-Host "About to start asynchronous calls."
 
 # Checks that CurrentUtcDateTime does not update following an asynchronous call
 $tasks = @()
-$tasks += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "Seattle" -NoWait
+$tasks += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Seattle" -NoWait
 # <Timestamp2>
 Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 
-$tasks += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "London" -NoWait
+$tasks += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "London" -NoWait
 # <Timestamp2>
 Add-Content -Value $Context.CurrentUtcDateTime -Path $path
 

--- a/test/E2E/TestFunctionApp/DurableClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClient/run.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 $FunctionName = $Request.Query.FunctionName ?? 'DurableOrchestrator'
 
-$InstanceId = Start-NewOrchestration -FunctionName $FunctionName -InputObject 'Hello'
+$InstanceId = Start-DurableOrchestration -FunctionName $FunctionName -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/test/E2E/TestFunctionApp/DurableClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClient/run.ps1
@@ -11,7 +11,7 @@ $FunctionName = $Request.Query.FunctionName ?? 'DurableOrchestrator'
 $InstanceId = Start-NewOrchestration -FunctionName $FunctionName -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "DurableClient completed"

--- a/test/E2E/TestFunctionApp/DurableClientLegacyNames/function.json
+++ b/test/E2E/TestFunctionApp/DurableClientLegacyNames/function.json
@@ -1,0 +1,24 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }    
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableClientLegacyNames/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClientLegacyNames/run.ps1
@@ -1,0 +1,15 @@
+using namespace System.Net
+
+param($Request, $TriggerMetadata)
+
+Write-Host "DurableClientLegacyNames started"
+
+$ErrorActionPreference = 'Stop'
+
+$InstanceId = Start-NewOrchestration -FunctionName 'DurableOrchestratorLegacyNames' -InputObject 'Hello'
+Write-Host "Started orchestration with ID = '$InstanceId'"
+
+$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+Push-OutputBinding -Name Response -Value $Response
+
+Write-Host "DurableClientLegacyNames completed"

--- a/test/E2E/TestFunctionApp/DurableOrchestrator/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestrator/run.ps1
@@ -10,18 +10,18 @@ Set-DurableCustomStatus -CustomStatus 'Custom status: started'
 
 # Function chaining
 $output = @()
-$output += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "Tokyo"
+$output += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Tokyo"
 
 # Fan-out/Fan-in
 $tasks = @()
-$tasks += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "Seattle" -NoWait
-$tasks += Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "London" -NoWait
+$tasks += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Seattle" -NoWait
+$tasks += Invoke-DurableActivity -FunctionName "DurableActivity" -Input "London" -NoWait
 $output += Wait-DurableTask -Task $tasks
 
 # Retries
 $retryOptions = New-DurableRetryOptions -FirstRetryInterval (New-Timespan -Seconds 2) -MaxNumberOfAttempts 5
 $inputData = @{ Name = 'Toronto'; StartTime = $Context.CurrentUtcDateTime }
-$output += Invoke-ActivityFunction -FunctionName "DurableActivityFlaky" -Input $inputData -RetryOptions $retryOptions
+$output += Invoke-DurableActivity -FunctionName "DurableActivityFlaky" -Input $inputData -RetryOptions $retryOptions
 
 Set-DurableCustomStatus -CustomStatus 'Custom status: finished'
 

--- a/test/E2E/TestFunctionApp/DurableOrchestratorLegacyNames/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorLegacyNames/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorLegacyNames/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorLegacyNames/run.ps1
@@ -1,0 +1,13 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "DurableOrchestratorLegacyNames: started. Input: $($Context.Input)"
+
+Invoke-ActivityFunction -FunctionName "DurableActivity" -Input "Tokyo"
+
+Write-Host "DurableOrchestratorLegacyNames: finished."
+
+return $output

--- a/test/E2E/TestFunctionApp/DurableOrchestratorWithException/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorWithException/run.ps1
@@ -4,6 +4,6 @@ param($Context)
 
 $ErrorActionPreference = 'Stop'
 
-Invoke-ActivityFunction -FunctionName 'DurableActivityWithException' -Input 'Name' -ErrorAction Stop
+Invoke-DurableActivity -FunctionName 'DurableActivityWithException' -Input 'Name' -ErrorAction Stop
 
 'This should not be returned'

--- a/test/E2E/TestFunctionApp/DurableTimerClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableTimerClient/run.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 $InstanceId = Start-NewOrchestration -FunctionName 'DurableTimerOrchestrator'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Write-Host "DurableTimerClient completed"

--- a/test/E2E/TestFunctionApp/DurableTimerClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableTimerClient/run.ps1
@@ -6,7 +6,7 @@ Write-Host "DurableTimerClient started"
 
 $ErrorActionPreference = 'Stop'
 
-$InstanceId = Start-NewOrchestration -FunctionName 'DurableTimerOrchestrator'
+$InstanceId = Start-DurableOrchestration -FunctionName 'DurableTimerOrchestrator'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/test/E2E/TestFunctionApp/ExternalEventClient/run.ps1
+++ b/test/E2E/TestFunctionApp/ExternalEventClient/run.ps1
@@ -11,7 +11,7 @@ $OrchestratorInputs = @{ FirstDuration = 5; SecondDuration = 60 }
 $InstanceId = Start-NewOrchestration -FunctionName 'ExternalEventOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-$Response = New-OrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
 
 Start-Sleep -Seconds 15

--- a/test/E2E/TestFunctionApp/ExternalEventClient/run.ps1
+++ b/test/E2E/TestFunctionApp/ExternalEventClient/run.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 $OrchestratorInputs = @{ FirstDuration = 5; SecondDuration = 60 }
 
-$InstanceId = Start-NewOrchestration -FunctionName 'ExternalEventOrchestrator' -InputObject $OrchestratorInputs
+$InstanceId = Start-DurableOrchestration -FunctionName 'ExternalEventOrchestrator' -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId


### PR DESCRIPTION
Renaming some Durable Functions commands to follow the following pattern consistently:

_[Verb]_-**Durable**_[Additional qualifiers]_

**Old name** | **New name**
--- | ---
Invoke-ActivityFunction | Invoke-DurableActivity
New-OrchestrationCheckStatusResponse | New-DurableOrchestrationCheckStatusResponse
Start-NewOrchestration | Start-DurableOrchestration

The old names are kept as aliases for backward-compatibility purposes.