### PR TITLE
Bump Grpc.Net.Client from 2.49.0 to 2.52.0 in /src (#968)

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -20,7 +20,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.11" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Cherry-picked https://github.com/Azure/azure-functions-powershell-worker/pull/968 to the `v4.x/ps7.2 ` branch. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
