### PR TITLE
[Durable] Add Version property to $Context

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,1 @@
-* Set environment variable to avoid Get-AzAccessToken breaking change
+* [Durable] Add Version property to $Context

--- a/src/DurableSDK/HistoryEvent.cs
+++ b/src/DurableSDK/HistoryEvent.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         [DataMember]
         public string Name { get; set; }
+
+        [DataMember]
+        public string Version { get; set; }
         
         [DataMember]
         public string Result { get; set; }

--- a/src/DurableSDK/OrchestrationContext.cs
+++ b/src/DurableSDK/OrchestrationContext.cs
@@ -39,17 +39,17 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         private readonly Lazy<string> _version;
 
-        public OrchestrationContext()
-        {
-            _version = new Lazy<string>(() => OrchestrationVersionExtractor.GetVersionFromHistory(History));
-        }
-
         public string Version 
         {
             get 
             {
                 return _version.Value;
             }
+        }
+
+        public OrchestrationContext()
+        {
+            _version = new Lazy<string>(() => OrchestrationVersionExtractor.GetVersionFromHistory(History));
         }
     }
 }

--- a/src/DurableSDK/OrchestrationContext.cs
+++ b/src/DurableSDK/OrchestrationContext.cs
@@ -36,5 +36,19 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         internal OrchestrationActionCollector OrchestrationActionCollector { get; } = new OrchestrationActionCollector();
 
         internal object CustomStatus { get; set; }
+
+        public string Version 
+        {
+            get 
+            {
+                if (History == null)
+                {
+                    return null;
+                }
+                
+                var executionStartedEvent = Array.Find(History, e => e.EventType == HistoryEventType.ExecutionStarted);
+                return executionStartedEvent?.Version;
+            }
+        }
     }
 }

--- a/src/DurableSDK/OrchestrationContext.cs
+++ b/src/DurableSDK/OrchestrationContext.cs
@@ -41,13 +41,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         {
             get 
             {
-                if (History == null)
-                {
-                    return null;
-                }
-                
-                var executionStartedEvent = Array.Find(History, e => e.EventType == HistoryEventType.ExecutionStarted);
-                return executionStartedEvent?.Version;
+                return OrchestrationVersionExtractor.GetVersionFromHistory(History);
             }
         }
     }

--- a/src/DurableSDK/OrchestrationContext.cs
+++ b/src/DurableSDK/OrchestrationContext.cs
@@ -37,11 +37,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         internal object CustomStatus { get; set; }
 
+        private readonly Lazy<string> _version;
+
+        public OrchestrationContext()
+        {
+            _version = new Lazy<string>(() => OrchestrationVersionExtractor.GetVersionFromHistory(History));
+        }
+
         public string Version 
         {
             get 
             {
-                return OrchestrationVersionExtractor.GetVersionFromHistory(History);
+                return _version.Value;
             }
         }
     }

--- a/src/DurableSDK/OrchestrationVersionExtractor.cs
+++ b/src/DurableSDK/OrchestrationVersionExtractor.cs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
+{
+    using System;
+
+    /// <summary>
+    /// Helper class to extract version information from orchestration context.
+    /// </summary>
+    internal static class OrchestrationVersionExtractor
+    {
+        /// <summary>
+        /// Gets the orchestration version from a collection of history events.
+        /// </summary>
+        /// <param name="historyEvents">The history events to search.</param>
+        /// <returns>The version, or null if not found.</returns>
+        public static string GetVersionFromHistory(HistoryEvent[] historyEvents)
+        {
+            if (historyEvents == null)
+            {
+                return null;
+            }
+            
+            var executionStartedEvent = Array.Find(historyEvents, e => e.EventType == HistoryEventType.ExecutionStarted);
+            return executionStartedEvent?.Version;
+        }
+    }
+}

--- a/test/Unit/Durable/OrchestrationVersionExtractorTests.cs
+++ b/test/Unit/Durable/OrchestrationVersionExtractorTests.cs
@@ -14,80 +14,51 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         [Fact]
         public void GetVersionFromHistory_ReturnsNull_WhenHistoryIsNull()
         {
-            // Act
             string result = OrchestrationVersionExtractor.GetVersionFromHistory(null);
 
-            // Assert
             Assert.Null(result);
         }
 
         [Fact]
         public void GetVersionFromHistory_ReturnsNull_WhenHistoryHasNoExecutionStartedEvent()
         {
-            // Arrange
             var historyEvents = new[]
             {
-                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 1 },
-                new HistoryEvent { EventType = HistoryEventType.TaskCompleted, EventId = 2, TaskScheduledId = 1 }
+                new HistoryEvent { EventType = HistoryEventType.OrchestratorStarted },
+                new HistoryEvent { EventType = HistoryEventType.TaskScheduled }
             };
 
-            // Act
             string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
 
