### PR TITLE
Update logic to set shouldAddSBOM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,20 @@ steps:
 
 - pwsh: |
       $ErrorActionPreference = "Stop"
-      $shouldAddSBOM = [bool]"$(IsReleaseBuild)"
+
+      $shouldAddSBOM = $null
+      if ([string]::IsNullOrEmpty($IsReleaseBuild))
+      {
+        Write-Host "IsReleaseBuild is null or empty. Setting shouldAddSBOM to false"
+        $shouldAddSBOM = $false
+      }
+      else
+      {
+        Write-Host "IsReleaseBuild: $IsReleaseBuild"
+        $shouldAddSBOM = ($IsReleaseBuild -eq "true")
+      }
+
+      Write-Host "shouldAddSBOM: $shouldAddSBOM"
 
       ./build.ps1 -Clean -Configuration Release -BuildNumber "$(buildNumber)" -AddSBOM:$shouldAddSBOM -SBOMUtilSASUrl "$(SBOMUtilSASUrl)"
   displayName: 'Build worker code'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR fixes the logic to set `$shouldAddSBOM`. In my previous PR https://github.com/Azure/azure-functions-powershell-worker/pull/919, I updated the logic to set this variable, but failed to consider when `$IsReleaseBuild` is `$null` as this assignment `[bool]"$(IsReleaseBuild)"` will throw in PowerShell. Additionally, I've added some extra logging to see how `$shouldAddSBOM` is set.  

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
