### PR TITLE
Add Get-TaskResult CmdLet for DF

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,2 +1,3 @@
 * Bug fix: [Context.InstanceId can now be accessed](https://github.com/Azure/azure-functions-powershell-worker/issues/727)
 * Bug fix: [Data in External Events is now read and returned to orchestrator](https://github.com/Azure/azure-functions-powershell-worker/issues/68)
+* New feature (external contribution): [Get-TaskResult can now be used to obtain the result of an already-completed Durable Functions Task](https://github.com/Azure/azure-functions-powershell-worker/pull/786)

--- a/src/Durable/Commands/GetDurableTaskResult.cs
+++ b/src/Durable/Commands/GetDurableTaskResult.cs
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member 'member'
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Commands
+{
+    using System.Collections;
+    using System.Management.Automation;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks;
+
+    [Cmdlet("Get", "DurableTaskResult")]
+    public class GetDurableTaskResultCommand : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        [ValidateNotNull]
+        public DurableTask[] Task { get; set; }
+
+        private readonly DurableTaskHandler _durableTaskHandler = new DurableTaskHandler();
+
+        protected override void EndProcessing()
+        {
+            var privateData = (Hashtable)MyInvocation.MyCommand.Module.PrivateData;
+            var context = (OrchestrationContext)privateData[SetFunctionInvocationContextCommand.ContextKey];
+
+            _durableTaskHandler.GetTaskResult(Task, context, WriteObject);
+        }
+
+        protected override void StopProcessing()
+        {
+            _durableTaskHandler.Stop();
+        }
+    }
+}

--- a/src/Durable/DurableTaskHandler.cs
+++ b/src/Durable/DurableTaskHandler.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                 if (scheduledHistoryEvent != null)
                 {
                     scheduledHistoryEvent.IsProcessed = true;
+                    scheduledHistoryEvent.IsPlayed = true;
                 }
 
                 if (completedHistoryEvent != null)
@@ -179,6 +180,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
                     }
 
                     completedHistoryEvent.IsProcessed = true;
+                    completedHistoryEvent.IsPlayed = true;
                 }
             }
 
@@ -192,6 +194,21 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             else
             {
                 InitiateAndWaitForStop(context);
+            }
+        }
+
+        public void GetTaskResult(
+            IReadOnlyCollection<DurableTask> tasksToQueryResultFor,
+            OrchestrationContext context,
+            Action<object> output)
+        {
+            foreach (var task in tasksToQueryResultFor) {
+                var scheduledHistoryEvent = task.GetScheduledHistoryEvent(context, true);
+                var processedHistoryEvent = task.GetCompletedHistoryEvent(context, scheduledHistoryEvent, true);
+                if (processedHistoryEvent != null)
+                {
+                    output(GetEventResult(processedHistoryEvent));
+                }
             }
         }
 

--- a/src/Durable/Tasks/ActivityInvocationTask.cs
+++ b/src/Durable/Tasks/ActivityInvocationTask.cs
@@ -37,15 +37,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
         {
         }
 
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return context.History.FirstOrDefault(
                 e => e.EventType == HistoryEventType.TaskScheduled &&
                      e.Name == FunctionName &&
-                     !e.IsProcessed);
+                     e.IsProcessed == processed);
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed)
         {
             return scheduledHistoryEvent == null
                 ? null

--- a/src/Durable/Tasks/DurableTask.cs
+++ b/src/Durable/Tasks/DurableTask.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
 
     public abstract class DurableTask
     {
-        internal abstract HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context);
+        internal abstract HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed = false);
 
-        internal abstract HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent);
+        internal abstract HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed = false);
 
         internal abstract OrchestrationAction CreateOrchestrationAction();
     }

--- a/src/Durable/Tasks/DurableTimerTask.cs
+++ b/src/Durable/Tasks/DurableTimerTask.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
             Action = new CreateDurableTimerAction(FireAt);
         }
 
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return context.History.FirstOrDefault(
                 e => e.EventType == HistoryEventType.TimerCreated &&
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
                      !e.IsProcessed);
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent scheduledHistoryEvent, bool processed)
         {
             return scheduledHistoryEvent == null
                 ? null

--- a/src/Durable/Tasks/ExternalEventTask.cs
+++ b/src/Durable/Tasks/ExternalEventTask.cs
@@ -21,17 +21,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
         }
 
         // There is no corresponding history event for an expected external event
