### PR TITLE
Enable external Durable SDK by default

### DIFF
--- a/src/DurableWorker/DurableController.cs
+++ b/src/DurableWorker/DurableController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
         private readonly ILogger _logger;
 
         private bool isExternalDFSdkEnabled { get; } =
-            PowerShellWorkerConfiguration.GetBoolean(Utils.ExternalDurableSdkEnvVariable) ?? false;
+            PowerShellWorkerConfiguration.GetBoolean(Utils.ExternalDurableSdkEnvVariable) ?? true;
 
         public DurableController(
             DurableFunctionInfo durableDurableFunctionInfo,
@@ -69,18 +69,18 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
             {
                 if (isExternalSdkLoaded)
                 {
-                    // Enable external SDK only when customer has opted-in
+                    // Enable external SDK (now true by default)
                     _powerShellServices.EnableExternalDurableSDK();
                 }
                 else
                 {
-                    // Customer attempted to enable external SDK but the module is not in the session. Default to built-in SDK.
-                    _logger.Log(isUserOnlyLog: false, LogLevel.Error, string.Format(PowerShellWorkerStrings.ExternalSDKWasNotLoaded, Utils.ExternalDurableSdkName));
+                    // Customer is configured to use the external SDK but the module is not in the session. Fail with helpful error message.
+                    throw new InvalidOperationException(string.Format(PowerShellWorkerStrings.ExternalSDKWasNotLoaded, Utils.ExternalDurableSdkName, Utils.ExternalDurableSdkEnvVariable));
                 }
             }
             else if (isExternalSdkLoaded)
             {
-                // External SDK is in the session, but customer did not explicitly enable it. Report the potential of runtime errors.
+                // External SDK is in the session, but customer explicitly disabled it. Report the potential of runtime errors.
                 _logger.Log(isUserOnlyLog: false, LogLevel.Error, String.Format(PowerShellWorkerStrings.PotentialDurableSDKClash, Utils.ExternalDurableSdkName, Utils.ExternalDurableSdkEnvVariable));
             }
         }

