### PR TITLE
Remove release_notes from process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,6 @@ resolves #issue_for_this_pr
 
 * [ ] My changes **do not** require documentation changes
   * [ ] Otherwise: Documentation issue linked to PR
-* [ ] My changes **should not** be added to the release notes for the next release
-  * [ ] Otherwise: I've added my notes to `release_notes.md`
 * [ ] My changes **do not** need to be backported to a previous version
   * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
 * [ ] I have added all required tests (Unit tests, E2E tests)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,0 @@
-* Bug fix: [Context.InstanceId can now be accessed](https://github.com/Azure/azure-functions-powershell-worker/issues/727)
-* Bug fix: [Data in External Events is now read and returned to orchestrator](https://github.com/Azure/azure-functions-powershell-worker/issues/68)
-* New feature (external contribution): [Get-TaskResult can now be used to obtain the result of an already-completed Durable Functions Task](https://github.com/Azure/azure-functions-powershell-worker/pull/786)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

From my last conversation with @Francisco-Gamino, I understood that we were dropping the use of `release_notes.md` from our PR-making process. Assuming I understand that correctly, I made this PR to remove the `release_notes.md` file from the repo, as well as removing the instruction to use it in our PR-making template.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information
