### PR TITLE
Shut off MD module upgrades after 7.4 EOL

### DIFF
--- a/create_new_worker_instructions.md
+++ b/create_new_worker_instructions.md
@@ -1,0 +1,6 @@
+##  Instructions for Upgrading the PowerShell Language Worker to a New PowerShell SDK Minor Version (7.6+)
+Once a new PowerShell SDK version is released on [GiHub](https://github.com/PowerShell/PowerShell/releases), follow these steps to upgrade the PowerShell SDK reference used by the language worker:
+
+- Update the solution targets as needed for whatever .NET version is targeted by the new PowerShell 
+- Follow instructions in upgrade_ps_sdk_instructions.md to update loosely linked dependencies in project files
+- Update the Managed Dependency shutoff date in src/DependencyManagement/WorkerEnvironment.cs

--- a/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
+++ b/src/DependencyManagement/BackgroundDependencySnapshotMaintainer.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private bool EnableAutomaticUpgrades { get; } =
             PowerShellWorkerConfiguration.GetBoolean("MDEnableAutomaticUpgrades") ?? false;
 
+
         private readonly IDependencyManagerStorage _storage;
         private readonly IDependencySnapshotInstaller _installer;
         private readonly IDependencySnapshotPurger _purger;
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
             _purger.SetCurrentlyUsedSnapshot(currentSnapshotPath, logger);
 
-            if (!EnableAutomaticUpgrades)
+            if (WorkerEnvironment.IsPowerShellSDKDeprecated() && !EnableAutomaticUpgrades)
             {
                 logger.Log(
                     isUserOnlyLog: false,

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         private Task _dependencyInstallationTask;
 
+        private bool EnableAutomaticUpgrades { get; } =
+            PowerShellWorkerConfiguration.GetBoolean("MDEnableAutomaticUpgrades") ?? false;
+
         #endregion
 
         public DependencyManager(
@@ -203,6 +206,16 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     isUserOnlyLog: false,
                     RpcLog.Types.Level.Trace,
                     PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
+
+                if (WorkerEnvironment.IsPowerShellSDKDeprecated() && !EnableAutomaticUpgrades)
+                {
+                    logger.Log(
+                        isUserOnlyLog: false,
+                        RpcLog.Types.Level.Warning,
+                        PowerShellWorkerStrings.AutomaticUpgradesAreDisabled);
+
+                    return null;
+                }
 
                 // Background installation: can't use the firstPwsh runspace because it belongs
                 // to the pool used to run functions code, so create a new runspace.

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -220,16 +220,6 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                     RpcLog.Types.Level.Trace,
                     PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled);
 
-                if (!ShouldEnableManagedDpendencyUpgrades())
-                {
-                    logger.Log(
-                        isUserOnlyLog: false,
-                        RpcLog.Types.Level.Warning,
-                        PowerShellWorkerStrings.AutomaticUpgradesAreDisabled);
-
-                    return null;
-                }
-
                 // Background installation: can't use the firstPwsh runspace because it belongs
                 // to the pool used to run functions code, so create a new runspace.
                 _nextSnapshotPath = _backgroundSnapshotMaintainer.InstallAndPurgeSnapshots(pwshFactory, logger);

--- a/src/DependencyManagement/WorkerEnvironment.cs
+++ b/src/DependencyManagement/WorkerEnvironment.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private const string ContainerName = "CONTAINER_NAME";
         private const string LegionServiceHost = "LEGION_SERVICE_HOST";
 
+        private static readonly DateTime PowerShellSDKDeprecationDate = new DateTime(2026, 11, 10);
+
         public static bool IsAppService()
         {
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(AzureWebsiteInstanceId));
@@ -31,6 +33,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             return !IsAppService() &&
                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ContainerName)) &&
                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(LegionServiceHost));
+        }
+
+        public static bool IsPowerShellSDKDeprecated()
+        {
+            return DateTime.Now > PowerShellSDKDeprecationDate;
         }
     }
 }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -352,6 +352,9 @@
   <data name="DependencySnapshotDoesNotContainAcceptableModuleVersions" xml:space="preserve">
     <value>Dependency snapshot '{0}' does not contain acceptable module versions.</value>
   </data>
+  <data name="WorkerInitCompleted" xml:space="preserve">
+    <value>Worker init request completed in {0} ms.</value>
+  </data>
   <data name="FoundExternalDurableSdkInSession" xml:space="preserve">
     <value>Found external Durable Functions SDK in session: Name='{0}', Version='{1}', Path='{2}'.</value>
   </data>
@@ -360,9 +363,6 @@
   </data>
   <data name="UnableToInitializeOrchestrator" xml:space="preserve">
     <value>Unable to initialize orchestrator function due to presence of other bindings. Total number of bindings found is '{0}'. Orchestrator Functions should never use any input or output bindings other than the orchestration trigger itself. See: aka.ms/df-bindings</value>
-  </data>
-  <data name="WorkerInitCompleted" xml:space="preserve">
-    <value>Worker init request completed in {0} ms.</value>
   </data>
   <data name="UnexpectedResultCount" xml:space="preserve">
     <value>Operation '{0}' expected '{1}' result(s) but received '{2}'.</value>
