### PR TITLE
Add weekly schedule to code mirror

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -7,6 +7,15 @@ trigger:
     - v4.x/*
     - v3.x/*
 
+schedules:
+# Build weekly to ensure the pipeline isn't deactivated.
+- cron: "0 0 1/7 * *"
+  displayName: Weekly sync
+  branches:
+    include:
+    - dev
+  always: true
+
 resources:
   repositories:
   - repository: eng


### PR DESCRIPTION
Adds a weekly schedule to the code mirror job, to prevent it from being disabled automatically

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

