### PR TITLE
Fix various DF bugs

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,2 @@
-* Bug fix: Activity Functions can now use output bindings (https://github.com/Azure/azure-functions-powershell-worker/issues/646)
+* Bug fix: [Context.InstanceId can now be accessed](https://github.com/Azure/azure-functions-powershell-worker/issues/727)
+* Bug fix: [Data in External Events is now read and returned to orchestrator](https://github.com/Azure/azure-functions-powershell-worker/issues/68)

--- a/src/Durable/DurableTaskHandler.cs
+++ b/src/Durable/DurableTaskHandler.cs
@@ -57,7 +57,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                                 output(eventResult);
                             }
                             break;
-
+                        case HistoryEventType.EventRaised:
+                            var eventRaisedResult = GetEventResult(completedHistoryEvent);
+                            if (eventRaisedResult != null)
+                            {
+                                output(eventRaisedResult);
+                            }
+                            break;
                         case HistoryEventType.TaskFailed:
                             if (retryOptions == null)
                             {

--- a/src/Durable/DurableTaskHandler.cs
+++ b/src/Durable/DurableTaskHandler.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     }
 
                     completedHistoryEvent.IsProcessed = true;
+                    context.IsReplaying = completedHistoryEvent.IsPlayed;
 
                     switch (completedHistoryEvent.EventType)
                     {
@@ -132,6 +133,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             var allTasksCompleted = completedEvents.Count == tasksToWaitFor.Count;
             if (allTasksCompleted)
             {
+                context.IsReplaying = completedEvents.Count == 0 ? false : completedEvents[0].IsPlayed;
                 CurrentUtcDateTimeUpdater.UpdateCurrentUtcDateTime(context);
 
                 foreach (var completedHistoryEvent in completedEvents)
@@ -170,6 +172,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                 if (scheduledHistoryEvent != null)
                 {
                     scheduledHistoryEvent.IsProcessed = true;
+                    scheduledHistoryEvent.IsPlayed = true;
                 }
 
                 if (completedHistoryEvent != null)
@@ -185,12 +188,14 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     }
 
                     completedHistoryEvent.IsProcessed = true;
+                    completedHistoryEvent.IsPlayed = true;
                 }
             }
 
             var anyTaskCompleted = completedTasks.Count > 0;
             if (anyTaskCompleted)
             {
+                context.IsReplaying = context.History[firstCompletedHistoryEventIndex].IsPlayed;
                 CurrentUtcDateTimeUpdater.UpdateCurrentUtcDateTime(context);
                 // Return a reference to the first completed task
                 output(firstCompletedTask);

--- a/src/Durable/OrchestrationContext.cs
+++ b/src/Durable/OrchestrationContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         internal string ParentInstanceId { get; set; }
 
         [DataMember]
-        internal bool IsReplaying { get; set; }
+        public bool IsReplaying { get; set; }
 
         [DataMember]
         internal HistoryEvent[] History { get; set; }

--- a/src/Durable/OrchestrationContext.cs
+++ b/src/Durable/OrchestrationContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         public object Input { get; internal set; }
 
         [DataMember]
-        internal string InstanceId { get; set; }
+        public string InstanceId { get; set; }
 
         [DataMember]
         internal string ParentInstanceId { get; set; }

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -80,6 +80,8 @@ function Get-DurableStatus {
     The input value that will be passed to the orchestration Azure Function.
 .PARAMETER DurableClient
     The orchestration client object.
+.PARAMETER InstanceId
+    The InstanceId for the new orchestration.
 #>
 function Start-DurableOrchestration {
     [CmdletBinding()]
@@ -98,7 +100,11 @@ function Start-DurableOrchestration {
 
 		[Parameter(
             ValueFromPipelineByPropertyName=$true)]
-        [object] $DurableClient
+        [object] $DurableClient,
+
+        [Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $InstanceId
     )
 
     $ErrorActionPreference = 'Stop'
@@ -107,7 +113,9 @@ function Start-DurableOrchestration {
         $DurableClient = GetDurableClientFromModulePrivateData
     }
 
-    $InstanceId = (New-Guid).Guid
+    if (-not $InstanceId) {
+        $InstanceId = (New-Guid).Guid
+    }
 
     $Uri =
         if ($DurableClient.rpcBaseUrl) {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -12,6 +12,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
     using System.Net.Http;
     using Newtonsoft.Json;
+    using System.Text;
 
     [Collection(Constants.FunctionAppCollectionName)]
     public class DurableEndToEndTests
@@ -190,6 +191,66 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                                 Assert.Equal("True", statusResponseBody.output[0].ToString());
                                 Assert.Equal("Hello myInstanceId", statusResponseBody.output[1].ToString());
                                 Assert.Equal("False", statusResponseBody.output[2].ToString());
+                                return;
+                            }
+
+                        default:
+                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                            break;
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ExternalEventReturnsData()
+        {
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorRaiseEvent");
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
+            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
+            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
+            var raiseEventUri = (string)initialResponseBodyObject.sendEventPostUri;
+
+            raiseEventUri = raiseEventUri.Replace("{eventName}", "TESTEVENTNAME");
+
+            var startTime = DateTime.UtcNow;
+
+            using (var httpClient = new HttpClient())
+            {
+                while (true)
+                {
+                    // Send external event payload
+                    var json = JsonConvert.SerializeObject("helloWorld!");
+                    var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+                    await httpClient.PostAsync(raiseEventUri, httpContent);
+
+                    var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
+                    switch (statusResponse.StatusCode)
+                    {
+                        case HttpStatusCode.Accepted:
+                            {
+                                var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                                var runtimeStatus = (string)statusResponseBody.runtimeStatus;
+                                Assert.True(
+                                    runtimeStatus == "Running" || runtimeStatus == "Pending",
+                                    $"Unexpected runtime status: {runtimeStatus}");
+
+                                if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
+                                {
+                                    Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                                }
+
+                                await Task.Delay(TimeSpan.FromSeconds(2));
+                                break;
+                            }
+
+                        case HttpStatusCode.OK:
+                            {
+                                var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                                Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
+                                Assert.Equal("helloWorld!", statusResponseBody.output.ToString());
                                 return;
                             }
 

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -148,6 +148,60 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         }
 
         [Fact]
+        public async Task OrchestratationContextHasAllExpectedProperties()
+        {
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClientOrchContextProperties", queryString: string.Empty);
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
+            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
+            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
+
+            var startTime = DateTime.UtcNow;
+
+            using (var httpClient = new HttpClient())
+            {
+                while (true)
+                {
+                    var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
+                    switch (statusResponse.StatusCode)
+                    {
+                        case HttpStatusCode.Accepted:
+                            {
+                                var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                                var runtimeStatus = (string)statusResponseBody.runtimeStatus;
+                                Assert.True(
+                                    runtimeStatus == "Running" || runtimeStatus == "Pending",
+                                    $"Unexpected runtime status: {runtimeStatus}");
+
+                                if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
+                                {
+                                    Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                                }
+
+                                await Task.Delay(TimeSpan.FromSeconds(2));
+                                break;
+                            }
+
+                        case HttpStatusCode.OK:
+                            {
+                                var statusResponseBody = await GetResponseBodyAsync(statusResponse);
+                                Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
+                                Assert.Equal("True", statusResponseBody.output[0].ToString());
+                                Assert.Equal("Hello myInstanceId", statusResponseBody.output[1].ToString());
+                                Assert.Equal("False", statusResponseBody.output[2].ToString());
+                                return;
+                            }
+
+                        default:
+                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                            break;
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public async Task ActivityCanHaveQueueBinding()
         {
             const string queueName = "outqueue";

--- a/test/E2E/TestFunctionApp/DurableClientOrchContextProperties/function.json
+++ b/test/E2E/TestFunctionApp/DurableClientOrchContextProperties/function.json
@@ -1,0 +1,24 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": [
+        "post",
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableClientOrchContextProperties/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableClientOrchContextProperties/run.ps1
@@ -1,0 +1,9 @@
+using namespace System.Net
+
+param($Request, $TriggerMetadata)
+
+$InstanceId = Start-DurableOrchestration -FunctionName "DurableOrchestratorAccessContextProps" -InstanceId "myInstanceId"
+Write-Host "Started orchestration with ID = '$InstanceId'"
+
+$Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId
+Push-OutputBinding -Name Response -Value $Response

--- a/test/E2E/TestFunctionApp/DurableOrchestratorAccessContextProps/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorAccessContextProps/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorAccessContextProps/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorAccessContextProps/run.ps1
@@ -1,0 +1,8 @@
+param($Context)
+
+$output = @()
+
+$output += $Context.IsReplaying
+$output += Invoke-DurableActivity -FunctionName 'DurableActivity' -Input $Context.InstanceId
+$output += $Context.IsReplaying
+$output

--- a/test/E2E/TestFunctionApp/DurableOrchestratorRaiseEvent/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorRaiseEvent/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorRaiseEvent/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorRaiseEvent/run.ps1
@@ -1,0 +1,7 @@
+param($Context)
+
+$output = @()
+
+$output += Start-DurableExternalEventListener -EventName "TESTEVENTNAME" 
+
+$output


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains some of the changes originally proposed in https://github.com/Azure/azure-functions-powershell-worker/pull/746

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/727, https://github.com/Azure/azure-functions-powershell-worker/issues/685

This PR contains a few small DF bug patches. The behavioral changes are listed below.

1. The context object now exposes the `.InstanceId` field, as is the case in other PLs
2. The context object now exposes and correctly updates its `IsReplaying` flag
3. The DF SDK now correctly parses the output of WaitForExternalEvent Tasks.
4. The `Start-DurableOrchestration` CmdLet` now accepts an `InstanceId` parameter, as is the case in other PLs

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-powershell-worker/pull/795, https://github.com/Azure/azure-functions-powershell-worker/pull/796
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This should be backported to all DF-supported branches. Can someone help me list them?