@@ -387,5 +387,8 @@
   </data>
   <data name="InvalidOpenTelemetryContext" xml:space="preserve">
     <value>The app is configured to use OpenTelemetry but the TraceContext passed from host was null. </value>
+  </data>
+  <data name="AutomaticUpgradesAreDisabled" xml:space="preserve">
+    <value>Automatic upgrades are disabled in PowerShell 7.4 function apps. This warning should not be emitted until PowerShell 7.4's End of Life date, at which time, more guidance will be available regarding how to upgrade your function app to the latest version. </value>
   </data>
 </root>

--- a/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
+++ b/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
                 // ReSharper disable once AccessToDisposedClosure
                 var installedSnapshotPath = maintainer.InstallAndPurgeSnapshots(() => dummyPowerShell, _mockLogger.Object);
-                Assert.Equal("new snapshot path", installedSnapshotPath);
+                Assert.Equal(null, installedSnapshotPath);
 
                 // ReSharper disable once AccessToDisposedClosure
                 _mockInstaller.Verify(

--- a/test/Unit/DependencyManagement/DependencyManagerTests.cs
+++ b/test/Unit/DependencyManagement/DependencyManagerTests.cs
@@ -229,49 +229,40 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void StartDependencyInstallationIfNeeded_InvokesBackgroundMaintainer_WhenAcceptableDependenciesAlreadyInstalled()
         {
-            try
+            _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
+                .Returns("AlreadyInstalled");
+            _mockStorage.Setup(_ => _.GetDependencies()).Returns(GetAnyNonEmptyDependencyManifestEntries());
+
+            var firstPowerShellRunspace = PowerShell.Create();
+            Func<PowerShell> powerShellFactory = PowerShell.Create;
+
+            _mockStorage.Setup(_ => _.SnapshotExists("AlreadyInstalled")).Returns(true);
+
+            _mockBackgroundDependencySnapshotMaintainer.Setup(
+                _ => _.InstallAndPurgeSnapshots(It.IsAny<Func<PowerShell>>(), It.IsAny<ILogger>()))
+                .Returns("NewSnapshot");
+
+            using (var dependencyManager = CreateDependencyManagerWithMocks())
             {
-                Environment.SetEnvironmentVariable("MDEnableAutomaticUpgrades", "true");
+                dependencyManager.Initialize(_mockLogger.Object);
+                dependencyManager.StartDependencyInstallationIfNeeded(firstPowerShellRunspace, powerShellFactory, _mockLogger.Object);
+                var hadToWait = dependencyManager.WaitForDependenciesAvailability(() => _mockLogger.Object);
 
-                _mockInstalledDependenciesLocator.Setup(_ => _.GetPathWithAcceptableDependencyVersionsInstalled())
-                    .Returns("AlreadyInstalled");
-                _mockStorage.Setup(_ => _.GetDependencies()).Returns(GetAnyNonEmptyDependencyManifestEntries());
+                Assert.False(hadToWait);
+                Assert.Equal("NewSnapshot", dependencyManager.WaitForBackgroundDependencyInstallationTaskCompletion());
 
-                var firstPowerShellRunspace = PowerShell.Create();
-                Func<PowerShell> powerShellFactory = PowerShell.Create;
-
-                _mockStorage.Setup(_ => _.SnapshotExists("AlreadyInstalled")).Returns(true);
-
-                _mockBackgroundDependencySnapshotMaintainer.Setup(
-                    _ => _.InstallAndPurgeSnapshots(It.IsAny<Func<PowerShell>>(), It.IsAny<ILogger>()))
-                    .Returns("NewSnapshot");
-
-                using (var dependencyManager = CreateDependencyManagerWithMocks())
-                {
-                    dependencyManager.Initialize(_mockLogger.Object);
-                    dependencyManager.StartDependencyInstallationIfNeeded(firstPowerShellRunspace, powerShellFactory, _mockLogger.Object);
-                    var hadToWait = dependencyManager.WaitForDependenciesAvailability(() => _mockLogger.Object);
-
-                    Assert.False(hadToWait);
-                    Assert.Equal("NewSnapshot", dependencyManager.WaitForBackgroundDependencyInstallationTaskCompletion());
-
-                    _mockBackgroundDependencySnapshotMaintainer.Verify(
-                        _ => _.InstallAndPurgeSnapshots(powerShellFactory, _mockLogger.Object),
-                        Times.Once);
-                }
-
-                _mockLogger.Verify(
-                    _ => _.Log(
-                        false,
-                        LogLevel.Trace,
-                        It.Is<string>(message => message.Contains(PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled)),
-                        It.IsAny<Exception>()),
+                _mockBackgroundDependencySnapshotMaintainer.Verify(
+                    _ => _.InstallAndPurgeSnapshots(powerShellFactory, _mockLogger.Object),
                     Times.Once);
             }
-            finally
-            {
-                Environment.SetEnvironmentVariable("MDEnableAutomaticUpgrades", null);
-            }
+
+            _mockLogger.Verify(
+                _ => _.Log(
+                    false,
+                    LogLevel.Trace,
+                    It.Is<string>(message => message.Contains(PowerShellWorkerStrings.AcceptableFunctionAppDependenciesAlreadyInstalled)),
+                    It.IsAny<Exception>()),
+                Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Will need to be added as part of documentation work for #943 
Backport to 7.2 required, will link to that PR once this one is merged and rebased

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)