### PR TITLE
fix: durable orchestration with special characters

### DIFF
--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -129,7 +129,7 @@ function Start-DurableOrchestration {
 
     $Body = $InputObject | ConvertTo-Json -Compress
               
-    $null = Invoke-RestMethod -Uri $Uri -Method 'POST' -ContentType 'application/json' -Body $Body
+    $null = Invoke-RestMethod -Uri $Uri -Method 'POST' -ContentType 'application/json;charset=utf-8' -Body $Body
     
     return $instanceId
 }


### PR DESCRIPTION
Fix *Start-DurableOrchestration* with charset utf-8 to allow special characters in the *InputObject*.