### PR TITLE
Patch regression in ExternalEvent History-search

### DIFF
--- a/src/DurableSDK/Tasks/ExternalEventTask.cs
+++ b/src/DurableSDK/Tasks/ExternalEventTask.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable.Tasks
             return context.History.FirstOrDefault(
                     e => e.EventType == HistoryEventType.EventRaised &&
                          e.Name == ExternalEventName &&
-                         e.IsPlayed == processed);
+                         e.IsProcessed == processed);
         }
 
         internal override OrchestrationAction CreateOrchestrationAction()

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -251,7 +251,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                             {
                                 var statusResponseBody = await GetResponseBodyAsync(statusResponse);
                                 Assert.Equal("Completed", (string)statusResponseBody.runtimeStatus);
-                                Assert.Equal("helloWorld!", statusResponseBody.output.ToString());
+                                Assert.Contains("helloWorld!", statusResponseBody.output.ToString());
                                 return;
                             }
 

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -206,7 +206,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         [Fact]
         public async Task ComplexExternalEventReturnsData()
         {
-            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorComplextRaiseEvent");
+            var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClient", queryString: "?FunctionName=DurableOrchestratorComplexRaiseEvent");
             Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
 
             var initialResponseBody = await initialResponse.Content.ReadAsStringAsync();

--- a/test/E2E/TestFunctionApp/DurableOrchestratorComplexRaiseEvent/function.json
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorComplexRaiseEvent/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/TestFunctionApp/DurableOrchestratorComplexRaiseEvent/run.ps1
+++ b/test/E2E/TestFunctionApp/DurableOrchestratorComplexRaiseEvent/run.ps1
@@ -1,0 +1,10 @@
+param($Context)
+
+$output = @()
+
+Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Tokyo"
+Invoke-DurableActivity -FunctionName "DurableActivity" -Input "Seattle"
+$output += Start-DurableExternalEventListener -EventName "TESTEVENTNAME" 
+Invoke-DurableActivity -FunctionName "DurableActivity" -Input "London"
+
+$output


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

It appears a recent external contribution (https://github.com/Azure/azure-functions-powershell-worker/pull/786) accidentally broke the logic we use to retrieve external-event results from the History. In particular, it changed our History filtering condition to utilize `History.IsPlayed` (which we do not control) instead of `History.IsProcessed` (which we manage ourselves in the SDK). The result is that the `StartExternalEventListener` commandlet may fail if a user schedules any activities beneath it.

There's some relationship between `IsPlayed` and `IsProcessed` so I'm not surprised that we didn't catch this during review. To ensure this doesn't regress again, I've added a test against this edge-case.


### Issue describing the changes in this PR

related: https://github.com/Azure/azure-functions-powershell-worker/issues/851

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
