### PR TITLE
Make official pipeline run nightly

### DIFF
--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -5,6 +5,16 @@ trigger:
       - v4.x/*
       - v3.x/*
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - dev
+    - v4.x/*
+    - v3.x/*
+  always: true
+
 # CI only, does not trigger on PRs.
 pr: none
 


### PR DESCRIPTION
Follow up to: https://github.com/Azure/azure-functions-powershell-worker/pull/1083
We meant to have the official pipeline run nightly, so the code mirror can send CodeQL reports.
