### PR TITLE
Update feed destination, filter publish step

### DIFF
--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -55,8 +55,13 @@ extends:
           image: 1es-ubuntu-22.04
           os: linux
 
-      - stage: Publish
+      - stage: Build
         dependsOn: [WindowsUnitTests, LinuxUnitTests]
+        jobs:
+          - template: /eng/ci/templates/build.yml@self
+
+      - stage: Publish
+        dependsOn: [Build]
         condition: >-
           and(
             succeeded(),
@@ -77,6 +82,17 @@ extends:
                   notifyUsers: ""
                   instructions: "Approve to publish the NuGet package to the public/infra feed."
 
-          - template: /eng/ci/templates/build.yml@self
-            parameters:
-              dependsOn: ApprovePublish
+          - job: PushNuGet
+            dependsOn: ApprovePublish
+            templateContext:
+              outputs:
+                - output: nuget
+                  packagesToPush: "$(Pipeline.Workspace)/nuget-packages/*.nupkg"
+                  packageParentPath: "$(Pipeline.Workspace)/nuget-packages"
+                  nuGetFeedType: internal
+                  publishVstsFeed: "public/infra"
+                  allowPackageConflicts: true
+            steps:
+              - download: current
+                artifact: nuget-packages
+                displayName: "Download NuGet package from Build stage"

--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -55,7 +55,28 @@ extends:
           image: 1es-ubuntu-22.04
           os: linux
 
-      - stage: Build
+      - stage: Publish
         dependsOn: [WindowsUnitTests, LinuxUnitTests]
+        condition: >-
+          and(
+            succeeded(),
+            ne(variables['Build.Reason'], 'Schedule'),
+            or(
+              eq(variables['Build.Reason'], 'Manual'),
+              startsWith(variables['Build.SourceBranch'], 'refs/heads/v3.x/'),
+              startsWith(variables['Build.SourceBranch'], 'refs/heads/v4.x/')
+            )
+          )
         jobs:
+          - deployment: ApprovePublish
+            environment: nuget-publish  # Configure manual approval on this environment in ADO
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - script: echo "Publish approved"
+                      displayName: "Approval gate"
+
           - template: /eng/ci/templates/build.yml@self
+            parameters:
+              dependsOn: ApprovePublish

--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -68,14 +68,14 @@ extends:
             )
           )
         jobs:
-          - deployment: ApprovePublish
-            environment: nuget-publish  # Configure manual approval on this environment in ADO
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - script: echo "Publish approved"
-                      displayName: "Approval gate"
+          - job: ApprovePublish
+            pool: server
+            steps:
+              - task: ManualValidation@1
+                displayName: "Approve NuGet publish"
+                inputs:
+                  notifyUsers: ""
+                  instructions: "Approve to publish the NuGet package to the public/infra feed."
 
           - template: /eng/ci/templates/build.yml@self
             parameters:

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -5,7 +5,7 @@ jobs:
         - output: nuget
           packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
           packageParentPath: "$(Build.ArtifactStagingDirectory)"
-          nuGetFeedType: public
+          nuGetFeedType: internal
           publishVstsFeed: "public/infra"
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -5,8 +5,8 @@ jobs:
         - output: nuget
           packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
           packageParentPath: "$(Build.ArtifactStagingDirectory)"
-          nuGetFeedType: internal
-          publishVstsFeed: "e6a70c92-4128-439f-8012-382fe78d6396/c0493cce-bc63-4e11-9fc9-e7c45291f151"
+          nuGetFeedType: public
+          publishVstsFeed: "public/infra"
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
           allowPackageConflicts: true

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -1,22 +1,12 @@
-parameters:
-  - name: dependsOn
-    type: string
-    default: ''
-
 jobs:
-  - job: BuildAndPublish
-    ${{ if ne(parameters.dependsOn, '') }}:
-      dependsOn: ${{ parameters.dependsOn }}
+  - job: Build
     templateContext:
       outputs:
-        - output: nuget
-          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
-          packageParentPath: "$(Build.ArtifactStagingDirectory)"
-          nuGetFeedType: internal
-          publishVstsFeed: "public/infra"
+        - output: pipelineArtifact
+          targetPath: "$(Build.ArtifactStagingDirectory)"
+          artifactName: "nuget-packages"
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
-          allowPackageConflicts: true
     steps:
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -1,5 +1,12 @@
+parameters:
+  - name: dependsOn
+    type: string
+    default: ''
+
 jobs:
-  - job:
+  - job: BuildAndPublish
+    ${{ if ne(parameters.dependsOn, '') }}:
+      dependsOn: ${{ parameters.dependsOn }}
     templateContext:
       outputs:
         - output: nuget
@@ -10,13 +17,6 @@ jobs:
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
           allowPackageConflicts: true
-        # - output: nuget
-        #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true))
-        #   packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-        #   packageParentPath: '$(Build.ArtifactStagingDirectory)'
-        #   nuGetFeedType: 'internal'
-        #   publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df' # AzureFunctionsPreRelease feed
-        #   allowPackageConflicts: true
     steps:
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"


### PR DESCRIPTION
Changes the feed destination to the new artifacts feed in public
Also gates the "publish" step behind two conditions - pipeline run is manually triggered, or triggered by a commit to an ADO tracked branch, and a manual approval step, to stop flooding the feed with versions from nightly builds

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
