### PR TITLE
Allow DF Activity Functions to have multiple output bindings

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,1 @@
+* Bug fix: Activity Functions can now use output bindings (https://github.com/Azure/azure-functions-powershell-worker/issues/646)

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         /// </summary>
         private static void BindOutputFromResult(InvocationResponse response, AzFunctionInfo functionInfo, IDictionary results)
         {
-            if (functionInfo.DurableFunctionInfo.Type == DurableFunctionType.None) // TODO: but let activity functions have output bindings, too
+            if (functionInfo.DurableFunctionInfo.Type != DurableFunctionType.OrchestrationFunction)
             {
                 // Set out binding data and return response to be sent back to host
                 foreach (var (bindingName, bindingInfo) in functionInfo.OutputBindings)

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -148,6 +148,56 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         }
 
         [Fact]
+        public async Task ActivityCanHaveQueueBinding()
+        {
+            const string queueName = "outqueue";
+            await StorageHelpers.ClearQueue(queueName);
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorWriteToQueue");
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
+            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
+            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
+
+            var startTime = DateTime.UtcNow;
+
+            using var httpClient = new HttpClient();
+
+            while (true)
+            {
+                var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
+                switch (statusResponse.StatusCode)
+                {
+                    case HttpStatusCode.Accepted:
+                        {
+                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
+                            {
+                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                            }
+
+                            await Task.Delay(TimeSpan.FromSeconds(2));
+                            break;
+                        }
+
+                    case HttpStatusCode.OK:
+                        {
+                            var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                            Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
+
+                            var queueMessage = await StorageHelpers.ReadFromQueue(queueName);
+                            Assert.Equal("QueueData", queueMessage);
+                            return;
+                        }
+
+                    default:
+                        Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                        break;
+                }
+            }
+        }
+
+
+        [Fact]
         public async Task ActivityExceptionIsPropagatedThroughOrchestrator()
         {
             var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorWithException");

--- a/test/E2E/TestFunctionApp/DurableActivityWritesToQueue/function.json
+++ b/test/E2E/TestFunctionApp/DurableActivityWritesToQueue/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    },
+    {
+        "type": "queue",
+        "direction": "out",
+        "name": "outputQueueItem",
+        "queueName": "outqueue",
+        "connection": "AzureWebJobsStorage"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableActivityWritesToQueue/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableActivityWritesToQueue/run.ps1
@@ -1,0 +1,7 @@
+param($name)
+
+Write-Information "Pushing to outputQueueItem output binding"
+Push-OutputBinding -Name outputQueueItem -Value $name
+Write-Information "Done"
+
+"Hello $name!"

--- a/test/E2E/TestFunctionApp/DurableClient/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClient/run.ps1
@@ -16,7 +16,7 @@ Push-OutputBinding -Name Response -Value $Response
 
 $Status = Get-DurableStatus -InstanceId $InstanceId
 Write-Host "Orchestration $InstanceId status: $($Status | ConvertTo-Json)"
-if ($Status.runtimeStatus -notin 'Pending', 'Running', 'Failed') {
+if ($Status.runtimeStatus -notin 'Pending', 'Running', 'Failed', 'Completed') {
     throw "Unexpected orchestration $InstanceId runtime status: $($Status.runtimeStatus)"
 }
 

--- a/test/E2E/TestFunctionApp/DurableOrchestratorWriteToQueue/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorWriteToQueue/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorWriteToQueue/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorWriteToQueue/run.ps1
@@ -1,0 +1,5 @@
+using namespace System.Net
+
+param($Context)
+
+Invoke-DurableActivity -FunctionName 'DurableActivityWritesToQueue' -Input 'QueueData'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/646
replaces https://github.com/Azure/azure-functions-powershell-worker/pull/700

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-powershell-worker/pull/703, https://github.com/Azure/azure-functions-powershell-worker/pull/704
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Previously, the Function `BindOutputFromResult` would only bind output values for non-DF Function types. It appears this was put in place to prevent DF orchestrators from having multiple output bindings. However, the implementation also prevented Activity Functions from having multiple output bindings, which led to the bug report linked above.

This PR refines the logic to apply **only** to orchestrators. 