### PR TITLE
Allow completed Tasks to expose their results

### DIFF
--- a/src/Durable/Commands/GetDurableTaskResult.cs
+++ b/src/Durable/Commands/GetDurableTaskResult.cs
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member 'member'
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Commands
+{
+    using System.Collections;
+    using System.Management.Automation;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks;
+
+    [Cmdlet("Get", "DurableTaskResult")]
+    public class GetDurableTaskResultCommand : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        [ValidateNotNull]
+        public DurableTask[] Task { get; set; }
+
+        private readonly DurableTaskHandler _durableTaskHandler = new DurableTaskHandler();
+
+        protected override void EndProcessing()
+        {
+            var privateData = (Hashtable)MyInvocation.MyCommand.Module.PrivateData;
+            var context = (OrchestrationContext)privateData[SetFunctionInvocationContextCommand.ContextKey];
+
+            _durableTaskHandler.GetTaskResult(Task, context, WriteObject);
+        }
+
+        protected override void StopProcessing()
+        {
+            _durableTaskHandler.Stop();
+        }
+    }
+}

--- a/src/Durable/DurableTaskHandler.cs
+++ b/src/Durable/DurableTaskHandler.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                 if (scheduledHistoryEvent != null)
                 {
                     scheduledHistoryEvent.IsProcessed = true;
+                    scheduledHistoryEvent.IsPlayed = true;
                 }
 
                 if (completedHistoryEvent != null)
@@ -179,6 +180,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     }
 
                     completedHistoryEvent.IsProcessed = true;
+                    completedHistoryEvent.IsPlayed = true;
                 }
             }
 
@@ -192,6 +194,21 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             else
             {
                 InitiateAndWaitForStop(context);
+            }
+        }
+
+        public void GetTaskResult(
+            IReadOnlyCollection<DurableTask> tasksToQueryResultFor,
+            OrchestrationContext context,
+            Action<object> output)
+        {
+            foreach (var task in tasksToQueryResultFor) {
+                var scheduledHistoryEvent = task.GetScheduledHistoryEvent(context, true);
+                var processedHistoryEvent = task.GetCompletedHistoryEvent(context, scheduledHistoryEvent, true);
+                if (processedHistoryEvent != null)
+                {
+                    output(GetEventResult(processedHistoryEvent));
+                }
             }
         }
 

--- a/src/Durable/Tasks/ActivityInvocationTask.cs
+++ b/src/Durable/Tasks/ActivityInvocationTask.cs
@@ -37,15 +37,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
         {
         }
 
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return context.History.FirstOrDefault(
                 e => e.EventType == HistoryEventType.TaskScheduled &&
                      e.Name == FunctionName &&
-                     !e.IsProcessed);
+                     e.IsProcessed == processed);
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed)
         {
             return scheduledHistoryEvent == null
                 ? null

--- a/src/Durable/Tasks/DurableTask.cs
+++ b/src/Durable/Tasks/DurableTask.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
 
     public abstract class DurableTask
     {
-        internal abstract HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context);
+        internal abstract HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed = false);
 
-        internal abstract HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent);
+        internal abstract HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed = false);
 
         internal abstract OrchestrationAction CreateOrchestrationAction();
     }

