### PR TITLE
Set requirements.psd1 max dependency entries to 50

### DIFF
--- a/src/DependencyManagement/DependencyManifest.cs
+++ b/src/DependencyManagement/DependencyManifest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         private readonly int _maxDependencyEntries;
 
-        public DependencyManifest(string functionAppRootPath, int maxDependencyEntries = 10)
+        public DependencyManifest(string functionAppRootPath, int maxDependencyEntries = 50)
         {
             if (string.IsNullOrWhiteSpace(functionAppRootPath))
             {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-powershell-worker/issues/675

We already have regression tests to validate the error message when the number of entries in requirements.psd1 exceeds  `_maxDependencyEntries` at https://github.com/Azure/azure-functions-powershell-worker/blob/dev/test/Unit/DependencyManagement/DependencyManifestTests.cs#L163