### PR TITLE
Upgrade to PowerShell 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ On macOS if you installed via `brew`
 /usr/local/Cellar/azure-functions-core-tools/<version>/workers/
 ```
 
-Under the `workers/powershell` folder, create a folder with the name `7.2` if it does not exist yet. Copy the result of the `publish` directory into the `workers/powershell/7.2` folder, and copy the `publish/worker.config.json` file into the `workers/powershell` folder:
+Under the `workers/powershell` folder, create a folder with the name `7.4` if it does not exist yet. Copy the result of the `publish` directory into the `workers/powershell/7.4` folder, and copy the `publish/worker.config.json` file into the `workers/powershell` folder:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/net6.0/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell/7.2"
-Copy-Item -Recurse -Force ./src/bin/Debug/net6.0/publish/worker.config.json "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/net7.0/publish/ "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell/7.4"
+Copy-Item -Recurse -Force ./src/bin/Debug/net7.0/publish/worker.config.json "/usr/local/Cellar/azure-functions-core-tools/$(func --version)/workers/powershell"
 ```
 
 > NOTE: if the powershell folder already exists, you should delete it or debugging won't work.
@@ -93,7 +93,7 @@ Copy-Item -Recurse -Force ./src/bin/Debug/net6.0/publish/worker.config.json "/us
 Then `cd` into a Function App with PowerShell as the worker runtime 
 (NOTE: There's an example PowerShell Function App in the `examples` folder).
 
-Set the environment variable `FUNCTIONS_WORKER_RUNTIME_VERSION` to `7.2`, or add this as an app setting to the `local.settings.json` file.
+Set the environment variable `FUNCTIONS_WORKER_RUNTIME_VERSION` to `7.4`, or add this as an app setting to the `local.settings.json` file.
 
 Lastly, run:
 
@@ -119,15 +119,15 @@ set the environment variable `"AzureWebJobsScriptRoot"`
 to the root folder path (the folder which contains the `host.json`)
 of your test functions app.
 
-Under the `workers/powershell` folder, create a folder with the name `7.2` if it does not exist yet. Then copy the `publish` directory to `workers/powershell/7.2`, and the `publish/worker.config.json` to `workers/powershell`:
+Under the `workers/powershell` folder, create a folder with the name `7.4` if it does not exist yet. Then copy the `publish` directory to `workers/powershell/7.4`, and the `publish/worker.config.json` to `workers/powershell`:
 ```powershell
-Copy-Item -Recurse -Force ./src/bin/Debug/net6.0/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/net6.0/workers/powershell/7.2"
-Copy-Item -Force ./src/bin/Debug/net6.0/publish/worker.config.json "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/net6.0/workers/powershell"
+Copy-Item -Recurse -Force ./src/bin/Debug/net7.0/publish/ "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/net7.0/workers/powershell/7.4"
+Copy-Item -Force ./src/bin/Debug/net7.0/publish/worker.config.json "<Azure Functions Host Root>/src/WebJobs.Script.WebHost/bin/Debug/net7.0/workers/powershell"
 ```
 
 Then you can start the host by running:
 ```sh
-dotnet ./src/WebJobs.Script.WebHost/bin/Debug/net6.0/Microsoft.Azure.WebJobs.Script.WebHost.dll
+dotnet ./src/WebJobs.Script.WebHost/bin/Debug/net7.0/Microsoft.Azure.WebJobs.Script.WebHost.dll
 ```
 
 > Note: Remember to remove `"AzureWebJobsScriptRoot"`
@@ -149,6 +149,6 @@ That will place a `Microsoft.Azure.Functions.PowerShellWorker.*.nupkg` in:
 
 It pulls the contents of the publish folder in:
 
-`azure-functions-powershell-worker/src/bin/Debug/net6.0/publish`
+`azure-functions-powershell-worker/src/bin/Debug/net7.0/publish`
 
 if you specify a different Configuration or TargetFramework that will be honored.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ with any additional questions or comments.
 
 ### Prereqs
 
-* [.NET 6.0 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
+* [.NET 7.0 SDK](https://www.microsoft.com/net/download/visual-studio-sdks)
 
 ### Build
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ pool:
 
 variables:
   Configuration: Release
-  buildNumber: $[ counter('build', 400) ] # Start higher than our AppVeyor versions. Every build (pr or branch) will increment.
+  buildNumber: $[ counter('build', 001) ] # Start higher than our AppVeyor versions. Every build (pr or branch) will increment.
 
 steps:
 - pwsh: |

--- a/build.ps1
+++ b/build.ps1
@@ -49,15 +49,16 @@ $DefaultPSWorkerVersion = '7.4'
 
 if (-not $workerVersion)
 {
-    Write-Host "Worker version not specified. Setting workerVersion to '$DefaultPSWorkerVersion'"
+    Write-Log "Worker version not specified. Setting workerVersion to '$DefaultPSWorkerVersion'"
     $workerVersion = $DefaultPSWorkerVersion
 }
 
 $PowerShellVersion = $WorkerVersion
+Write-Log "Build worker version: $PowerShellVersion"
 
 # Set target framework for 7.2 to net6.0 and for 7.4 to net7.0
 $TargetFramework = ($PowerShellVersion -eq "7.2") ? 'net6.0' : 'net7.0'
-
+Write-Log "Target framework: $TargetFramework"
 
 function Get-FunctionsCoreToolsDir {
     if ($CoreToolsDir) {
@@ -93,7 +94,7 @@ function Install-SBOMUtil
     }
 
     $MANIFESTOOLNAME = "ManifestTool"
-    Write-Host "Installing $MANIFESTOOLNAME..."
+    Write-Log "Installing $MANIFESTOOLNAME..."
 
     $MANIFESTOOL_DIRECTORY = Join-Path $PSScriptRoot $MANIFESTOOLNAME
     Remove-Item -Recurse -Force $MANIFESTOOL_DIRECTORY -ErrorAction Ignore
@@ -109,7 +110,7 @@ function Install-SBOMUtil
         throw "$MANIFESTOOL_DIRECTORY does not contain '$dllName'"
     }
 
-    Write-Host 'Done.'
+    Write-Log 'Done.'
 
     return $manifestToolPath
 }

--- a/build.ps1
+++ b/build.ps1
@@ -43,6 +43,8 @@ param(
 
 #Requires -Version 7.0
 
+Import-Module "$PSScriptRoot/tools/helper.psm1" -Force
+
 $PowerShellVersion = $null
 $TargetFramework = $null
 $DefaultPSWorkerVersion = '7.4'
@@ -138,8 +140,6 @@ function Deploy-PowerShellWorker {
 
     Write-Log "Deployed worker to $powerShellWorkerDir"
 }
-
-Import-Module "$PSScriptRoot/tools/helper.psm1" -Force
 
 # Bootstrap step
 if ($Bootstrap.IsPresent) {

--- a/build.ps1
+++ b/build.ps1
@@ -34,13 +34,30 @@ param(
     $AddSBOM,
 
     [string]
-    $SBOMUtilSASUrl
+    $SBOMUtilSASUrl,
+
+    [string]
+    [ValidateSet("7.2", "7.4")]
+    $WorkerVersion
 )
 
-#Requires -Version 6.0
+#Requires -Version 7.0
 
-$PowerShellVersion = '7.2'
-$TargetFramework = 'net6.0'
+$PowerShellVersion = $null
+$TargetFramework = $null
+$DefaultPSWorkerVersion = '7.4'
+
+if (-not $workerVersion)
+{
+    Write-Host "Worker version not specified. Setting workerVersion to '$DefaultPSWorkerVersion'"
+    $workerVersion = $DefaultPSWorkerVersion
+}
+
+$PowerShellVersion = $WorkerVersion
+
+# Set target framework for 7.2 to net6.0 and for 7.4 to net7.0
+$TargetFramework = ($PowerShellVersion -eq "7.2") ? 'net6.0' : 'net7.0'
+
 
 function Get-FunctionsCoreToolsDir {
     if ($CoreToolsDir) {
@@ -101,6 +118,12 @@ function Deploy-PowerShellWorker {
     $ErrorActionPreference = 'Stop'
 
     $powerShellWorkerDir = "$(Get-FunctionsCoreToolsDir)/workers/powershell/$PowerShellVersion"
+
+    if (-not (Test-Path $powerShellWorkerDir))
+    {
+        Write-Log "Creating directory: '$powerShellWorkerDir'"
+        New-Item -Path $powerShellWorkerDir -ItemType Directory -Force | Out-Null
+    }
 
     Write-Log "Deploying worker to $powerShellWorkerDir..."
 

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.Package.csproj
@@ -5,7 +5,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\PowerShellWorker.Common.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -5,7 +5,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.Azure.Functions.PowerShellWorker.PS7.2</id>
+    <id>Microsoft.Azure.Functions.PowerShellWorker.PS7.4</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
     <title>Azure Function PowerShell Language Worker (PowerShell 7.2)</title>
@@ -26,7 +26,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7.2" />
+    <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7.4" />
     <file src="..\src\bin\$configuration$\$targetFramework$\publish\worker.config.json" target="contentFiles\any\any\workers\powershell" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>

--- a/src/DurableWorker/DurableController.cs
+++ b/src/DurableWorker/DurableController.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             {
                 var durableClient =
                     inputData.First(item => item.Name == _durableFunctionInfo.DurableClientBindingName)
-                        .Data.ToObject();
+                        .Data.ToObject(isDurableClient: true);
 
                 _powerShellServices.SetDurableClient(durableClient);
             }

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   <Import Project="..\PowerShellWorker.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <Product>Azure Function PowerShell Language Worker</Product>
     <AssemblyName>Microsoft.Azure.Functions.PowerShellWorker</AssemblyName>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0-preview.1" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -122,19 +122,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 retObj = psObj.BaseObject;
             }
 
-            if (retObj is Hashtable hashtable)
-            {
-                try
-                {
-                    // ConvertFromJson returns case-sensitive Hashtable by design -- JSON may contain keys that only differ in case.
-                    // We try casting the Hashtable to a case-insensitive one, but if that fails, we keep using the original one.
-                    retObj = new Hashtable(hashtable, StringComparer.OrdinalIgnoreCase);
-                }
-                catch
-                {
-                    retObj = hashtable;
-                }
-            }
+            // By default, the PowerShell 7.4 language worker no longer wraps the output of ConvertFromJson to try to create a
+            // case-insensitive hashtable to support deserializing JSON which may contain keys that only differ in case.
+            // For more information, please see https://github.com/Azure/azure-functions-powershell-worker/issues/909
 
             return retObj;
         }

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 try
                 {
                     // ConvertFromJson returns case-sensitive Ordered Hashtable by design -- JSON may contain keys that only differ in case.
-                    // We try casting the Ordered Hashtable to a case-insensitive Hashtable, but if that fails, we keep using the original one.
+                    // We try to convert the Ordered Hashtable to a case-insensitive Hashtable, but if that fails, we keep using the original one.
                     retObj = new Hashtable(hashtable, StringComparer.OrdinalIgnoreCase);
                 }
                 catch

--- a/src/Utility/TypeExtensions.cs
+++ b/src/Utility/TypeExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             switch (data.DataCase)
             {
                 case TypedData.DataOneofCase.Json:
-                    return ConvertFromJson(data.Json, isDurableClient: isDurableClient);
+                    return ConvertFromJson(data.Json, returnCaseInsensitiveHashtable: isDurableClient);
                 case TypedData.DataOneofCase.Bytes:
                     return data.Bytes.ToByteArray();
                 case TypedData.DataOneofCase.Double:
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 case TypedData.DataOneofCase.String:
                     string str = data.String;
                     return convertFromJsonIfValidJson && IsValidJson(str)
-                                ? ConvertFromJson(str, isDurableClient: isDurableClient)
+                                ? ConvertFromJson(str, returnCaseInsensitiveHashtable: isDurableClient)
                                 : str;
                 case TypedData.DataOneofCase.None:
                     return null;
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
             }
         }
 
-        public static object ConvertFromJson(string json, bool isDurableClient = false)
+        public static object ConvertFromJson(string json, bool returnCaseInsensitiveHashtable = false)
         {
             object retObj = JsonObject.ConvertFromJson(json, returnHashtable: true, error: out _);
 
@@ -122,18 +122,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
                 retObj = psObj.BaseObject;
             }
 
-            // TODO: Review this comment to see if it is still relevant.
-            // By default, the PowerShell 7.4 language worker no longer wraps the output of ConvertFromJson to try to create a
-            // case-insensitive hashtable to support deserializing JSON which may contain keys that only differ in case.
-            // For more information, please see https://github.com/Azure/azure-functions-powershell-worker/issues/909
+            // By default, the PowerShell language worker no longer tries to create a case-insensitive Hashtable from the output of ConvertFromJson.
+            // This is a breaking change which is tracked by https://github.com/Azure/azure-functions-powershell-worker/issues/909.
 
-            if (isDurableClient && (retObj is Hashtable hashtable))
+            if (returnCaseInsensitiveHashtable && (retObj is Hashtable hashtable))
             {
-                // Durable data is case sensitive when it arrives from the Host. However, customers expect Durable client data to be case insensitive, therefore, we tried to convert the Ordered
+                // In order to call into the DurableClient properties without having to worry about casing,
+                // we need to return a case-insensitive Hashtable for the DurableClient code path.
                 try
                 {
-                    // ConvertFromJson returns case-sensitive Hashtable by design -- JSON may contain keys that only differ in case.
-                    // We try casting the Hashtable to a case-insensitive one, but if that fails, we keep using the original one.
+                    // ConvertFromJson returns case-sensitive Ordered Hashtable by design -- JSON may contain keys that only differ in case.
+                    // We try casting the Ordered Hashtable to a case-insensitive Hashtable, but if that fails, we keep using the original one.
                     retObj = new Hashtable(hashtable, StringComparer.OrdinalIgnoreCase);
                 }
                 catch

--- a/src/worker.config.json
+++ b/src/worker.config.json
@@ -4,7 +4,7 @@
         "extensions":[".ps1", ".psm1"],
         "defaultExecutablePath":"dotnet",
         "defaultWorkerPath":"%FUNCTIONS_WORKER_RUNTIME_VERSION%/Microsoft.Azure.Functions.PowerShellWorker.dll",
-        "supportedRuntimeVersions":["7", "7.2"],
+        "supportedRuntimeVersions":["7", "7.2", "7.4"],
         "defaultRuntimeVersion": "7.2",
         "sanitizeRuntimeVersionRegex":"\\d+\\.?\\d*"
     }

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -58,7 +58,7 @@ function NewTaskHubName
 $taskHubName = NewTaskHubName -Length 45
 
 $FUNC_RUNTIME_VERSION = '4'
-$TARGET_FRAMEWORK = 'net6.0'
+$TARGET_FRAMEWORK = 'net7.0'
 $POWERSHELL_VERSION = '7.4'
 
 $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()

--- a/test/E2E/Start-E2ETest.ps1
+++ b/test/E2E/Start-E2ETest.ps1
@@ -59,7 +59,7 @@ $taskHubName = NewTaskHubName -Length 45
 
 $FUNC_RUNTIME_VERSION = '4'
 $TARGET_FRAMEWORK = 'net6.0'
-$POWERSHELL_VERSION = '7.2'
+$POWERSHELL_VERSION = '7.4'
 
 $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
 if ($IsWindows) {

--- a/test/E2E/TestFunctionApp/local.settings.json
+++ b/test/E2E/TestFunctionApp/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsEventHubSender":"",
     "AzureWebJobsCosmosDBConnectionString":"",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4",
     "PSWorkerInProcConcurrencyUpperBound": 10
   }
 }

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\PowerShellWorker.Common.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -318,8 +318,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             var actual = input.ToObject();
             Assert.IsType<Hashtable>(actual);
             var actualHash = (Hashtable)actual;
-            Assert.IsType<Hashtable>(actualHash["Foo"]);
-            var nestedHash = (Hashtable)actualHash["Foo"];
+            Assert.IsType<OrderedHashtable>(actualHash["Foo"]);
+            var nestedHash = (OrderedHashtable)actualHash["Foo"];
             Assert.Single(nestedHash);
             Assert.Equal("Zoo", nestedHash["Bar"]);
         }
@@ -372,8 +372,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Equal(2, actualArray.Length);
             Assert.Equal("Foo", actualArray[0]);
 
-            Assert.IsType<Hashtable>(actualArray[1]);
-            var nestedHash = (Hashtable)actualArray[1];
+            Assert.IsType<OrderedHashtable>(actualArray[1]);
+            var nestedHash = (OrderedHashtable)actualArray[1];
             Assert.Single(nestedHash);
             Assert.Equal("Zoo", nestedHash["Bar"]);
         }

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -299,8 +299,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
             var input = new TypedData { Json = data };
             var actual = input.ToObject();
-            Assert.IsType<Hashtable>(actual);
-            var actualHash = (Hashtable)actual;
+            Assert.IsType<OrderedHashtable>(actual);
+            var actualHash = (OrderedHashtable)actual;
             Assert.IsType<object[]>(actualHash["Foo"]);
             var actualArray = (object[])actualHash["Foo"];
             Assert.Equal(2, actualArray.Length);
@@ -316,8 +316,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
 
             var input = new TypedData { Json = data };
             var actual = input.ToObject();
-            Assert.IsType<Hashtable>(actual);
-            var actualHash = (Hashtable)actual;
+            Assert.IsType<OrderedHashtable>(actual);
+            var actualHash = (OrderedHashtable)actual;
             Assert.IsType<OrderedHashtable>(actualHash["Foo"]);
             var nestedHash = (OrderedHashtable)actualHash["Foo"];
             Assert.Single(nestedHash);

--- a/test/Unit/Utility/TypeExtensionsTests.cs
+++ b/test/Unit/Utility/TypeExtensionsTests.cs
@@ -379,6 +379,27 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         }
 
         [Fact]
