### PR TITLE
Update feed destination, filter publish step (#1134)

### DIFF
--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -59,3 +59,40 @@ extends:
         dependsOn: [WindowsUnitTests, LinuxUnitTests]
         jobs:
           - template: /eng/ci/templates/build.yml@self
+
+      - stage: Publish
+        dependsOn: [Build]
+        condition: >-
+          and(
+            succeeded(),
+            ne(variables['Build.Reason'], 'Schedule'),
+            or(
+              eq(variables['Build.Reason'], 'Manual'),
+              startsWith(variables['Build.SourceBranch'], 'refs/heads/v3.x/'),
+              startsWith(variables['Build.SourceBranch'], 'refs/heads/v4.x/')
+            )
+          )
+        jobs:
+          - job: ApprovePublish
+            pool: server
+            steps:
+              - task: ManualValidation@1
+                displayName: "Approve NuGet publish"
+                inputs:
+                  notifyUsers: ""
+                  instructions: "Approve to publish the NuGet package to the public/infra feed."
+
+          - job: PushNuGet
+            dependsOn: ApprovePublish
+            templateContext:
+              outputs:
+                - output: nuget
+                  packagesToPush: "$(Pipeline.Workspace)/nuget-packages/*.nupkg"
+                  packageParentPath: "$(Pipeline.Workspace)/nuget-packages"
+                  nuGetFeedType: internal
+                  publishVstsFeed: "public/infra"
+                  allowPackageConflicts: true
+            steps:
+              - download: current
+                artifact: nuget-packages
+                displayName: "Download NuGet package from Build stage"

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -1,22 +1,12 @@
 jobs:
-  - job:
+  - job: Build
     templateContext:
       outputs:
-        - output: nuget
-          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
-          packageParentPath: "$(Build.ArtifactStagingDirectory)"
-          nuGetFeedType: internal
-          publishVstsFeed: "e6a70c92-4128-439f-8012-382fe78d6396/c0493cce-bc63-4e11-9fc9-e7c45291f151"
+        - output: pipelineArtifact
+          targetPath: "$(Build.ArtifactStagingDirectory)"
+          artifactName: "nuget-packages"
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
-          allowPackageConflicts: true
-        # - output: nuget
-        #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true))
-        #   packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-        #   packageParentPath: '$(Build.ArtifactStagingDirectory)'
-        #   nuGetFeedType: 'internal'
-        #   publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df' # AzureFunctionsPreRelease feed
-        #   allowPackageConflicts: true
     steps:
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"


### PR DESCRIPTION
Cherry-picks 15b920d to v4.x/ps7.4 with the build pipeline feed destination change

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
