### PR TITLE
Updating build to check for vulnerabilities

### DIFF
--- a/Check-CsprojVulnerabilities.ps1
+++ b/Check-CsprojVulnerabilities.ps1
@@ -1,0 +1,54 @@
+param
+(
+    [String[]]
+    $CsprojFilePath
+)
+
+if (-not $CsprojFilePath)
+{
+    $CsprojFilePath = @(
+        "$PSScriptRoot/src/Microsoft.Azure.Functions.PowerShellWorker.csproj"
+        "$PSScriptRoot/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj"
+        "$PSScriptRoot/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj"
+    )
+}
+
+$logFilePath = "$PSScriptRoot/build.log"
+
+try
+{
+    foreach ($projectFilePath in $CsprojFilePath)
+    {
+        Write-Host "Analyzing '$projectFilePath' for vulnerabilities..."
+        
+        $projectFolder = Split-Path $projectFilePath
+        
+        Push-Location $projectFolder
+        & { dotnet restore $projectFileName }
+        & { dotnet list $projectFilePath package --include-transitive --vulnerable } 3>&1 2>&1 > $logFilePath
+        Pop-Location
+
+        # Check and report if vulnerabilities are found
+        $report = Get-Content $logFilePath -Raw
+        $result = $report | Select-String "has no vulnerable packages given the current sources"
+
+        if ($result)
+        {
+            Write-Host "No vulnerabilities found"
+        }
+        else
+        {
+            $output = [System.Environment]::NewLine + "Vulnerabilities found!" + $report
+            Write-Host $output -ForegroundColor Red
+            Exit 1
+        }
+        Write-Host ""
+    }
+}
+finally
+{
+    if (Test-Path $logFilePath)
+    {
+        Remove-Item $logFilePath -Force
+    }
+}

--- a/Check-CsprojVulnerabilities.ps1
+++ b/Check-CsprojVulnerabilities.ps1
@@ -24,7 +24,7 @@ try
         $projectFolder = Split-Path $projectFilePath
         
         Push-Location $projectFolder
-        & { dotnet restore $projectFileName }
+        & { dotnet restore $projectFilePath }
         & { dotnet list $projectFilePath package --include-transitive --vulnerable } 3>&1 2>&1 > $logFilePath
         Pop-Location
 

--- a/Check-CsprojVulnerabilities.ps1
+++ b/Check-CsprojVulnerabilities.ps1
@@ -1,7 +1,10 @@
 param
 (
     [String[]]
-    $CsprojFilePath
+    $CsprojFilePath,
+
+    [switch]
+    $PrintReport
 )
 
 if (-not $CsprojFilePath)
@@ -38,7 +41,12 @@ try
         }
         else
         {
-            $output = [System.Environment]::NewLine + "Vulnerabilities found!" + $report
+            $output = [System.Environment]::NewLine + "Vulnerabilities found!"            
+            if ($PrintReport.IsPresent)
+            {
+                $output += $report
+            }
+            
             Write-Host $output -ForegroundColor Red
             Exit 1
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,9 @@ steps:
 - pwsh: ./build.ps1 -NoBuild -Bootstrap
   displayName: 'Running ./build.ps1 -NoBuild -Bootstrap'
 
+- pwsh: ./Check-CsprojVulnerabilities.ps1
+  displayName: 'Check for security vulnerabilities'
+
 - pwsh: |
       $ErrorActionPreference = "Stop"
 

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Microsoft.Azure.Functions.PowerShellWorker": {
+      "commandName": "Project",
+      "commandLineArgs": "--host 127.0.0.1 --port 50821 --workerId e9efd817-47a1-45dc-9e20-e6f975d7a025 --requestId cbef5957-cdb3-4462-9ee7-ac9f91be0a51 --grpcMaxMessageLength 2147483647  --functions-uri http://127.0.0.1:50821 --functions-worker-id e9efd817-47a1-45dc-9e20-e6f975d7a025 --functions-request-id cbef5957-cdb3-4462-9ee7-ac9f91be0a51 --functions-grpc-max-message-length 2147483647"
+    }
+  }
+}

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Microsoft.Azure.Functions.PowerShellWorker": {
-      "commandName": "Project",
-      "commandLineArgs": "--host 127.0.0.1 --port 50821 --workerId e9efd817-47a1-45dc-9e20-e6f975d7a025 --requestId cbef5957-cdb3-4462-9ee7-ac9f91be0a51 --grpcMaxMessageLength 2147483647  --functions-uri http://127.0.0.1:50821 --functions-worker-id e9efd817-47a1-45dc-9e20-e6f975d7a025 --functions-request-id cbef5957-cdb3-4462-9ee7-ac9f91be0a51 --functions-grpc-max-message-length 2147483647"
-    }
-  }
-}

--- a/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
+++ b/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-2.final" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves https://github.com/Azure/azure-functions-powershell-worker/issues/1023

This PR contains the following changes:

* Added `Check-CsprojVulnerabilities.ps1` to ensure that the dependencies of the worker, unit test, and E2E test projects are up-to-date.
* Introduced a new stage in the pipeline named Check for security vulnerabilities that invokes `Check-CsprojVulnerabilities.ps1`.
* Upgraded dependencies with vulnerabilities in the unit test and E2E test projects.

Below is a screenshot of the new stage in the pipeline.
<img width="806" alt="image" src="https://github.com/Azure/azure-functions-powershell-worker/assets/12720858/a0746913-20bb-4fc2-b344-f8aa04189b03">

If vulnerabilities are found, the user can run `Check-CsprojVulnerabilities.ps1 -PrintReport` locally to see which packages need to be upgraded.

```powershell
PS E:\GH\azure-functions-powershell-worker> .\Check-CsprojVulnerabilities.ps1 -PrintReport
Analyzing 'E:\GH\azure-functions-powershell-worker/src/Microsoft.Azure.Functions.PowerShellWorker.csproj' for vulnerabilities...
  Determining projects to restore...
  All projects are up-to-date for restore.
No vulnerabilities found

Analyzing 'E:\GH\azure-functions-powershell-worker/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj' for vulnerabilities...
  Determining projects to restore...
  All projects are up-to-date for restore.
No vulnerabilities found

Analyzing 'E:\GH\azure-functions-powershell-worker/test/E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E/Azure.Functions.PowerShellWorker.E2E.csproj' for vulnerabilities...
  Determining projects to restore...
  All projects are up-to-date for restore.

Vulnerabilities found!
The following sources were used:
   https://api.nuget.org/v3/index.json
   https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions%40internalrelease/nuget/v3/index.json
   https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions%40staging/nuget/v3/index.json
   C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\

Project `Azure.Functions.PowerShellWorker.E2E` has the following vulnerable packages
   [net8.0]:
   Transitive Package                    Resolved   Severity   Advisory URL
   > System.Net.Http                     4.3.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Text.RegularExpressions      4.3.0      High       https://github.com/advisories/GHSA-cmhx-cq75-c4mj


PS E:\GH\azure-functions-powershell-worker>
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
