### PR TITLE
Update language worker to support parsing command-line arguments prefix with functions-<argumentname>

### DIFF
--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                             workerOptions.Host = uri.Host;
                             workerOptions.Port = uri.Port;
                         }
-                        catch (UriFormatException ex)
+                        catch (UriFormatException formatEx)
                         {
-                            var message = $"Invalid URI format: {workerArgs.FunctionsUri}. Error message: {ex.Message}";
+                            var message = $"Invalid URI format: {workerArgs.FunctionsUri}. Error message: {formatEx.Message}";
                             throw new ArgumentException(message, nameof(workerArgs.FunctionsUri));
                         }
                     }
@@ -69,13 +69,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     }
 
                     // Validate workerOptions
-                    ValidateProperty(workerOptions.WorkerId, "WorkerId");
-                    ValidateProperty(workerOptions.RequestId, "RequestId");
-                    ValidateProperty(workerOptions.Host, "Host");
+                    ValidateProperty("WorkerId", workerOptions.WorkerId);
+                    ValidateProperty("RequestId", workerOptions.RequestId);
+                    ValidateProperty("Host", workerOptions.Host);
 
                     if (workerOptions.Port <= 0)
                     {
-                        throw new ArgumentException("Port has not been initialized", nameof(workerOptions.Port));
+                        throw new ArgumentException("Port number has not been initialized", nameof(workerOptions.Port));
                     }
                 });
 
@@ -125,11 +125,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             RpcLogger.WriteSystemLog(LogLevel.Information, message);
         }
 
-        private static void ValidateProperty(string value, string propertyName)
+        private static void ValidateProperty(string name, string value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
-                throw new ArgumentException($"{propertyName} is null or empty", propertyName);
+                throw new ArgumentException($"{name} is null or empty", name);
             }
         }
     }

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -33,7 +33,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
             var workerOptions = new WorkerOptions();
 
-            var parser = new Parser(settings => settings.EnableDashDash = true);
+            var parser = new Parser(settings =>
+            {
+                settings.EnableDashDash = true;
+                settings.IgnoreUnknownArguments = true;
+            });
             parser.ParseArguments<WorkerArguments>(args)
                 .WithParsed(workerArgs =>
                 {

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -147,9 +147,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         [Option("requestId", Required = false, HelpText = "Request ID used for gRPC communication with the Host.")]
         public string RequestId { get; set; }
 
-        [Option("grpcMaxMessageLength", Required = false, HelpText = "[Deprecated and ignored] gRPC Maximum message size.")]
-        public int MaxMessageLength { get; set; }
-
         [Option("functions-uri", Required = false, HelpText = "URI with IP Address and Port used to connect to the Host via gRPC.")]
         public string FunctionsUri { get; set; }
 
@@ -158,9 +155,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
         [Option("functions-requestid", Required = false, HelpText = "Request ID used for gRPC communication with the Host.")]
         public string FunctionsRequestId { get; set; }
-
-        [Option("functions-grpcmaxmessagelength", Required = false, HelpText = "[Deprecated and ignored] gRPC Maximum message size.")]
-        public int FunctionsMaxMessageLength { get; set; }
     }
 
     internal class WorkerOptions

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -121,6 +121,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
         [Option("requestId", Required = false, HelpText = "Request ID used for gRPC communication with the Host.")]
         public string RequestId { get; set; }
 
+        [Option("grpcMaxMessageLength", Required = false, HelpText = "[Deprecated and ignored] gRPC Maximum message size.")]
+        public int MaxMessageLength { get; set; }
+
         [Option("functions-uri", Required = false, HelpText = "URI with IP Address and Port used to connect to the Host via gRPC.")]
         public string FunctionsUri { get; set; }
 
@@ -129,6 +132,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
 
         [Option("functions-requestid", Required = false, HelpText = "Request ID used for gRPC communication with the Host.")]
         public string FunctionsRequestId { get; set; }
+
+        [Option("functions-grpcmaxmessagelength", Required = false, HelpText = "[Deprecated and ignored] gRPC Maximum message size.")]
+        public int FunctionsMaxMessageLength { get; set; }
     }
 
     internal class WorkerOptions

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -56,9 +56,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                             workerOptions.Host = uri.Host;
                             workerOptions.Port = uri.Port;
                         }
-                        catch (UriFormatException)
+                        catch (UriFormatException ex)
                         {
-                            throw new ArgumentException($"Invalid URI format: {workerArgs.FunctionsUri}", nameof(workerArgs.FunctionsUri));
+                            var message = $"Invalid URI format: {workerArgs.FunctionsUri}. Error message: {ex.Message}";
+                            throw new ArgumentException(message, nameof(workerArgs.FunctionsUri));
                         }
                     }
                     else


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves `(1)` and `(2)` for https://github.com/Azure/azure-functions-powershell-worker/issues/992
`(3)` must be done after the Functions Host changes have propagated, and we have a Core Tools version with this new Functions Host.

Changes in this PR:
* Add support to parsing command-line arguments prefix with `functions-<argumentname>`
* Parser to ignore unknown arguments
* Remove deprecated option `grpcMaxMessageLength`

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