-        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context)
+        internal override HistoryEvent GetScheduledHistoryEvent(OrchestrationContext context, bool processed)
         {
             return null;
         }
 
-        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent taskScheduled)
+        internal override HistoryEvent GetCompletedHistoryEvent(OrchestrationContext context, HistoryEvent taskScheduled, bool processed)
         {
             return context.History.FirstOrDefault(
                     e => e.EventType == HistoryEventType.EventRaised &&
                          e.Name == ExternalEventName &&
-                         !e.IsProcessed);
+                         e.IsPlayed == processed);
         }
 
         internal override OrchestrationAction CreateOrchestrationAction()

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psd1
@@ -59,6 +59,7 @@ FunctionsToExport = @(
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(
     'Get-OutputBinding',
+    'Get-DurableTaskResult'
     'Invoke-DurableActivity',
     'Push-OutputBinding',
     'Set-DurableCustomStatus',

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -235,6 +235,8 @@ function New-DurableOrchestrationCheckStatusResponse {
     The TaskHubName of the orchestration instance that will handle the external event.
 .PARAMETER ConnectionName
     The name of the connection string associated with TaskHubName
+.PARAMETER AppCode
+    The Azure Functions system key
 #>
 function Send-DurableExternalEvent {
     [CmdletBinding()]
@@ -263,12 +265,16 @@ function Send-DurableExternalEvent {
 
         [Parameter(
             ValueFromPipelineByPropertyName=$true)]
-        [string] $ConnectionName
+        [string] $ConnectionName,
+
+        [Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $AppCode
     )
     
     $DurableClient = GetDurableClientFromModulePrivateData
 
-    $RequestUrl = GetRaiseEventUrl -DurableClient $DurableClient -InstanceId $InstanceId -EventName $EventName -TaskHubName $TaskHubName -ConnectionName $ConnectionName
+    $RequestUrl = GetRaiseEventUrl -DurableClient $DurableClient -InstanceId $InstanceId -EventName $EventName -TaskHubName $TaskHubName -ConnectionName $ConnectionName -AppCode $AppCode
 
     $Body = $EventData | ConvertTo-Json -Compress
               
@@ -280,7 +286,8 @@ function GetRaiseEventUrl(
     [string] $InstanceId,
     [string] $EventName,
     [string] $TaskHubName,
-    [string] $ConnectionName) {
+    [string] $ConnectionName,
+    [string] $AppCode) {
 
     $RequestUrl = $DurableClient.BaseUrl + "/instances/$InstanceId/raiseEvent/$EventName"
     
@@ -290,6 +297,9 @@ function GetRaiseEventUrl(
     }
     if ($null -eq $ConnectionName) {
         $query += "connection=$ConnectionName"
+    }
+    if ($null -eq $AppCode) {
+        $query += "code=$AppCode"
     }
     if ($query.Count -gt 0) {
         $RequestUrl += "?" + [string]::Join("&", $query)

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -314,7 +314,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             }
         }
 
-
         [Fact]
         public async Task ActivityCanHaveQueueBinding()
         {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -148,60 +148,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         }
 
         [Fact]
-        public async Task OrchestratationContextHasAllExpectedProperties()
-        {
-            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClientOrchContextProperties", queryString: string.Empty);
-            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
-
-            var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();
-            dynamic initialResponseBodyObject = JsonConvert.DeserializeObject(initialResponseBody);
-            var statusQueryGetUri = (string)initialResponseBodyObject.statusQueryGetUri;
-
-            var startTime = DateTime.UtcNow;
-
-            using (var httpClient = new HttpClient())
-            {
-                while (true)
-                {
-                    var statusResponse = await httpClient.GetAsync(statusQueryGetUri);
-                    switch (statusResponse.StatusCode)
-                    {
-                        case HttpStatusCode.Accepted:
-                        {
-                            var statusResponseBody = await GetResponseBodyAsync(statusResponse);
-                            var runtimeStatus = (string)statusResponseBody.runtimeStatus;
-                            Assert.True(
-                                runtimeStatus == "Running" || runtimeStatus == "Pending",
-                                $"Unexpected runtime status: {runtimeStatus}");
-
-                            if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
-                            {
-                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
-                            }
-
-                            await Task.Delay(TimeSpan.FromSeconds(2));
-                            break;
-                        }
-
-                        case HttpStatusCode.OK:
-                        {
-                            var statusResponseBody = await GetResponseBodyAsync(statusResponse);
-                            Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
-                            Assert.Equal("True", statusResponseBody.output[0].ToString());
-                            Assert.Equal("Hello myInstanceId", statusResponseBody.output[1].ToString());
-                            Assert.Equal("False", statusResponseBody.output[2].ToString());
-                            return;
-                        }
-
-                        default:
-                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
-                            break;
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public async Task OrchestratationCanAlwaysObtainTaskResult()
         {
             var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorGetTaskResult");

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -147,12 +147,6 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             }
         }
 
-
-Viewed
-@@ -147,6 +147,112 @@ public async Task LegacyDurableCommandNamesStillWork()
-            }
-        }
-
         [Fact]
         public async Task OrchestratationContextHasAllExpectedProperties()
         {

--- a/test/E2E/TestFunctionApp/DurableOrchestratorGetTaskResult/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorGetTaskResult/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorGetTaskResult/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorGetTaskResult/run.ps1
@@ -1,0 +1,8 @@
+param($Context)
+
+$output = @()
+
+$task = Invoke-DurableActivity -FunctionName 'DurableActivity' -Input "world" -NoWait
+$firstTask = Wait-DurableTask -Task @($task) -Any
+$output += Get-DurableTaskResult -Task @($firstTask)
+$output

--- a/test/Unit/Durable/ActivityInvocationTaskTests.cs
+++ b/test/Unit/Durable/ActivityInvocationTaskTests.cs
@@ -225,8 +225,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
             var orchestrationContext = new OrchestrationContext { History = history };
 
             var task = new ActivityInvocationTask(FunctionName, FunctionInput);
-            var scheduledEvent = task.GetScheduledHistoryEvent(orchestrationContext);
-            var completedEvent = task.GetCompletedHistoryEvent(orchestrationContext, scheduledEvent);
+            var scheduledEvent = task.GetScheduledHistoryEvent(orchestrationContext, false);
+            var completedEvent = task.GetCompletedHistoryEvent(orchestrationContext, scheduledEvent, false);
 
             Assert.Equal(scheduledEvent.EventId, completedEvent.TaskScheduledId);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Related to https://github.com/Azure/azure-functions-powershell-worker/issues/685 and https://github.com/Azure/azure-functions-powershell-worker/pull/753

Currently, users do not have a way of obtaining the result of a DF Task that has already completed. This means that if a user did not assign a Task onto a variable when first invoking it, then they have no way of accessing its result.

This is an urgently missing feature and user oobegreg is proposing a CmdLet named Get-DurableTaskResult that allows us to do just that.

In general, this serves the purpose of performing an await (or yield in Python and JS) on a completed Durable Task, because in those languages re-awaiting a completed Task is a supported means of extracting that Task's result. Another way to do this is to expose a .result property on the DurableTask class and have users access that. However, I think this CmdLet-based approach is also sound, and I don't see why we couldn't have both given that users in other PLs can both access their classes' .result property and call yield/await for the same effect.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR: https://github.com/Azure/azure-functions-powershell-worker/issues/797
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-powershell-worker/pull/799, https://github.com/Azure/azure-functions-powershell-worker/pull/798
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This needs a documentation update (to announce the new CmdLet) and also needs to be backported to all DF-supported branches.

Where should this documentation issue requested by the PR checklist be created? In the azure docs repo? I suppose that we can create it in this repo as well, just checking for this group goes about it :-)