--- a/src/DurableWorker/DurableController.cs
+++ b/src/DurableWorker/DurableController.cs
@@ -64,6 +64,13 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Durable
 
         private void tryEnablingExternalSDK()
         {
+            // Short-circuit if this is not a durable function
+            // This prevents non-durable functions from failing when external SDK is enabled by default
+            if (_durableFunctionInfo.Type == DurableFunctionType.None && !_durableFunctionInfo.IsDurableClient)
+            {
+                return;
+            }
+
             var isExternalSdkLoaded = _powerShellServices.isExternalDurableSdkLoaded();
             if (isExternalDFSdkEnabled)
             {

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -368,7 +368,7 @@
     <value>Operation '{0}' expected '{1}' result(s) but received '{2}'.</value>
   </data>
   <data name="ExternalSDKWasNotLoaded" xml:space="preserve">
-    <value>The external Durable Functions SDK is enabled but it cannot be used because it was not loaded onto the current PowerShell session. Please add `Import-Module -Name {0} -ErrorAction Stop` to your profile.ps1 so it may be used. Defaulting to built-in SDK.</value>
+    <value>Use of the built-in Durable Functions SDK is disabled by default starting in PowerShell 7.6. Please ensure the {0} module is present and add `Import-Module -Name {0} -ErrorAction Stop` to your profile.ps1 so it may be used, or explicitly opt-in to the built-in SDK using the {1} setting. For more information, see https://aka.ms/durable-powershell-sdk</value>
   </data>
   <data name="MultipleExternalSDKsInSession" xml:space="preserve">
     <value>Get-Module returned '{0}' instances of '{1}' in the PowerShell session, but only 1 or 0 are expected. This may create runtime errors. Please ensure your script only imports a single version of '{0}' in your profile.ps1. The modules currently in session are:\n '{2}'.</value>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -368,7 +368,7 @@
     <value>Operation '{0}' expected '{1}' result(s) but received '{2}'.</value>
   </data>
   <data name="ExternalSDKWasNotLoaded" xml:space="preserve">
-    <value>Use of the built-in Durable Functions SDK is disabled by default starting in PowerShell 7.6. Please ensure the {0} module is present and add `Import-Module -Name {0} -ErrorAction Stop` to your profile.ps1 so it may be used, or explicitly opt-in to the built-in SDK using the {1} setting. For more information, see https://aka.ms/durable-powershell-sdk</value>
+    <value>Use of the built-in Durable Functions SDK is disabled by default starting in PowerShell 7.6. Please ensure the {0} module is present and add `Import-Module -Name {0} -ErrorAction Stop` to your profile.ps1 so it may be used, or explicitly opt-in to the built-in SDK by setting the environment variable '{1}' to "false". For more information, see https://aka.ms/durable-powershell-sdk</value>
   </data>
   <data name="MultipleExternalSDKsInSession" xml:space="preserve">
     <value>Get-Module returned '{0}' instances of '{1}' in the PowerShell session, but only 1 or 0 are expected. This may create runtime errors. Please ensure your script only imports a single version of '{0}' in your profile.ps1. The modules currently in session are:\n '{2}'.</value>

--- a/src/resources/PowerShellWorkerStrings.resx
+++ b/src/resources/PowerShellWorkerStrings.resx
@@ -374,7 +374,7 @@
     <value>Get-Module returned '{0}' instances of '{1}' in the PowerShell session, but only 1 or 0 are expected. This may create runtime errors. Please ensure your script only imports a single version of '{0}' in your profile.ps1. The modules currently in session are:\n '{2}'.</value>
   </data>
   <data name="PotentialDurableSDKClash" xml:space="preserve">
-    <value>The external Durable Functions SDK is not enabled but '{0}' has been imported to the PowerShell session. This may create runtime conflicts between the built-in and external Durable Functions CommandLets. If you mean to use the external Durable Functions SDK, please set the enviroment variable '{1}' to "true"</value>
+    <value>Use of the built-in Durable Functions SDK is enabled by the environment variable '{1}', but '{0}' has also been imported to the PowerShell session. This may create runtime conflicts between the built-in and external Durable Functions cmdlets. If you mean to use the built-in Durable Functions SDK, please remove the '{0}' module. For more information, see https://aka.ms/durable-powershell-sdk</value>
   </data>
   <data name="UtilizingExternalDurableSDK" xml:space="preserve">
     <value>Utilizing external Durable Functions SDK: '{0}'.</value>

--- a/test/Unit/Durable/DurableControllerTests.cs
+++ b/test/Unit/Durable/DurableControllerTests.cs
@@ -264,24 +264,11 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         }
 
         [Theory]
-        [InlineData(DurableFunctionType.None)]
-        [InlineData(DurableFunctionType.OrchestrationFunction)]
+        [InlineData(DurableFunctionType.None)] // Durable client function
+        [InlineData(DurableFunctionType.OrchestrationFunction)] // Orchestration function
         internal void ExternalDurableSdkIsNotConfiguredByDefault(DurableFunctionType durableFunctionType)
         {
-            var durableController = CreateDurableController(durableFunctionType);
-            var inputData = GetDurableBindings(durableFunctionType);
-
-            if (durableFunctionType == DurableFunctionType.None)
-            {
-                _mockPowerShellServices.Setup(_ => _.SetDurableClient(It.IsAny<object>()));
-            }
-            else
-            {
-                _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(
-                    It.IsAny<ParameterBinding>(),
-                    out It.Ref<IExternalOrchestrationInvoker>.IsAny)).Returns(_orchestrationBindingInfo);
-                _mockOrchestrationInvoker.Setup(_ => _.SetExternalInvoker(It.IsAny<IExternalOrchestrationInvoker>()));
-            }
+            var (durableController, inputData) = CreateDurableControllerForTest(durableFunctionType);
 
             _mockPowerShellServices.Setup(_ => _.HasExternalDurableSDK()).Returns(false);
             _mockPowerShellServices.Setup(_ => _.EnableExternalDurableSDK()).Throws(new Exception("should not be called"));
@@ -293,8 +280,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         }
 
         [Theory]
-        [InlineData(DurableFunctionType.None)]
-        [InlineData(DurableFunctionType.OrchestrationFunction)]
+        [InlineData(DurableFunctionType.None)] // Durable client function
+        [InlineData(DurableFunctionType.OrchestrationFunction)] // Orchestration function
         internal void ExternalDurableSdkCanBeEnabled(DurableFunctionType durableFunctionType)
         {
             try
@@ -302,20 +289,7 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                 // opt-in to external DF SDK
                 Environment.SetEnvironmentVariable("ExternalDurablePowerShellSDK", "true");
 
-                var durableController = CreateDurableController(durableFunctionType);
-                var inputData = GetDurableBindings(durableFunctionType);
-
-                if (durableFunctionType == DurableFunctionType.None)
-                {
-                    _mockPowerShellServices.Setup(_ => _.SetDurableClient(It.IsAny<object>()));
-                }
-                else
-                {
-                    _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(
-                        It.IsAny<ParameterBinding>(),
-                        out It.Ref<IExternalOrchestrationInvoker>.IsAny)).Returns(_orchestrationBindingInfo);
-                    _mockOrchestrationInvoker.Setup(_ => _.SetExternalInvoker(It.IsAny<IExternalOrchestrationInvoker>()));
-                }
+                var (durableController, inputData) = CreateDurableControllerForTest(durableFunctionType);
 
                 _mockPowerShellServices.Setup(_ => _.HasExternalDurableSDK()).Returns(true);
                 _mockPowerShellServices.Setup(_ => _.EnableExternalDurableSDK());
