### PR TITLE
Remove top level worker config

### DIFF
--- a/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
+++ b/package/Microsoft.Azure.Functions.PowerShellWorker.nuspec
@@ -27,7 +27,6 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
   </metadata>
   <files>
     <file src="..\src\bin\$configuration$\$targetFramework$\publish\**\*" target="contentFiles\any\any\workers\powershell\7.4" />
-    <file src="..\src\bin\$configuration$\$targetFramework$\publish\worker.config.json" target="contentFiles\any\any\workers\powershell" />
     <file src="..\images\Powershell_black_64.png" target="images\" />
   </files>
 </package>


### PR DESCRIPTION
Remove the top-level worker.config.json from 7.4 worker (we will use the 7.6 worker's going forward)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
