### PR TITLE
Preserve requirements.psd1 and use it for managed dependencies snapshot comparison

### DIFF
--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             ILogger logger = null)
         {
             _storage = storage ?? new DependencyManagerStorage(GetFunctionAppRootPath(requestMetadataDirectory));
-            _installedDependenciesLocator = installedDependenciesLocator ?? new InstalledDependenciesLocator(_storage);
+            _installedDependenciesLocator = installedDependenciesLocator ?? new InstalledDependenciesLocator(_storage, logger);
             var snapshotContentLogger = new PowerShellModuleSnapshotLogger();
             _installer = installer ?? new DependencySnapshotInstaller(
                                             moduleProvider ?? new PowerShellGalleryModuleProvider(logger),

--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             _maxDependencyEntries = maxDependencyEntries;
         }
 
+        public string GetPath()
+        {
+            return Path.Combine(_functionAppRootPath, RequirementsPsd1FileName);
+        }
+
         public IEnumerable<DependencyManifestEntry> GetEntries()
         {
             var hashtable = ParsePowerShellDataFile();
@@ -93,7 +98,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private Hashtable ParsePowerShellDataFile()
         {
             // Path to requirements.psd1 file.
-            var requirementsFilePath = Path.Join(_functionAppRootPath, RequirementsPsd1FileName);
+            var requirementsFilePath = GetPath();
 
             if (!File.Exists(requirementsFilePath))
             {

--- a/src/DependencyManagement/DependencySnapshotInstaller.cs
+++ b/src/DependencyManagement/DependencySnapshotInstaller.cs
@@ -108,7 +108,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         {
             try
             {
-                return _storage.CreateInstallingSnapshot(path);
+                var installingPath = _storage.CreateInstallingSnapshot(path);
+                _storage.PreserveDependencyManifest(installingPath);
+                return installingPath;
             }
             catch (Exception e)
             {

--- a/src/DependencyManagement/IDependencyManagerStorage.cs
+++ b/src/DependencyManagement/IDependencyManagerStorage.cs
@@ -37,5 +37,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         void SetSnapshotAccessTimeToUtcNow(string path);
 
         DateTime GetSnapshotAccessTimeUtc(string path);
+
+        void PreserveDependencyManifest(string path);
+
+        bool IsEquivalentDependencyManifest(string path);
     }
 }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -337,4 +337,19 @@
   <data name="LogDependencySnapshotsInstalledAndSnapshotsToKeep" xml:space="preserve">
     <value>Number of dependency snapshots installed: '{0}'. Dependency snapshots to keep: '{1}'.</value>
   </data>
+  <data name="NoInstalledDependencySnapshot" xml:space="preserve">
+    <value>No installed dependency snapshot found.</value>
+  </data>
+  <data name="LastInstalledDependencySnapshotFound" xml:space="preserve">
+    <value>Last installed dependency snapshot found: '{0}'.</value>
+  </data>
+  <data name="EquivalentDependencySnapshotManifest" xml:space="preserve">
+    <value>Dependency snapshot '{0}' manifest is equivalent to the current manifest.</value>
+  </data>
+  <data name="DependencySnapshotContainsAcceptableModuleVersions" xml:space="preserve">
+    <value>Dependency snapshot '{0}' contains acceptable module versions.</value>
+  </data>
+  <data name="DependencySnapshotDoesNotContainAcceptableModuleVersions" xml:space="preserve">
+    <value>Dependency snapshot '{0}' does not contain acceptable module versions.</value>
+  </data>
 </root>

--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 var mockModuleProvider = new MockModuleProvider { SuccessfulDownload = true };
 
                 // Create DependencyManager and process the requirements.psd1 file at the function app root.
-                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, mockModuleProvider))
+                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, mockModuleProvider, logger: _testLogger))
                 {
                     dependencyManager.Initialize(_testLogger);
 
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 var mockModuleProvider = new MockModuleProvider { ShouldNotThrowAfterCount = 2 };
 
                 // Create DependencyManager and process the requirements.psd1 file at the function app root.
-                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, mockModuleProvider))
+                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, mockModuleProvider, logger: _testLogger))
                 {
                     dependencyManager.Initialize(_testLogger);
 
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 var functionLoadRequest = GetFuncLoadRequest(functionFolderPath, true);
 
                 // Create DependencyManager and process the requirements.psd1 file at the function app root.
-                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, new MockModuleProvider()))
+                using (var dependencyManager = new DependencyManager(functionLoadRequest.Metadata.Directory, new MockModuleProvider(), logger: _testLogger))
                 {
                     dependencyManager.Initialize(_testLogger);
 
@@ -382,7 +382,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 // the PSGallery to retrieve the latest module version
                 using (var dependencyManager = new DependencyManager(
                     functionLoadRequest.Metadata.Directory,
-                    new MockModuleProvider { GetLatestModuleVersionThrows = true }))
+                    new MockModuleProvider { GetLatestModuleVersionThrows = true },
+                    logger: _testLogger))
                 {
                     dependencyManager.Initialize(_testLogger);
                     dependencyManager.StartDependencyInstallationIfNeeded(PowerShell.Create(), PowerShell.Create, _testLogger);
@@ -417,7 +418,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
                 // the PSGallery to retrive the latest module version
                 using (var dependencyManager = new DependencyManager(
                     functionLoadRequest.Metadata.Directory,
-                    new MockModuleProvider { GetLatestModuleVersionThrows = true }))
+                    new MockModuleProvider { GetLatestModuleVersionThrows = true },
+                    logger: _testLogger))
                 {
                     // Create a path to mimic an existing installation of the Az module
                     AzModulePath = Path.Join(managedDependenciesFolderPath, "FakeDependenciesSnapshot", "Az");

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -313,7 +313,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 installer: _mockInstaller.Object,
                 newerSnapshotDetector: _mockNewerDependencySnapshotDetector.Object,
                 maintainer: _mockBackgroundDependencySnapshotMaintainer.Object,
-                currentSnapshotContentLogger: _mockBackgroundDependencySnapshotContentLogger.Object);
+                currentSnapshotContentLogger: _mockBackgroundDependencySnapshotContentLogger.Object,
+                logger: _mockLogger.Object);
         }
     }
 }

