### PR TITLE
Replace deprecated packages in E2E

### DIFF
--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.18.0" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Constants.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Constants.cs
@@ -23,8 +23,8 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         public static class CosmosDB {
             public static string CosmosDBConnectionStringSetting = Environment.GetEnvironmentVariable("AzureWebJobsCosmosDBConnectionString");
             public static string DbName = "ItemDb";
-            public static string InputCollectionName = "ItemCollectionIn";
-            public static string OutputCollectionName = "ItemCollectionOut";
+            public static string InputCollectionName = "PartitionedItemCollectionIn";
+            public static string OutputCollectionName = "PartitionedItemCollectionOut";
             public static string LeaseCollectionName = "leases";
         }
 

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -14,6 +14,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
         private class Document
         {
+            // lower-case because Cosmos expects a field with this name
             public string id { get; set; }
         }
 

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -97,7 +97,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, "/id");
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, "/id");
-            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/_partitionKey");
+            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/id");
 
         }
         public async static Task DeleteDocumentCollections()

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -63,7 +63,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         public async static Task DeleteTestDocuments(string docId)
         {
             await DeleteDocument(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, docId);
-            await DeleteDocument(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, docId);
+            await DeleteDocument(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, docId);
         }
 
         private async static Task DeleteDocument(string dbName, string collectionName, string docId)

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -7,11 +7,6 @@ using Microsoft.Azure.Cosmos;
 
 namespace Azure.Functions.PowerShell.Tests.E2E
 {
-    public class TestDocument
-    {
-        public string id { get; set; }
-        public string name { get; set; }
-    }
 
     public static class CosmosDBHelpers
     {
@@ -43,15 +38,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             Document insertedDoc = await _inputContainer.CreateItemAsync<Document>(documentToTest, new PartitionKey(documentToTest.id));
         }
 
-        //public async static Task CreateDocument(TestDocument testDocument)
-        //{
-        //    Document insertedDoc = await _docDbClient.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName), testDocument);
-        //}
-
         // keep
         public async static Task<string> ReadDocument(string docId)
         {
-            //var docUri = UriFactory.CreateDocumentUri(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, docId);
             Document retrievedDocument = null;
             await Utilities.RetryAsync(async () =>
             {
@@ -97,6 +86,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, "/id");
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, "/id");
+            // While using extensions v2-3, the leases may not have a partition key, but the new SDK requires
+            // one to manually create a collection. This comment may be removed and this line uncommented when
+            // extension bundles for tests are updated. 
             //await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/id");
         }
         public async static Task DeleteDocumentCollections()
@@ -138,7 +130,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             {
                 IndexingPolicy = indexingPolicy
             };
-            await database.CreateContainerIfNotExistsAsync(containerProperties);
+            await database.CreateContainerIfNotExistsAsync(containerProperties, 400);
         }
     }
 }

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -71,7 +71,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             try
             {
                 Container container = _cosmosDbClient.GetContainer(dbName, collectionName);
-                await container.DeleteItemAsync<Document>(dbName, new PartitionKey(dbName));
+                await container.DeleteItemAsync<Document>(docId, new PartitionKey(docId));
             }
             catch (Exception)
             {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -19,7 +19,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
         private class Document
         {
-            public string Id { get; set; }
+            public string id { get; set; }
         }
 
         static CosmosDBHelpers()
@@ -35,12 +35,12 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         {
             Document documentToTest = new Document()
             {
-                Id = docId
+                id = docId
             };
 
             Container _inputContainer = _cosmosDbClient.GetContainer(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName);
 
-            Document insertedDoc = await _inputContainer.CreateItemAsync<Document>(documentToTest, new PartitionKey(documentToTest.Id));
+            Document insertedDoc = await _inputContainer.CreateItemAsync<Document>(documentToTest, new PartitionKey(documentToTest.id));
         }
 
         //public async static Task CreateDocument(TestDocument testDocument)
@@ -67,7 +67,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     return false;
                 }
             }, 120000, 4000);
-            return retrievedDocument.Id;
+            return retrievedDocument.id;
         }
 
         // keep
@@ -95,9 +95,9 @@ namespace Azure.Functions.PowerShell.Tests.E2E
         {
             Database db = await _cosmosDbClient.CreateDatabaseIfNotExistsAsync(Constants.CosmosDB.DbName);
 
-            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName);
-            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName);
-            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName);
+            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, "/id");
+            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, "/id");
+            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/_partitionKey");
 
         }
         public async static Task DeleteDocumentCollections()
