### PR TITLE
Make enviroment variable tracking external SDK into a constant

### DIFF
--- a/src/DurableWorker/DurableController.cs
+++ b/src/DurableWorker/DurableController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         private readonly ILogger _logger;
 
         private bool isExternalDFSdkEnabled { get; } =
-            PowerShellWorkerConfiguration.GetBoolean("ExternalDurablePowerShellSDK") ?? false;
+            PowerShellWorkerConfiguration.GetBoolean(Utils.ExternalDurableSdkEnvVariable) ?? false;
 
         public DurableController(
             DurableFunctionInfo durableDurableFunctionInfo,
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             else if (isExternalSdkLoaded)
             {
                 // External SDK is in the session, but customer did not explicitly enable it. Report the potential of runtime errors.
-                _logger.Log(isUserOnlyLog: false, LogLevel.Error, String.Format(PowerShellWorkerStrings.PotentialDurableSDKClash, Utils.ExternalDurableSdkName));
+                _logger.Log(isUserOnlyLog: false, LogLevel.Error, String.Format(PowerShellWorkerStrings.PotentialDurableSDKClash, Utils.ExternalDurableSdkName, Utils.ExternalDurableSdkEnvVariable));
             }
         }
 

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         internal const string ExternalDurableSdkName = "AzureFunctions.PowerShell.Durable.SDK";
         internal const string IsOrchestrationFailureKey = "IsOrchestrationFailure";
         internal const string TracePipelineObjectCmdlet = "Microsoft.Azure.Functions.PowerShellWorker\\Trace-PipelineObject";
+        internal const string ExternalDurableSdkEnvVariable = "ExternalDurablePowerShellSDK";
 
         internal readonly static object BoxedTrue = (object)true;
         internal readonly static object BoxedFalse = (object)false;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This PR is a follow up to https://github.com/Azure/azure-functions-powershell-worker/pull/839

In it, we introduced a new optional environment variable named `ExternalDurablePowerShellSDK`. This environment variable controls whether the external DF SDK logic is invoked. 

In this PR, we turn that variable name into a constant string, for re-usability and logging. No logic changes have taken place other than logging the variable name in usage warnings.

### Issue describing the changes in this PR

resolves N/A


### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