--- a/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
+++ b/test/Unit/DependencyManagement/DependencySnapshotInstallerTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
             _targetPathInstalled = DependencySnapshotFolderNameTools.CreateUniqueName();
             _targetPathInstalling = DependencySnapshotFolderNameTools.ConvertInstalledToInstalling(_targetPathInstalled);
             _mockStorage.Setup(_ => _.CreateInstallingSnapshot(_targetPathInstalled)).Returns(_targetPathInstalling);
+            _mockStorage.Setup(_ => _.PreserveDependencyManifest(_targetPathInstalling));
             _mockStorage.Setup(_ => _.PromoteInstallingSnapshotToInstalledAtomically(_targetPathInstalled));
             _mockStorage.Setup(_ => _.GetLatestInstalledSnapshot()).Returns(default(string));
         }


### PR DESCRIPTION
Potentially fixes #647 without the need to introduce a [breaking change](https://github.com/Azure/Azure-Functions/issues/2011).

- When a new snapshot is created, _copy_ the `requirements.psd1` file from the app content to the snapshot directory, so that each snapshot is explicitly associated with the app author intent.
- When the worker evaluates an existing snapshot content to decide whether this snapshot is acceptable or not:
  - Compare the `requirements.psd1` files in the snapshot and in the app content _before_ looking for specific versions.
  - If the `requirements.psd1` content matches, consider this snapshot acceptable (since this snapshot is the result of applying `Save-Module`, regardless of the module version matching rules implemented internally by `Save-Module`).
  - If these files don't match (or the snapshot does not contain `requirements.psd1` because this is an older snapshot, created before rolling out this fix), proceed with looking for specific module versions as usual.

As a result, for example, if `requirements.psd1` contains `'PnP.PowerShell' = '1.5'`, invoking `Save-Module` will still install version **1.5.0**. But, since the original `requirements.psd1` is preserved with the snapshot, the next PowerShell Worker instance will consider this snapshot acceptable and will start using it right away, without creating another one. The problem is solved without introducing a breaking change.