### PR TITLE
Use rpcBaseUrl in durable operations when possible

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,1 @@
+* Use rpcBaseUrl in Durable operations when possible

--- a/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
+++ b/src/Modules/Microsoft.Azure.Functions.PowerShellWorker/Microsoft.Azure.Functions.PowerShellWorker.psm1
@@ -46,7 +46,11 @@ function Get-DurableStatus {
         $DurableClient = GetDurableClientFromModulePrivateData
     }
 
-    $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId"
+    if ($DurableClient.rpcBaseUrl) {
+        $requestUrl = "$($DurableClient.rpcBaseUrl)/instances/$InstanceId"
+    } else {
+        $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId"
+    }
 
     $query = @()
     if ($ShowHistory.IsPresent) {
@@ -158,8 +162,12 @@ function Stop-DurableOrchestration {
         $DurableClient = GetDurableClientFromModulePrivateData
     }
 
-    $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId/terminate?reason=$([System.Web.HttpUtility]::UrlEncode($Reason))"
-
+    if ($DurableClient.rpcBaseUrl) {
+        $requestUrl = "$($DurableClient.rpcBaseUrl)/instances/$InstanceId/terminate?reason=$([System.Web.HttpUtility]::UrlEncode($Reason))"
+    } else {
+        $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId/terminate?reason=$([System.Web.HttpUtility]::UrlEncode($Reason))"
+    }
+    
     Invoke-RestMethod -Uri $requestUrl -Method 'POST'
 }
 
@@ -297,7 +305,12 @@ function GetRaiseEventUrl(
     [string] $ConnectionName,
     [string] $AppCode) {
 
-    $RequestUrl = $DurableClient.BaseUrl + "/instances/$InstanceId/raiseEvent/$EventName"
+
+    if ($DurableClient.rpcBaseUrl) {
+        $RequestUrl = $DurableClient.rpcBaseUrl + "/instances/$InstanceId/raiseEvent/$EventName"
+    } else {
+        $RequestUrl = $DurableClient.BaseUrl + "/instances/$InstanceId/raiseEvent/$EventName"
+    }
     
     $query = @()
     if ($null -eq $TaskHubName) {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

When experimenting with https://github.com/Azure/azure-functions-durable-powershell/issues/73, I found that if a user does not explicitly call Import-Module on the external SDK, _functions_ that are exposed in the external Durable SDK are not used, and instead the definitions loaded in the bundled module are used. 

This change imports the fix from https://github.com/Azure/azure-functions-durable-powershell/pull/66 into the bundled module, with additional checks to prevent breaking backwards compatibility. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
