### PR TITLE
Add SBOM generation as part of the build process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,10 @@ steps:
 
 - pwsh: |
       $ErrorActionPreference = "Stop"
-      ./build.ps1 -Clean -Configuration Release -BuildNumber "$(buildNumber)"
+      ./build.ps1 -Clean -Configuration Release -BuildNumber "$(buildNumber)" -AddSBOM -SBOMUtilSASUrl $env:SBOMUtilSASUrl
   displayName: 'Build worker code'
+  env:
+    SBOMUtilSASUrl: $(SBOMUtilSASUrl)
 
 - pwsh: ./build.ps1 -NoBuild -Test
   displayName: 'Running UnitTest'

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -9,6 +9,13 @@ $IsWindowsEnv = [RuntimeInformation]::IsOSPlatform([OSPlatform]::Windows)
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 
 $DotnetSDKVersionRequirements = @{
+
+    # .NET SDK 3.1 is required by the Microsoft.ManifestTool.dll tool
+    '3.1' = @{
+        MinimalPatch = '415'
+        DefaultPatch = '415'
+    }
+
     '6.0' = @{
         MinimalPatch = '100'
         DefaultPatch = '100'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
* Updated `build.ps1` to generate the SBOM as part of the build process
    * Added `$AddSBOM` parameter switch to specify the generation of the manifest during the build
    * Added `$SBOMUtilSASUrl` parameter, which is a SAS url pointing to the location where the `ManifestTool` is located
    * Install `Microsoft.ManifestTool.dll` from the `$SBOMUtilSASUrl` (encrypted pipeline variable)
* Install .Net 3.1 (the runtime is required by `Microsoft.ManifestTool.dll`)
* Updated `azure-pipelines.yml` to pass the new parameters to the `build.ps1` 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
