### PR TITLE
Test warning log for DF external SDK

### DIFF
--- a/src/DurableWorker/DurableController.cs
+++ b/src/DurableWorker/DurableController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         private readonly ILogger _logger;
 
         private bool isExternalDFSdkEnabled { get; } =
-            PowerShellWorkerConfiguration.GetBoolean("ExternalDurablePowerShellSDK") ?? false;
+            PowerShellWorkerConfiguration.GetBoolean(Utils.ExternalDurableSdkEnvVariable) ?? false;
 
         public DurableController(
             DurableFunctionInfo durableDurableFunctionInfo,
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             else if (isExternalSdkLoaded)
             {
                 // External SDK is in the session, but customer did not explicitly enable it. Report the potential of runtime errors.
-                _logger.Log(isUserOnlyLog: false, LogLevel.Error, String.Format(PowerShellWorkerStrings.PotentialDurableSDKClash, Utils.ExternalDurableSdkName));
+                _logger.Log(isUserOnlyLog: false, LogLevel.Error, String.Format(PowerShellWorkerStrings.PotentialDurableSDKClash, Utils.ExternalDurableSdkName, Utils.ExternalDurableSdkEnvVariable));
             }
         }
 

--- a/src/Utility/Utils.cs
+++ b/src/Utility/Utils.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Utility
         internal const string ExternalDurableSdkName = "AzureFunctions.PowerShell.Durable.SDK";
         internal const string IsOrchestrationFailureKey = "IsOrchestrationFailure";
         internal const string TracePipelineObjectCmdlet = "Microsoft.Azure.Functions.PowerShellWorker\\Trace-PipelineObject";
+        internal const string ExternalDurableSdkEnvVariable = "ExternalDurablePowerShellSDK";
 
         internal readonly static object BoxedTrue = (object)true;
         internal readonly static object BoxedFalse = (object)false;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-powershell-worker/issues/910

This PR adds a simple unit test validating that users are warned, through logs, when they load the DF External SDK without first setting the environment variable that enables it

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
