### PR TITLE
Set environment variable to avoid Get-AzAccessToken breaking change

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,1 @@
-* Use rpcBaseUrl in Durable operations when possible
+* Set environment variable to avoid Get-AzAccessToken breaking change

--- a/src/RequestProcessor.cs
+++ b/src/RequestProcessor.cs
@@ -106,6 +106,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             Environment.SetEnvironmentVariable("AZUREPS_HOST_ENVIRONMENT", $"AzureFunctions/{workerInitRequest.HostVersion}");
             Environment.SetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL", $"Azure-Functions:{workerInitRequest.HostVersion}");
 
+            // Set the environment variable to force the Get-AzAccessToken to return a
+            // plaintext token and avoid the planned breaking change.
+            // TODO: Remove this for the next PowerShell version (7.6).
+            Environment.SetEnvironmentVariable("AZUREPS_OUTPUT_PLAINTEXT_AZACCESSTOKEN", "true");
+
             StreamingMessage response = NewStreamingMessageTemplate(
                 request.RequestId,
                 StreamingMessage.ContentOneofCase.WorkerInitResponse,


### PR DESCRIPTION
One of the next versions of Az.Accounts will have a breaking change: by default, the `Get-AzAccessToken` will return a `SecureString` instead a plaintext `string` even when the `-AsSecureString` switch is not provided. This environment variable will force the new `Get-AzAccessToken` to keep the old behavior by default.

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