@@ -120,7 +120,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
             }
         }
 
-        private async static Task CreateCollection(string dbName, string collectionName)
+        private async static Task CreateCollection(string dbName, string collectionName, string partitionKey)
         {
             Database database = _cosmosDbClient.GetDatabase(dbName);
             IndexingPolicy indexingPolicy = new IndexingPolicy
@@ -135,7 +135,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                     }
                 }
             };
-            var containerProperties = new ContainerProperties(collectionName, "/Id")
+            var containerProperties = new ContainerProperties(collectionName, partitionKey)
             {
                 IndexingPolicy = indexingPolicy
             };

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/CosmosDBHelpers.cs
@@ -97,8 +97,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
 
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.InputCollectionName, "/id");
             await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.OutputCollectionName, "/id");
-            await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/id");
-
+            //await CreateCollection(Constants.CosmosDB.DbName, Constants.CosmosDB.LeaseCollectionName, "/id");
         }
         public async static Task DeleteDocumentCollections()
         {

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/EventHubsHelpers.cs
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Helpers/EventHubsHelpers.cs
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
@@ -29,13 +30,11 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                 events.Add(evt);
             }
 
-            EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(Constants.EventHubs.EventHubsConnectionStringSetting);
-            builder.EntityPath = eventHubName;
-            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
+            EventHubProducerClient eventHubClient = new EventHubProducerClient(Constants.EventHubs.EventHubsConnectionStringSetting, eventHubName);
             await eventHubClient.SendAsync(events);
         }
 
-        public static async Task SendMessagesAsync(string eventId, string evenHubName)
+        public static async Task SendMessagesAsync(string eventId, string eventHubName)
         {
             // write 3 events
             List<EventData> events = new List<EventData>();
@@ -48,9 +47,7 @@ namespace Azure.Functions.PowerShell.Tests.E2E
                 events.Add(evt);
             }
 
-            EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(Constants.EventHubs.EventHubsConnectionStringSetting);
-            builder.EntityPath = evenHubName;
-            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
+            EventHubProducerClient eventHubClient = new EventHubProducerClient(Constants.EventHubs.EventHubsConnectionStringSetting, eventHubName);
             await eventHubClient.SendAsync(events);
         }
     }

--- a/test/E2E/TestFunctionApp/CosmosDBTriggerAndOutput/function.json
+++ b/test/E2E/TestFunctionApp/CosmosDBTriggerAndOutput/function.json
@@ -7,7 +7,7 @@
       "leaseCollectionName": "leases",
       "connectionStringSetting": "AzureWebJobsCosmosDBConnectionString",
       "databaseName": "ItemDb",
-      "collectionName": "ItemCollectionIn",
+      "collectionName": "PartitionedItemCollectionIn",
       "createLeaseCollectionIfNotExists": true
     },
     {
@@ -17,7 +17,7 @@
       "leaseCollectionName": "leases",
       "connectionStringSetting": "AzureWebJobsCosmosDBConnectionString",
       "databaseName": "ItemDb",
-      "collectionName": "ItemCollectionOut"
+      "collectionName": "PartitionedItemCollectionOut"
     }
   ]
 }

--- a/test/E2E/TestFunctionApp/host.json
+++ b/test/E2E/TestFunctionApp/host.json
@@ -5,7 +5,7 @@
     },
     "extensionBundle": {
         "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[2.*, 3.0.0)"
+        "version": "[4.*, 5.0.0)"
     },
     "extensions": {
         "durableTask": {

--- a/test/E2E/TestFunctionApp/host.json
+++ b/test/E2E/TestFunctionApp/host.json
@@ -9,7 +9,7 @@
     },
     "extensions": {
         "durableTask": {
-          "hubName": "ThisIsGarbage101723"
+          "hubName": "%TestTaskHubName%"
         }
       }
 }

--- a/test/E2E/TestFunctionApp/host.json
+++ b/test/E2E/TestFunctionApp/host.json
@@ -5,11 +5,11 @@
     },
     "extensionBundle": {
         "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[4.*, 5.0.0)"
+        "version": "[2.*, 3.0.0)"
     },
     "extensions": {
         "durableTask": {
-          "hubName": "%TestTaskHubName%"
+          "hubName": "ThisIsGarbage101723"
         }
       }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Replace deprecated packages in E2E

resolves #1017, #1018
Replaces Microsoft.Azure.EventHubs with latest stable Azure.Messaging.EventHubs
Replaces Microsoft.Azure.DocumentDB.Core with latest stable Microsoft.Azure.Cosmos

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #1019
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