+        public void TestTypedDataToCaseInsensitiveHashtable_Deserialize()
+        {
+            string[] keysToValidate = new string[] { "TASKHUBNAME", "taskhubname", "RPCBASEURL", "rpcbaseurl" };
+
+            var jsonString =
+                $$"""
+                {
+                    "taskHubName": "abcd1235",
+                    "rpcBaseUrl": "http://127.0.0.1:17071/durabletask/"
+                }
+                """;
+            var input = new TypedData { String = jsonString };
+            var result = (Hashtable)input.ToObject(isDurableClient: true);
+
+            foreach (var keyName in keysToValidate)
+            {
+                Assert.True(result.ContainsKey(keyName));
+            }
+        }
+
+        [Fact]
         public void TestTypedDataToObjectBytes()
         {
             var data = ByteString.CopyFromUtf8("Hello World");

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -16,9 +16,9 @@ $DotnetSDKVersionRequirements = @{
         DefaultPatch = '426'
     }
 
-    '6.0' = @{
-        MinimalPatch = '404'
-        DefaultPatch = '404'
+    '7.0' = @{
+        MinimalPatch = '101'
+        DefaultPatch = '101'
     }
 }
 

--- a/tools/protobuf.tools.csproj
+++ b/tools/protobuf.tools.csproj
@@ -6,7 +6,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <NoBuild>true</NoBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
* Resolves https://github.com/Azure/azure-functions-powershell-worker/issues/850
* After this PR is merged, by default, the `dev` branch will build the `PowerShell 7.4` language worker. Changes that are applicable to the `PowerShell 7.2` language worker will need to be cherry-picked from the `dev` to the `v4.x/ps7.2` branch
* Reset release build counter to start at 001, so the nuget package name and version will be follows:
   `Microsoft.Azure.Functions.PowerShellWorker.PS7.4`, version `4.0.001` 
* In `PowerShell 7.4` `ConvertFromJson` returns an ordered hashtable instead of a hashtable. This is a breaking change in the PowerShell language worker (Please see https://github.com/Azure/azure-functions-powershell-worker/issues/909 for more information).
In addition, in previous versions of the language worker, we had logic to try to create a case-insensitive hashtable from the output `ConvertFromJson`. For `PowerShell 7.4` language worker, we are removing this logic and just returning the output of `ConvertFromJson`. However, for the `DurableClient`, we will continue to create the case-insensitive hashtable, so that we can call into the `cmdlets`  of the `Microsoft.Azure.Functions.PowerShellWorker.psm1` module without having to worry about the casing. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
