### PR TITLE
Enable building PowerShell 7.0

### DIFF
--- a/PowerShellWorker.Common.props
+++ b/PowerShellWorker.Common.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
-    <Version>3.0.$(BuildNumber)</Version>
+    <Version>4.0.$(BuildNumber)</Version>
     <PackageTags>PowerShell;AzureFunctions;language;Azure;</PackageTags>
-    <PackageLicenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/Azure/azure-functions-powershell-worker/blob/dev/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/azure-functions-powershell-worker</RepositoryUrl>
   </PropertyGroup>

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -5,10 +5,10 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.Azure.Functions.PowerShellWorker.PS7</id>
+    <id>Microsoft.Azure.Functions.PowerShellWorker.PS7.0</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
-    <title>Azure Function PowerShell Language Worker (PowerShell 7)</title>
+    <title>Azure Function PowerShell Language Worker (PowerShell 7.0)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -27,7 +27,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </metadata>
   <files>
     <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7" />
-    <file src="..\src\bin\$configuration$\$targetFramework$\publish\worker.config.json" target="contentFiles\any\any\workers\powershell" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>
 </package>

--- a/src/worker.config.json
+++ b/src/worker.config.json
@@ -4,8 +4,8 @@
         "extensions":[".ps1", ".psm1"],
         "defaultExecutablePath":"dotnet",
         "defaultWorkerPath":"%FUNCTIONS_WORKER_RUNTIME_VERSION%/Microsoft.Azure.Functions.PowerShellWorker.dll",
-        "supportedRuntimeVersions":["6", "7"],
-        "defaultRuntimeVersion":"6",
-        "sanitizeRuntimeVersionRegex":"\\d+"
+        "supportedRuntimeVersions":["7", "7.2"],
+        "defaultRuntimeVersion":null,
+        "sanitizeRuntimeVersionRegex":"\\d+\\.?\\d*"
     }
 }


### PR DESCRIPTION
This PR contains the following:

* Update PowerShell worker version to match the Functions Host version
* Update package id to Microsoft.Azure.Functions.PowerShellWorker.PS7.0
* Update `worker.config.json` to support PowerShell 7.0