@@ -325,6 +299,40 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                 Assert.True(hasExternalSDK);
                 _mockPowerShellServices.Verify(_ => _.EnableExternalDurableSDK(), Times.Once);
 
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ExternalDurablePowerShellSDK", "false");
+            }
+        }
+
+        [Fact]
+        internal void NonDurableFunction_DoesNotFailWhenExternalSDKEnabledByDefault()
+        {
+            try
+            {
+                // Enable external DF SDK by default (the new behavior)
+                Environment.SetEnvironmentVariable("ExternalDurablePowerShellSDK", "true");
+
+                // Create a non-durable function (Type = None, no client binding)
+                var durableController = CreateDurableController(DurableFunctionType.None);
+                var inputData = new[]
+                {
+                    CreateParameterBinding("SomeParameter", "SomeValue")
+                };
+
+                // Set up that HasExternalDurableSDK returns false (called outside of tryEnablingExternalSDK)
+                _mockPowerShellServices.Setup(_ => _.HasExternalDurableSDK()).Returns(false);
+
+                // This should NOT throw even though external SDK is enabled and not loaded
+                // because this is not a durable function
+                durableController.InitializeBindings(inputData, out var hasExternalSDK);
+
+                Assert.False(hasExternalSDK);
+                // Verify that isExternalDurableSdkLoaded was never called due to short-circuit
+                _mockPowerShellServices.Verify(_ => _.isExternalDurableSdkLoaded(), Times.Never);
+                // HasExternalDurableSDK is called at the end of InitializeBindings (outside of tryEnablingExternalSDK)
+                _mockPowerShellServices.Verify(_ => _.HasExternalDurableSDK(), Times.Once);
             }
             finally
             {
@@ -343,6 +351,33 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
                             _mockPowerShellServices.Object,
                             _mockOrchestrationInvoker.Object,
                             _testLogger);
+        }
+
+        /// <summary>
+        /// Helper method to create a DurableController and input data for tests.
+        /// Sets up mocks based on the DurableFunctionType.
+        /// </summary>
+        private (DurableController controller, IList<ParameterBinding> inputData) CreateDurableControllerForTest(DurableFunctionType durableFunctionType)
+        {
+            // Durable client functions use Type.None with a binding name
+            string durableClientBindingName = durableFunctionType == DurableFunctionType.None ? "DurableClientBindingName" : null;
+            
+            var durableController = CreateDurableController(durableFunctionType, durableClientBindingName);
+            var inputData = GetDurableBindings(durableFunctionType);
+
+            if (durableFunctionType == DurableFunctionType.None)
+            {
+                _mockPowerShellServices.Setup(_ => _.SetDurableClient(It.IsAny<object>()));
+            }
+            else
+            {
+                _mockPowerShellServices.Setup(_ => _.SetOrchestrationContext(
+                    It.IsAny<ParameterBinding>(),
+                    out It.Ref<IExternalOrchestrationInvoker>.IsAny)).Returns(_orchestrationBindingInfo);
+                _mockOrchestrationInvoker.Setup(_ => _.SetExternalInvoker(It.IsAny<IExternalOrchestrationInvoker>()));
+            }
+
+            return (durableController, inputData);
         }
 
         private static ParameterBinding CreateParameterBinding(string parameterName, object value)

--- a/test/Unit/Durable/DurableControllerTests.cs
+++ b/test/Unit/Durable/DurableControllerTests.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test.Durable
         private static readonly OrchestrationBindingInfo _orchestrationBindingInfo = new OrchestrationBindingInfo(_contextParameterName, _orchestrationContext);
         private static readonly ILogger _testLogger = new ConsoleLogger();
 
+        static DurableControllerTests()
+        {
+            // Set up environment variable for tests
+            Environment.SetEnvironmentVariable("ExternalDurablePowerShellSDK", "false");
+        }
+
 
         [Fact]
         public void InitializeBindings_SetsDurableClient_ForDurableClientFunction()

--- a/test/Unit/PowerShell/PowerShellManagerTests.cs
+++ b/test/Unit/PowerShell/PowerShellManagerTests.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
         private readonly static List<ParameterBinding> s_testInputData;
 
         static PowerShellManagerTests()
-        {
+        {    
+            // Set up environment variable for tests
+            Environment.SetEnvironmentVariable("ExternalDurablePowerShellSDK", "false");
+
             s_funcDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "TestScripts", "PowerShell");
             s_testLogger = new ConsoleLogger();
             s_testInputData = new List<ParameterBinding>


### PR DESCRIPTION
Enables the external Durable SDK by default - throws an exception if the module is not present and the customer has not opted-out

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
