### PR TITLE
Allow worker to read results directly from the external SDK

### DIFF
--- a/src/DurableSDK/ExternalInvoker.cs
+++ b/src/DurableSDK/ExternalInvoker.cs
@@ -6,22 +6,21 @@
 namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 {
     using System;
+    using System.Collections;
     using System.Management.Automation;
 
     internal class ExternalInvoker : IExternalInvoker
     {
         private readonly Func<PowerShell, object> _externalSDKInvokerFunction;
-        private readonly IPowerShellServices _powerShellServices;
 
-        public ExternalInvoker(Func<PowerShell, object> invokerFunction, IPowerShellServices powerShellServices)
+        public ExternalInvoker(Func<PowerShell, object> invokerFunction)
         {
             _externalSDKInvokerFunction = invokerFunction;
-            _powerShellServices = powerShellServices;
         }
 
-        public void Invoke()
+        public Hashtable Invoke(IPowerShellServices powerShellServices)
         {
-            _externalSDKInvokerFunction.Invoke(_powerShellServices.GetPowerShell());
+            return (Hashtable)_externalSDKInvokerFunction.Invoke(powerShellServices.GetPowerShell());
         }
     }
 }

--- a/src/DurableSDK/IExternalInvoker.cs
+++ b/src/DurableSDK/IExternalInvoker.cs
@@ -5,10 +5,12 @@
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 {
+    using System.Collections;
+
     // Represents a contract for the 
     internal interface IExternalInvoker
     {
         // Method to invoke an orchestration using the external Durable SDK
-        void Invoke();
+        Hashtable Invoke(IPowerShellServices powerShellServices);
     }
 }

--- a/src/DurableSDK/OrchestrationContext.cs
+++ b/src/DurableSDK/OrchestrationContext.cs
@@ -35,18 +35,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         internal OrchestrationActionCollector OrchestrationActionCollector { get; } = new OrchestrationActionCollector();
 
-        internal object ExternalSDKResult;
-
-        internal bool ExternalSDKIsError;
-
-        // Called by the External DF SDK to communicate its orchestration result
-        // back to the worker.
-        internal void SetExternalResult(object result, bool isError)
-        {
-            this.ExternalSDKResult = result;
-            this.ExternalSDKIsError = isError;
-        }
-
         internal object CustomStatus { get; set; }
     }
 }

--- a/src/DurableSDK/OrchestrationInvoker.cs
+++ b/src/DurableSDK/OrchestrationInvoker.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
     internal class OrchestrationInvoker : IOrchestrationInvoker
     {
         private IExternalInvoker _externalInvoker;
+        internal static string isOrchestrationFailureKey = "IsOrchestrationFailure";
 
         public Hashtable Invoke(
             OrchestrationBindingInfo orchestrationBindingInfo,
@@ -29,6 +30,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                 }
                 return InvokeInternalDurableSDK(orchestrationBindingInfo, powerShellServices);
             }
+            catch (Exception ex)
+            {
+                ex.Data.Add(isOrchestrationFailureKey, true);
+                throw;
+            }
             finally
             {
                 powerShellServices.ClearStreamsAndCommands();
@@ -37,7 +43,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         public Hashtable InvokeExternalDurableSDK(IPowerShellServices powerShellServices)
         {
-
             return _externalInvoker.Invoke(powerShellServices);
         }
 
@@ -87,6 +92,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     // this should be treated as an entire orchestration failure
                     throw new OrchestrationFailureException(actions, context.CustomStatus, e);
                 }
+
             }
         }
 

--- a/src/DurableSDK/OrchestrationInvoker.cs
+++ b/src/DurableSDK/OrchestrationInvoker.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             {
                 if (powerShellServices.UseExternalDurableSDK())
                 {
-                    return InvokeExternalDurableSDK(orchestrationBindingInfo, powerShellServices);
+                    return InvokeExternalDurableSDK(powerShellServices);
                 }
                 return InvokeInternalDurableSDK(orchestrationBindingInfo, powerShellServices);
             }
@@ -35,22 +35,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             }
         }
 
