### PR TITLE
Fix CosmosDB E2E test

### DIFF
--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -57,7 +57,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     retrievedDocument = await _docDbClient.ReadDocumentAsync(docUri);
                     return true;
                 }
-                catch (DocumentClientException ex) when (ex.Error.Code == "NotFound")
+                catch (DocumentClientException ex) when (ex.Error.Code == "NotFound" || ex.Error.Code == "Not Found")
                 {
                     return false;
                 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

A Cosmos DB error code changed and the E2E test fails because it is not retrying ReadDocument when it should be.

Note: I will port this change via cherry pick to the `v3.x/ps7` and `v4.x/ps7.0` branches.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
