### PR TITLE
Allow DF Activity Functions to have multiple output bindings

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         private static void BindOutputFromResult(InvocationResponse response, AzFunctionInfo functionInfo, IDictionary results)
         {
-            if (functionInfo.DurableFunctionInfo.Type == DurableFunctionType.None) // TODO: but let activity functions have output bindings, too
+            if (functionInfo.DurableFunctionInfo.Type != DurableFunctionType.OrchestrationFunction)
             {
                 // Set out binding data and return response to be sent back to host
                 foreach (var (bindingName, bindingInfo) in functionInfo.OutputBindings)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/646

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Previously, the Function `BindOutputFromResult` would only bind output values for non-DF Function types. It appears this was put in place to prevent DF orchestrators from having multiple output bindings. However, the implementation also prevented Activity Functions from having multiple output bindings, which led to the bug report linked above.

This PR refines the logic to apply **only** to orchestrators. 

There are two work-items still left-over for this PR.

The first is that it needs a test, but I'll need some onboarding to that part of the codebase beforehand.

The second is that I don't understand the reasoning for preventing orchestrators from having multiple output bindings. To my knowledge, this is not a limitation in other DF SDKs.  Put differently, why is it that `BindOutputFromResult` needs to inspect whether a Function uses DF-bindings at all? Shouldn't it's logic be DF-independent in all cases? 

Thanks! Very excited to be making my first contribution to the PowerShell repo! ✨✨