-        public Hashtable InvokeExternalDurableSDK(
-            OrchestrationBindingInfo orchestrationBindingInfo,
-            IPowerShellServices powerShellServices)
+        public Hashtable InvokeExternalDurableSDK(IPowerShellServices powerShellServices)
         {
 
-            _externalInvoker.Invoke();
-            var result = orchestrationBindingInfo.Context.ExternalSDKResult;
-            var isError = orchestrationBindingInfo.Context.ExternalSDKIsError;
-            if (isError)
-            {
-                throw (Exception)result;
-            }
-            else
-            {
-                return (Hashtable)result;
-            }
+            return _externalInvoker.Invoke(powerShellServices);
         }
 
         public Hashtable InvokeInternalDurableSDK(

--- a/src/DurableSDK/OrchestrationInvoker.cs
+++ b/src/DurableSDK/OrchestrationInvoker.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     // this should be treated as an entire orchestration failure
                     throw new OrchestrationFailureException(actions, context.CustomStatus, e);
                 }
-
             }
         }
 

--- a/src/DurableSDK/PowerShellServices.cs
+++ b/src/DurableSDK/PowerShellServices.cs
@@ -99,11 +99,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     // The external SetFunctionInvocationContextCommand expects a .json string to deserialize
                     // and writes an invoker function to the output pipeline.
                     .AddParameter("OrchestrationContext", context.Data.String)
-                    .AddParameter("SetResult", (Action<object, bool>) orchestrationBindingInfo.Context.SetExternalResult)
                     .InvokeAndClearCommands<Func<PowerShell, object>>();
                 if (output.Count() == 1)
                 {
-                    externalInvoker = new ExternalInvoker(output[0], this);
+                    externalInvoker = new ExternalInvoker(output[0]);
                 }
                 else
                 {

--- a/src/PowerShell/PowerShellManager.cs
+++ b/src/PowerShell/PowerShellManager.cs
@@ -243,9 +243,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.PowerShell
                     Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(e));
                     throw;
                 }
-                catch (OrchestrationFailureException e)
+                catch (Exception e)
                 {
-                    if (e.InnerException is IContainsErrorRecord inner)
+                    if (e.Data.Contains(OrchestrationInvoker.isOrchestrationFailureKey) && e.InnerException is IContainsErrorRecord inner)
                     {
                         Logger.Log(isUserOnlyLog: true, LogLevel.Error, GetFunctionExceptionMessage(inner));
                     }

--- a/test/Unit/Durable/DurableControllerTests.cs
+++ b/test/Unit/Durable/DurableControllerTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         private const string _contextParameterName = "ParameterName";
         private static readonly OrchestrationContext _orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
         private static readonly OrchestrationBindingInfo _orchestrationBindingInfo = new OrchestrationBindingInfo(_contextParameterName, _orchestrationContext);
+        private readonly Mock<IExternalInvoker> _mockExternalInvoker = new Mock<IExternalInvoker>(MockBehavior.Strict);
 
         [Fact]
         public void InitializeBindings_SetsDurableClient_ForDurableClientFunction()
@@ -119,7 +120,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             {
                 CreateParameterBinding(_contextParameterName, _orchestrationContext)
             };
-
             _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(
                 It.IsAny<ParameterBinding>(),
                 out It.Ref<IExternalInvoker>.IsAny))

--- a/test/Unit/Durable/DurableControllerTests.cs
+++ b/test/Unit/Durable/DurableControllerTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         private const string _contextParameterName = "ParameterName";
         private static readonly OrchestrationContext _orchestrationContext = new OrchestrationContext { InstanceId = Guid.NewGuid().ToString() };
         private static readonly OrchestrationBindingInfo _orchestrationBindingInfo = new OrchestrationBindingInfo(_contextParameterName, _orchestrationContext);
-        private readonly Mock<IExternalInvoker> _mockExternalInvoker = new Mock<IExternalInvoker>(MockBehavior.Strict);
 
         [Fact]
         public void InitializeBindings_SetsDurableClient_ForDurableClientFunction()


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Allows the worker to read orchestration results directly from the `Hashtable` resulting from the external SDK invocation. Removes the need to pass the `SetResult` function to the `Set-FunctionInvocationContext` command.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr