### PR TITLE
Shutoff Managed Dependency upgrades after 7.2 EOL

### DIFF
--- a/create_new_worker_instructions.md
+++ b/create_new_worker_instructions.md
@@ -1,0 +1,6 @@
+##  Instructions for Upgrading the PowerShell Language Worker to a New PowerShell SDK Minor Version (7.6+)
+Once a new PowerShell SDK version is released on [GiHub](https://github.com/PowerShell/PowerShell/releases), follow these steps to upgrade the PowerShell SDK reference used by the language worker:
+
+- Update the solution targets as needed for whatever .NET version is targeted by the new PowerShell 
+- Follow instructions in upgrade_ps_sdk_instructions.md to update loosely linked dependencies in project files
+- Update the Managed Dependency shutoff date in src/DependencyManagement/WorkerEnvironment.cs

--- a/src/DependencyManagement/DependencyManager.cs
+++ b/src/DependencyManagement/DependencyManager.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
 
         private Task _dependencyInstallationTask;
 
+        private bool EnableAutomaticUpgrades { get; } =
+            PowerShellWorkerConfiguration.GetBoolean("MDEnableAutomaticUpgrades") ?? false;
+
         #endregion
 
         public DependencyManager(
@@ -67,7 +70,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 maintainer ?? new BackgroundDependencySnapshotMaintainer(
                                     _storage,
                                     _installer,
-                                    new DependencySnapshotPurger(_storage));
+                                    new DependencySnapshotPurger(_storage),
+                                    ShouldEnableManagedDpendencyUpgrades);
             _currentSnapshotContentLogger =
                 currentSnapshotContentLogger ?? new BackgroundDependencySnapshotContentLogger(snapshotContentLogger);
         }
@@ -124,6 +128,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
                 var errorMsg = string.Format(PowerShellWorkerStrings.FailToInstallFuncAppDependencies, e.Message);
                 throw new DependencyInstallationException(errorMsg, e);
             }
+        }
+
+        /// <summary>
+        /// Determines whether the function app should enable automatic upgrades for managed dependencies
+        /// </summary>
+        /// <returns>
+        /// True if Managed Dependencies should be upgraded (SDK is not past it's deprecation date OR user has configured this behavior via MDEnableAutomaticUpgrades env var
+        /// False if Managed Dependencies should not be upgraded
+        /// </returns>
+        private bool ShouldEnableManagedDpendencyUpgrades()
+        {
+            return !WorkerEnvironment.IsPowerShellSDKDeprecated() || EnableAutomaticUpgrades;
         }
 
         /// <summary>

--- a/src/DependencyManagement/WorkerEnvironment.cs
+++ b/src/DependencyManagement/WorkerEnvironment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private const string ContainerName = "CONTAINER_NAME";
         private const string LegionServiceHost = "LEGION_SERVICE_HOST";
 
-        private static readonly DateTime PowerShellSDKDeprecationDate = new DateTime(2026, 11, 10);
+        private static readonly DateTime PowerShellSDKDeprecationDate = new DateTime(2024, 11, 8);
 
         public static bool IsAppService()
         {

--- a/src/DependencyManagement/WorkerEnvironment.cs
+++ b/src/DependencyManagement/WorkerEnvironment.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
         private const string ContainerName = "CONTAINER_NAME";
         private const string LegionServiceHost = "LEGION_SERVICE_HOST";
 
+        private static readonly DateTime PowerShellSDKDeprecationDate = new DateTime(2026, 11, 10);
+
         public static bool IsAppService()
         {
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(AzureWebsiteInstanceId));
@@ -31,6 +33,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement
             return !IsAppService() &&
                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ContainerName)) &&
                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(LegionServiceHost));
+        }
+
+        public static bool IsPowerShellSDKDeprecated()
+        {
+            return DateTime.Now > PowerShellSDKDeprecationDate;
         }
     }
 }

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -352,6 +352,9 @@
   <data name="DependencySnapshotDoesNotContainAcceptableModuleVersions" xml:space="preserve">
     <value>Dependency snapshot '{0}' does not contain acceptable module versions.</value>
   </data>
+  <data name="WorkerInitCompleted" xml:space="preserve">
+    <value>Worker init request completed in {0} ms.</value>
+  </data>
   <data name="FoundExternalDurableSdkInSession" xml:space="preserve">
     <value>Found external Durable Functions SDK in session: Name='{0}', Version='{1}', Path='{2}'.</value>
   </data>
@@ -360,9 +363,6 @@
   </data>
   <data name="UnableToInitializeOrchestrator" xml:space="preserve">
     <value>Unable to initialize orchestrator function due to presence of other bindings. Total number of bindings found is '{0}'. Orchestrator Functions should never use any input or output bindings other than the orchestration trigger itself. See: aka.ms/df-bindings</value>
-  </data>
-  <data name="WorkerInitCompleted" xml:space="preserve">
-    <value>Worker init request completed in {0} ms.</value>
   </data>
   <data name="UnexpectedResultCount" xml:space="preserve">
     <value>Operation '{0}' expected '{1}' result(s) but received '{2}'.</value>
@@ -387,5 +387,8 @@
   </data>
   <data name="InvalidOpenTelemetryContext" xml:space="preserve">
     <value>The app is configured to use OpenTelemetry but the TraceContext passed from host was null. </value>
+  </data>
+  <data name="AutomaticUpgradesAreDisabled" xml:space="preserve">
+    <value>Automatic upgrades are disabled in PowerShell 7.4 function apps. This warning should not be emitted until PowerShell 7.4's End of Life date, at which time, more guidance will be available regarding how to upgrade your function app to the latest version. </value>
   </data>
 </root>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -389,6 +389,6 @@
     <value>The app is configured to use OpenTelemetry but the TraceContext passed from host was null. </value>
   </data>
   <data name="AutomaticUpgradesAreDisabled" xml:space="preserve">
-    <value>Automatic upgrades are disabled in PowerShell 7.4 function apps. This warning should not be emitted until PowerShell 7.4's End of Life date, at which time, more guidance will be available regarding how to upgrade your function app to the latest version. </value>
+    <value>Automatic upgrades are disabled in PowerShell 7.2 function apps. This warning should not be emitted until PowerShell 7.2's End of Life date. For more information, please see https://azure.microsoft.com/en-us/updates/v2/powershell72-azure-functions-retirement</value>
   </data>
 </root>

--- a/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
+++ b/test/Unit/DependencyManagement/BackgroundDependencySnapshotMaintainerTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
 
     using Microsoft.Azure.Functions.PowerShellWorker.DependencyManagement;
     using Microsoft.Azure.Functions.PowerShellWorker.Utility;
-
     using LogLevel = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types.Level;
+    using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 
     public class BackgroundDependencySnapshotMaintainerTests
     {
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         [Fact]
         public void SetsCurrentlyUsedSnapshotOnPurger()
         {
-            using (var maintainer = CreateMaintainerWithMocks())
+            using (var maintainer = CreateMaintainerWithMocks(true))
             {
                 maintainer.Start("current snapshot", _dependencyManifest, _mockLogger.Object);
             }
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                         It.IsAny<ILogger>()));
 
             using (var dummyPowerShell = PowerShell.Create())
-            using (var maintainer = CreateMaintainerWithMocks(_minBackgroundUpgradePeriod))
+            using (var maintainer = CreateMaintainerWithMocks(true, _minBackgroundUpgradePeriod))
             {
                 maintainer.Start("current snapshot", _dependencyManifest, _mockLogger.Object);
 
@@ -74,13 +74,48 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
         }
 
         [Fact]
+        public void DoesNothingIfManagedDependenciesUpgradesAreDisabled()
+        {
+            _mockStorage.Setup(_ => _.GetInstalledAndInstallingSnapshots()).Returns(new[] { "older snapshot" });
+            _mockStorage.Setup(_ => _.GetSnapshotCreationTimeUtc("older snapshot"))
+                .Returns(DateTime.UtcNow - _minBackgroundUpgradePeriod - TimeSpan.FromSeconds(1));
+
+            _mockStorage.Setup(_ => _.CreateNewSnapshotPath()).Returns("new snapshot path");
+
+            _mockInstaller.Setup(
+                _ => _.InstallSnapshot(
+                        It.IsAny<DependencyManifestEntry[]>(),
+                        It.IsAny<string>(),
+                        It.IsAny<PowerShell>(),
+                        It.IsAny<DependencySnapshotInstallationMode>(),
+                        It.IsAny<ILogger>()));
+
+            using (var dummyPowerShell = PowerShell.Create())
+            using (var maintainer = CreateMaintainerWithMocks(false, _minBackgroundUpgradePeriod))
+            {
+                maintainer.Start("current snapshot", _dependencyManifest, _mockLogger.Object);
+
+                // ReSharper disable once AccessToDisposedClosure
+                var installedSnapshotPath = maintainer.InstallAndPurgeSnapshots(() => dummyPowerShell, _mockLogger.Object);
+                Assert.Equal(null, installedSnapshotPath);
+
+                // ReSharper disable once AccessToDisposedClosure
+                _mockInstaller.Verify(
+                    _ => _.InstallSnapshot(_dependencyManifest, "new snapshot path", dummyPowerShell, DependencySnapshotInstallationMode.Optional, _mockLogger.Object),
+                    Times.Never);
+
+                _mockLogger.Verify(_ => _.Log(false, LogLevel.Warning, PowerShellWorkerStrings.AutomaticUpgradesAreDisabled, null), Times.Once);
+            }
+        }
+
+        [Fact]
         public void DoesNotInstallSnapshotIfRecentlyInstalledSnapshotFound()
         {
             _mockStorage.Setup(_ => _.GetInstalledAndInstallingSnapshots()).Returns(new[] { "older snapshot" });
             _mockStorage.Setup(_ => _.GetSnapshotCreationTimeUtc("older snapshot"))
                 .Returns(DateTime.UtcNow - _minBackgroundUpgradePeriod + TimeSpan.FromSeconds(1));
 
-            using (var maintainer = CreateMaintainerWithMocks(_minBackgroundUpgradePeriod))
+            using (var maintainer = CreateMaintainerWithMocks(true, _minBackgroundUpgradePeriod))
             {
                 maintainer.Start("current snapshot", _dependencyManifest, _mockLogger.Object);
 
@@ -112,7 +147,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 .Throws(injectedException);
 
             using (var dummyPowerShell = PowerShell.Create())
-            using (var maintainer = CreateMaintainerWithMocks(_minBackgroundUpgradePeriod))
+            using (var maintainer = CreateMaintainerWithMocks(true, _minBackgroundUpgradePeriod))
             {
                 maintainer.Start("current snapshot", _dependencyManifest, _mockLogger.Object);
 
@@ -129,12 +164,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.DependencyManagement
                 Times.Once);
         }
 
-        private BackgroundDependencySnapshotMaintainer CreateMaintainerWithMocks(TimeSpan? minBackgroundUpgradePeriod = null)
+        private BackgroundDependencySnapshotMaintainer CreateMaintainerWithMocks(bool shouldPerformManagedDependenciesUpgrades, TimeSpan? minBackgroundUpgradePeriod = null)
         {
             var maintainer = new BackgroundDependencySnapshotMaintainer(
                                     _mockStorage.Object,
                                     _mockInstaller.Object,
-                                    _mockPurger.Object);
+                                    _mockPurger.Object, 
+                                    () => { return shouldPerformManagedDependenciesUpgrades; });
 
             if (minBackgroundUpgradePeriod != null)
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Cherry-pick e034e29ce14a86f47f94904733496c43d8c17990 to v4.x/ps7.2
Backport new Managed Dependency shutoff logic to PowerShell 7.2

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
