### PR TITLE
Adding "WorkerStatus" capability

### DIFF
--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 out StatusResult status);
 
             response.WorkerInitResponse.Capabilities.Add("RpcHttpBodyOnly", "true");
+            response.WorkerInitResponse.Capabilities.Add("WorkerStatus", "true");
 
             // If the environment variable is set, spin up the custom named pipe server.
             // This is typically used for debugging. It will throw a friendly exception if the


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-powershell-worker/issues/785

PowerShell supports WorkerStatus requests but function hosts does not call the api as there is no corresponding capability:
PowerShell worker WorkerStatus support:
https://github.com/Azure/azure-functions-powershell-worker/blob/dev/src/RequestProcessor.cs#L57
Function Host check for WorkerStatus capability:
https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs#L162