### PR TITLE
Add Get-DurableStatus and Stop-DurableOrchestration commands

### DIFF
--- a/examples/durable/DurableApp/InstanceManagement/function.json
+++ b/examples/durable/DurableApp/InstanceManagement/function.json
@@ -1,0 +1,24 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }    
+  ]
+}

--- a/examples/durable/DurableApp/InstanceManagement/run.ps1
+++ b/examples/durable/DurableApp/InstanceManagement/run.ps1
@@ -1,0 +1,28 @@
+using namespace System.Net
+
+param($Request, $TriggerMetadata)
+
+Write-Host 'InstanceManagement started'
+
+$InstanceId = Start-DurableOrchestration -FunctionName 'FunctionChainingOrchestrator' -InputObject $Request.Query.Input
+Write-Host "Started orchestration $($Request.Params.FunctionName) with ID = '$InstanceId'"
+
+do {
+    $Status = Get-DurableStatus -InstanceId $InstanceId -ShowHistory -ShowHistoryOutput -ShowInput
+    Write-Host "Status: $($Status | ConvertTo-Json)"
+    Start-Sleep -Seconds 5
+} while ($Status.runtimeStatus -ne 'Running')
+
+Write-Host "Terminating orchestration $InstanceId..."
+Stop-DurableOrchestration -InstanceId $InstanceId -Reason 'Terminated intentionally'
+
+do {
+    $Status = Get-DurableStatus -InstanceId $InstanceId -ShowHistory -ShowHistoryOutput -ShowInput
+    Write-Host "Status: $($Status | ConvertTo-Json)"
+    Start-Sleep -Seconds 5
+} while ($Status.runtimeStatus -ne 'Terminated')
+
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+Push-OutputBinding -Name Response -Value $Response
+
+Write-Host 'InstanceManagement completed'

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -49,10 +49,12 @@ NestedModules = @('Microsoft.Azure.Functions.PowerShellWorker.psm1', 'Microsoft.
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
+    'Get-DurableStatus',
     'New-DurableRetryOptions',
     'New-DurableOrchestrationCheckStatusResponse',
     'Send-DurableExternalEvent',
-    'Start-DurableOrchestration')
+    'Start-DurableOrchestration',
+    'Stop-DurableOrchestration')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -414,7 +414,60 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                 }
             }
         }
-        
+
+        [Fact]
+        public async Task DurableClientTerminatesOrchestration()
+        {
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClientTerminating", queryString: string.Empty);
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var location = initialResponse.Headers.Location;
+
+            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
+            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
+            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
+
+            var startTime = DateTime.UtcNow;
+
+            using (var httpClient = new HttpClient())
+            {
+                while (true)
+                {
+                    var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
+                    switch (statusResponse.StatusCode)
+                    {
+                        case HttpStatusCode.Accepted:
+                        {
+                            var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                            var runtimeStatus = (string)statusResponseBody.runtimeStatus;
+                            Assert.True(
+                                runtimeStatus == "Running" || runtimeStatus == "Pending",
+                                $"Unexpected runtime status: {runtimeStatus}");
+
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
+                            {
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                            }
+
+                            await Task.Delay(TimeSpan.FromSeconds(2));
+                            break;
+                        }
+
+                        case HttpStatusCode.OK:
+                        {
+                            var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                            Assert.Equal("Terminated", (string)statusResponseBody.runtimeStatus);
+                            Assert.Equal("Terminated intentionally", (string)statusResponseBody.output);
+                            return;
+                        }
+
+                        default:
+                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                            break;
+                    }
+                }
+            }
+        }
         
         private void VerifyArrayItemsAreEqual(string[] array, int[] indices)
         {

--- a/test/E2E/TestFunctionApp/DurableClientTerminating/function.json
+++ b/test/E2E/TestFunctionApp/DurableClientTerminating/function.json
@@ -1,0 +1,24 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }    
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableClientTerminating/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClientTerminating/run.ps1
@@ -11,13 +11,9 @@ $FunctionName = $Request.Query.FunctionName ?? 'DurableOrchestrator'
 $InstanceId = Start-DurableOrchestration -FunctionName $FunctionName -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
+Stop-DurableOrchestration -InstanceId $InstanceId -Reason 'Terminated intentionally'
+
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response
-
-$Status = Get-DurableStatus -InstanceId $InstanceId
-Write-Host "Orchestration $InstanceId status: $($Status | ConvertTo-Json)"
-if ($Status.runtimeStatus -notin 'Pending', 'Running', 'Failed') {
-    throw "Unexpected orchestration $InstanceId runtime status: $($Status.runtimeStatus)"
-}
 
 Write-Host "DurableClient completed"


### PR DESCRIPTION
This implements two Durable Functions instance management features:

- `Get-DurableStatus` command: [Query instances](https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-instance-management?tabs=csharp#query-instances)
- `Stop-DurableOrchestration` command: [Terminate instances](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-instance-management?tabs=csharp#terminate-instances)