### PR TITLE
Set IsReleaseBuild only for non-integration builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ steps:
   displayName: 'Set IsReleaseBuild variable'
   env:
     BuildSourceBranch: $(Build.SourceBranch)
+  condition: eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], 'false')
 
 - pwsh: ./build.ps1 -NoBuild -Bootstrap
   displayName: 'Running ./build.ps1 -NoBuild -Bootstrap'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

I have changed the integration tests to target the `4.x/ps7.2` branch given that the `dev` branch points to PowerShell 7.4. 

When we run the pipeline for integration testing, we set the `UPLOADPACKAGETOPRERELEASEFEED` pipeline variable to `true` to upload the generated worker package PreRelease feed. As part of this work, I changed the logic to Set `IsReleaseBuild` only for non-integration builds. By doing this, we will not generate the SBOM as part of the build process given that this prerelease package will never be released to customers. 

After this change, we will only execute this block https://github.com/Azure/azure-functions-powershell-worker/blob/dev/azure-pipelines.yml#L26-L39 to set  `IsReleaseBuild` if `UPLOADPACKAGETOPRERELEASEFEED` is set to `false`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
