### PR TITLE
Update PowerShell 7.2 to SDK 7.2.9

### DIFF
--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -27,7 +27,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </metadata>
   <files>
     <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7.2" />
-    <file src="..\src\bin\$configuration$\$targetFramework$\publish\worker.config.json" target="contentFiles\any\any\workers\powershell" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>
 </package>

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.9" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -17,8 +17,8 @@ $DotnetSDKVersionRequirements = @{
     }
 
     '6.0' = @{
-        MinimalPatch = '404'
-        DefaultPatch = '404'
+        MinimalPatch = '405'
+        DefaultPatch = '405'
     }
 }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
* https://github.com/Azure/azure-functions-powershell-worker/issues/915
* Remove `worker.config.json` from the `PowerShell 7.2` language worker. Going forward, the Functions Host will use the `worker.config.json` included in the `PowerShell 7.4` language worker nuget package

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
