### PR TITLE
Populate language worker metadata in init response

### DIFF
--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -40,11 +40,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
             // and the dependency manager (used to download dependent modules if needed).
             var firstPowerShellInstance = Utils.NewPwshInstance();
-            LogPowerShellVersion(firstPowerShellInstance);
+            var pwshVersion = GetPowerShellVersion(firstPowerShellInstance);
+            LogPowerShellVersion(pwshVersion);
             WarmUpPowerShell(firstPowerShellInstance);
 
             var msgStream = new MessagingStream(arguments.Host, arguments.Port);
-            var requestProcessor = new RequestProcessor(msgStream, firstPowerShellInstance);
+            var requestProcessor = new RequestProcessor(msgStream, firstPowerShellInstance, pwshVersion);
 
             // Send StartStream message
             var startedMessage = new StreamingMessage()
@@ -75,10 +76,15 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                 .InvokeAndClearCommands();
         }
 
-        private static void LogPowerShellVersion(System.Management.Automation.PowerShell pwsh)
+        private static void LogPowerShellVersion(string pwshVersion)
         {
-            var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, Utils.GetPowerShellVersion(pwsh));
+            var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, pwshVersion);
             RpcLogger.WriteSystemLog(LogLevel.Information, message);
+        }
+
+        private static string GetPowerShellVersion(System.Management.Automation.PowerShell pwsh)
+        {
+            return Utils.GetPowerShellVersion(pwsh);
         }
     }
 

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             // This PowerShell instance is shared by the first PowerShellManager instance created in the pool,
             // and the dependency manager (used to download dependent modules if needed).
             var firstPowerShellInstance = Utils.NewPwshInstance();
-            var pwshVersion = GetPowerShellVersion(firstPowerShellInstance);
+            var pwshVersion = Utils.GetPowerShellVersion(firstPowerShellInstance);
             LogPowerShellVersion(pwshVersion);
             WarmUpPowerShell(firstPowerShellInstance);
 
@@ -80,11 +80,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         {
             var message = string.Format(PowerShellWorkerStrings.PowerShellVersion, pwshVersion);
             RpcLogger.WriteSystemLog(LogLevel.Information, message);
-        }
-
-        private static string GetPowerShellVersion(System.Management.Automation.PowerShell pwsh)
-        {
-            return Utils.GetPowerShellVersion(pwsh);
         }
     }
 

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -352,4 +352,7 @@
   <data name="DependencySnapshotDoesNotContainAcceptableModuleVersions" xml:space="preserve">
     <value>Dependency snapshot '{0}' does not contain acceptable module versions.</value>
   </data>
+  <data name="WorkerInitCompleted" xml:space="preserve">
+    <value>Worker init request completed in {0} ms.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following change:
- Populate the language worker metadata during worker init (resolves https://github.com/Azure/azure-functions-powershell-worker/issues/821)
 
### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
