### PR TITLE
Fix DependencyManagementTests: remove module installation time from expected log entry

### DIFF
--- a/test/Unit/DependencyManagement/DependencyManagementTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagementTests.cs
@@ -11,10 +11,8 @@ using Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 {
-    using System.Diagnostics;
     using System.Linq;
     using System.Management.Automation;
-    using System.Threading;
 
     public class DependencyManagementTests : IDisposable
     {
@@ -483,12 +481,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         {
             if (SuccessfulDownload || (SaveModuleCount >= ShouldNotThrowAfterCount))
             {
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
-                Thread.Sleep(10); // wait for 10 milliseconds
+                // Save the module name and version with a duration of 10 milliseconds for a successful download.
+                var expectedString = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, version, 10);
 
-                // Save the module name and version for a successful download.
-                DownloadedModuleInfo = string.Format(PowerShellWorkerStrings.ModuleHasBeenInstalled, moduleName, version, stopwatch.ElapsedMilliseconds);
+                // Remove the time in milliseconds given that this will be different depending on the machine where the test is executed.
+                DownloadedModuleInfo = expectedString.Substring(0, expectedString.IndexOf("10"));
+
                 return;
             }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/882

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