--- a/src/Durable/Tasks/DurableTimerTask.cs
+++ b/src/Durable/Tasks/DurableTimerTask.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
             Action = new CreateDurableTimerAction(FireAt);
         }
 
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return context.History.FirstOrDefault(
                 e => e.EventType == HistoryEventType.TimerCreated &&
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
                      !e.IsProcessed);
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed)
         {
             return scheduledHistoryEvent == null
                 ? null

--- a/src/Durable/Tasks/ExternalEventTask.cs
+++ b/src/Durable/Tasks/ExternalEventTask.cs
@@ -21,17 +21,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
         }
 
         // There is no corresponding history event for an expected external event
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return null;
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent taskScheduled)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent taskScheduled, bool processed)
         {
             return context.History.FirstOrDefault(
                     e => e.EventType == HistoryEventType.EventRaised &&
                          e.Name == ExternalEventName &&
-                         !e.IsProcessed);
+                         e.IsPlayed == processed);
         }
 
         internal override OrchestrationAction CreateOrchestrationAction()

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -59,6 +59,7 @@ FunctionsToExport = @(
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(
     'Get-OutputBinding',
+    'Get-DurableTaskResult'
     'Invoke-DurableActivity',
     'Push-OutputBinding',
     'Set-DurableCustomStatus',

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -235,6 +235,8 @@ function New-DurableOrchestrationCheckStatusResponse {
     The TaskHubName of the orchestration instance that will handle the external event.
 .PARAMETER ConnectionName
     The name of the connection string associated with TaskHubName
+.PARAMETER AppCode
+    The Azure Functions system key
 #>
 function Send-DurableExternalEvent {
     [CmdletBinding()]
@@ -263,12 +265,16 @@ function Send-DurableExternalEvent {
 
         [Parameter(
             ValueFromPipelineByPropertyName=$true)]
-        [string] $ConnectionName
+        [string] $ConnectionName,
+
+        [Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $AppCode
     )
     
     $DurableClient = GetDurableClientFromModulePrivateData
 
-    $RequestUrl = GetRaiseEventUrl -DurableClient $DurableClient -InstanceId $InstanceId -EventName $EventName -TaskHubName $TaskHubName -ConnectionName $ConnectionName
+    $RequestUrl = GetRaiseEventUrl -DurableClient $DurableClient -InstanceId $InstanceId -EventName $EventName -TaskHubName $TaskHubName -ConnectionName $ConnectionName -AppCode $AppCode
 
     $Body = $EventData | ConvertTo-Json -Compress
               
@@ -280,7 +286,8 @@ function GetRaiseEventUrl(
     [string] $InstanceId,
     [string] $EventName,
     [string] $TaskHubName,
-    [string] $ConnectionName) {
+    [string] $ConnectionName,
+    [string] $AppCode) {
 
     $RequestUrl = $DurableClient.BaseUrl + "/instances/$InstanceId/raiseEvent/$EventName"
     
@@ -290,6 +297,9 @@ function GetRaiseEventUrl(
     }
     if ($null -eq $ConnectionName) {
         $query += "connection=$ConnectionName"
+    }
+    if ($null -eq $AppCode) {
+        $query += "code=$AppCode"
     }
     if ($query.Count -gt 0) {
         $RequestUrl += "?" + [string]::Join("&", $query)

--- a/test/Unit/Durable/ActivityInvocationTaskTests.cs
+++ b/test/Unit/Durable/ActivityInvocationTaskTests.cs
@@ -225,8 +225,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             var orchestrationContext = new OrchestrationContext { History = history };
 
             var task = new ActivityInvocationTask(FunctionName, FunctionInput);
-            var scheduledEvent = task.GetScheduledHistoryEvent(orchestrationContext);
-            var completedEvent = task.GetCompletedHistoryEvent(orchestrationContext, scheduledEvent);
+            var scheduledEvent = task.GetScheduledHistoryEvent(orchestrationContext, false);
+            var completedEvent = task.GetCompletedHistoryEvent(orchestrationContext, scheduledEvent, false);
 
             Assert.Equal(scheduledEvent.EventId, completedEvent.TaskScheduledId);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Contribution by @oobegreg, thank you!

### Issue describing the changes in this PR

resolves #685

Currently, users do not have a way of obtaining the result of a DF Task that has already completed. This means that if a user did not assign a Task onto a variable when first invoking it, then they have no way of accessing its result. 

This is an urgently missing feature and @oobegreg is proposing a CmdLet named `Get-DurableTaskResult` that allows us to do just that.

In general, this serves the purpose of performing an `await` (or `yield` in Python and JS)  on a completed Durable Task, because in those languages re-awaiting a completed Task is a supported means of extracting that Task's result. Another way to do this is to expose a `.result` property on the `DurableTask` class and have users access that. However, I think this CmdLet-based approach is also sound, and I don't see why we couldn't have both given that users in other PLs can both access their classes' `.result` property *and* call `yield/await` for the same effect.

My recommendation is to merge this contribution, but I would like to get everyone's feedback first. Thanks!

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
