### PR TITLE
Patch Stop-DurableOrchestration

### DIFF
--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -160,7 +160,7 @@ function Stop-DurableOrchestration {
 
     $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId/terminate?reason=$([System.Web.HttpUtility]::UrlEncode($Reason))"
 
-    Invoke-RestMethod -Uri $requestUrl
+    Invoke-RestMethod -Uri $requestUrl -Method 'POST'
 }
 
 function IsValidUrl([uri]$Url) {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/DurableEndToEndTests.cs
@@ -693,7 +693,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             }
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-functions-powershell-worker/issues/640")]
+        [Fact]
         public async Task DurableClientTerminatesOrchestration()
         {
             var initialResponse = await Utilities.GetHttpTriggerResponse("DurableClientTerminating", queryString: string.Empty);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/640

The Terminate API demands a POST request instead of a GET method invoke. This PR ensures we're making the right HTTP request, and re-enables the test that was meant to catch this incompatibility. It seems most users manually utilize the HTTP endpoints to terminate orchestrations, which is probably why this error was not caught before.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-powershell-worker/pull/867, https://github.com/Azure/azure-functions-powershell-worker/pull/868
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