-            // Assert
             Assert.Null(result);
         }
 
         [Fact]
         public void GetVersionFromHistory_ReturnsVersion_WhenExecutionStartedEventExists()
         {
-            // Arrange
-            const string expectedVersion = "1.0.0";
             var historyEvents = new[]
             {
-                new HistoryEvent { 
-                    EventType = HistoryEventType.ExecutionStarted, 
-                    EventId = 1, 
-                    Version = expectedVersion 
-                },
-                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 2 }
+                new HistoryEvent { EventType = HistoryEventType.OrchestratorStarted },
+                new HistoryEvent { EventType = HistoryEventType.ExecutionStarted, Version = "1.0" },
             };
 
-            // Act
             string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
 
-            // Assert
-            Assert.Equal(expectedVersion, result);
+            Assert.Equal("1.0", result);
         }
 
         [Fact]
         public void GetVersionFromHistory_ReturnsFirstExecutionStartedVersion_WhenMultipleExecutionStartedEventsExist()
         {
-            // Arrange
-            const string expectedVersion = "1.0.0";
-            const string secondVersion = "2.0.0";
-            
             var historyEvents = new[]
             {
-                new HistoryEvent { 
-                    EventType = HistoryEventType.ExecutionStarted, 
-                    EventId = 1, 
-                    Version = expectedVersion 
-                },
-                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 2 },
-                new HistoryEvent { 
-                    EventType = HistoryEventType.ExecutionStarted,
-                    EventId = 3,
-                    Version = secondVersion
-                }
+                new HistoryEvent { EventType = HistoryEventType.ExecutionStarted, Version = "1.0" },
+                new HistoryEvent { EventType = HistoryEventType.ExecutionStarted, Version = "2.0" }
             };
 
-            // Act
             string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
 
-            // Assert
-            Assert.Equal(expectedVersion, result);
-            Assert.NotEqual(secondVersion, result);
+            Assert.Equal("1.0", result);
         }
     }
 }

--- a/test/Unit/Durable/OrchestrationVersionExtractorTests.cs
+++ b/test/Unit/Durable/OrchestrationVersionExtractorTests.cs
@@ -1,0 +1,93 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
+{
+    using System;
+    using Microsoft.Azure.Functions.PowerShellWorker.Durable;
+    using Xunit;
+
+    public class OrchestrationVersionExtractorTests
+    {
+        [Fact]
+        public void GetVersionFromHistory_ReturnsNull_WhenHistoryIsNull()
+        {
+            // Act
+            string result = OrchestrationVersionExtractor.GetVersionFromHistory(null);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetVersionFromHistory_ReturnsNull_WhenHistoryHasNoExecutionStartedEvent()
+        {
+            // Arrange
+            var historyEvents = new[]
+            {
+                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 1 },
+                new HistoryEvent { EventType = HistoryEventType.TaskCompleted, EventId = 2, TaskScheduledId = 1 }
+            };
+
+            // Act
+            string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetVersionFromHistory_ReturnsVersion_WhenExecutionStartedEventExists()
+        {
+            // Arrange
+            const string expectedVersion = "1.0.0";
+            var historyEvents = new[]
+            {
+                new HistoryEvent { 
+                    EventType = HistoryEventType.ExecutionStarted, 
+                    EventId = 1, 
+                    Version = expectedVersion 
+                },
+                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 2 }
+            };
+
+            // Act
+            string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
+
+            // Assert
+            Assert.Equal(expectedVersion, result);
+        }
+
+        [Fact]
+        public void GetVersionFromHistory_ReturnsFirstExecutionStartedVersion_WhenMultipleExecutionStartedEventsExist()
+        {
+            // Arrange
+            const string expectedVersion = "1.0.0";
+            const string secondVersion = "2.0.0";
+            
+            var historyEvents = new[]
+            {
+                new HistoryEvent { 
+                    EventType = HistoryEventType.ExecutionStarted, 
+                    EventId = 1, 
+                    Version = expectedVersion 
+                },
+                new HistoryEvent { EventType = HistoryEventType.TaskScheduled, EventId = 2 },
+                new HistoryEvent { 
+                    EventType = HistoryEventType.ExecutionStarted,
+                    EventId = 3,
+                    Version = secondVersion
+                }
+            };
+
+            // Act
+            string result = OrchestrationVersionExtractor.GetVersionFromHistory(historyEvents);
+
+            // Assert
+            Assert.Equal(expectedVersion, result);
+            Assert.NotEqual(secondVersion, result);
+        }
+    }
+}


### PR DESCRIPTION
Add Version property to the `$Context` object passed to orchestrator functions, matching the behavior implemented for .NET in-proc in https://github.com/Azure/azure-functions-durable-extension/pull/3072.

As a result, PowerShell Functions users will be able to specify a version in **host.json**:

``` json
{
  "extensions": {
    "durableTask": {
      "defaultVersion": "2.0"
    }
  }
}
```

and check the orchestration version in their orchestrator functions in order to keep them backward compatible, for example:

``` powershell
if ($Context.Version -eq '1.0') {
    # Legacy code path
    Invoke-DurableActivity 'A'
} elseif ($Context.Version -eq '2.0') {
    # New code path
    Invoke-DurableActivity 'B'
}
```

**Note: Microsoft.Azure.WebJobs.Extensions.DurableTask 3.1.0+ is required for this to work properly.**

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)