### PR TITLE
Resolve profile.ps1 without a filtered enumeration to avoid worker termination (#1146)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,2 @@
 * [Durable] Add Version property to $Context
+* Fix worker startup failure on the PowerShell 7.6 (.NET 10) worker for apps without a `profile.ps1`, by resolving the profile path with a direct existence check instead of a filtered directory enumeration (#1146)

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 
 namespace Microsoft.Azure.Functions.PowerShellWorker
@@ -16,6 +15,8 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
     /// </summary>
     internal static class FunctionLoader
     {
+        private const string ProfileFileName = "profile.ps1";
+
         private static readonly Dictionary<string, AzFunctionInfo> LoadedFunctions = new Dictionary<string, AzFunctionInfo>();
 
         internal static string FunctionAppRootPath { get; private set; }
@@ -89,9 +90,56 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
             }
 
             // Resolve the FunctionApp profile path
-            var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
-            var profiles = Directory.EnumerateFiles(FunctionAppRootPath, "profile.ps1", options);
-            FunctionAppProfilePath = profiles.FirstOrDefault();
+            FunctionAppProfilePath = ResolveFunctionAppProfilePath(FunctionAppRootPath);
+        }
+
+        /// <summary>
+        /// Resolve the path to the function app 'profile.ps1', if one exists.
+        /// </summary>
+        /// <remarks>
+        /// The profile file name is fixed and known, so we resolve it with a direct existence
+        /// check rather than a filtered directory enumeration. A filtered
+        /// Directory.EnumerateFiles(root, "profile.ps1", ...).FirstOrDefault() can throw on some
+        /// content-share file systems under .NET 10 (10.0.9 / 10.0.10) when there is no matching
+        /// file: the OS-level filter reports a zero-match as STATUS_OBJECT_NAME_NOT_FOUND, which
+        /// surfaces as "Could not find file 'C:\home\site\wwwroot'." and terminates the worker for
+        /// apps that do not include a profile.ps1. See issues #1146 and #1147.
+        /// File.Exists does not go through the filtered FileSystemEnumerator code path and simply
+        /// returns false when the file is absent.
+        /// </remarks>
+        private static string ResolveFunctionAppProfilePath(string functionAppRootPath)
+        {
+            try
+            {
+                if (!Directory.Exists(functionAppRootPath))
+                {
+                    return null;
+                }
+
+                // Fast path: exact match (case-insensitive on Windows, and the common casing elsewhere).
+                var profilePath = Path.Combine(functionAppRootPath, ProfileFileName);
+                if (File.Exists(profilePath))
+                {
+                    return profilePath;
+                }
+
+                // Fallback: preserve case-insensitive matching on case-sensitive file systems
+                // without relying on an OS-level filtered enumeration.
+                foreach (var file in Directory.EnumerateFiles(functionAppRootPath))
+                {
+                    if (string.Equals(Path.GetFileName(file), ProfileFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return file;
+                    }
+                }
+            }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
+            {
+                // Treat an inability to resolve the profile as "no profile" rather than a
+                // terminating failure. The worker functions correctly without a profile.ps1.
+            }
+
+            return null;
         }
     }
 }

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     return profilePath;
                 }
 
+                // On Windows, File.Exists is already case-insensitive, so if it's not found we can return early.
+                if (OperatingSystem.IsWindows())
+                {
+                    return null;
+                }
+
                 // Fallback: preserve case-insensitive matching on case-sensitive file systems
                 // without relying on an OS-level filtered enumeration.
                 foreach (var file in Directory.EnumerateFiles(functionAppRootPath))

--- a/src/FunctionLoader.cs
+++ b/src/FunctionLoader.cs
@@ -116,21 +116,20 @@ namespace Microsoft.Azure.Functions.PowerShellWorker
                     return null;
                 }
 
-                // Fast path: exact match (case-insensitive on Windows, and the common casing elsewhere).
+                // Fast path: exact-name match. On a case-insensitive file system (the default on
+                // Windows) this also resolves differently-cased names such as "Profile.PS1".
                 var profilePath = Path.Combine(functionAppRootPath, ProfileFileName);
                 if (File.Exists(profilePath))
                 {
                     return profilePath;
                 }
 
-                // On Windows, File.Exists is already case-insensitive, so if it's not found we can return early.
-                if (OperatingSystem.IsWindows())
-                {
-                    return null;
-                }
-
                 // Fallback: preserve case-insensitive matching on case-sensitive file systems
-                // without relying on an OS-level filtered enumeration.
+                // without relying on an OS-level filtered enumeration. This is not Windows-gated:
+                // NTFS supports per-directory case sensitivity, so a case-sensitive directory on
+                // Windows can hold a differently-cased "profile.ps1" that the exact-name File.Exists
+                // check above would miss. Enumerating without a filter is safe from the .NET 10
+                // Directory.EnumerateFiles bug, which only manifests when a search pattern is passed.
                 foreach (var file in Directory.EnumerateFiles(functionAppRootPath))
                 {
                     if (string.Equals(Path.GetFileName(file), ProfileFileName, StringComparison.OrdinalIgnoreCase))

--- a/test/Unit/Function/FunctionLoaderTests.cs
+++ b/test/Unit/Function/FunctionLoaderTests.cs
@@ -321,5 +321,74 @@ namespace Microsoft.Azure.Functions.PowerShellWorker.Test
             Assert.Contains("req", exception.Message);
             Assert.Contains("inputBlob", exception.Message);
         }
+
+        [Fact]
+        public void SetupWellKnownPathsResolvesProfileWhenPresent()
+        {
+            RunInTemporaryFunctionApp(includeProfile: true, profileFileName: "profile.ps1",
+                (functionLoadRequest, appRoot) =>
+                {
+                    FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath: null);
+
+                    Assert.Equal(Path.Combine(appRoot, "profile.ps1"), FunctionLoader.FunctionAppProfilePath);
+                });
+        }
+
+        [Fact]
+        public void SetupWellKnownPathsReturnsNullWhenProfileMissing()
+        {
+            // Regression test for #1146 / #1147: a missing profile.ps1 must not throw
+            // (a filtered Directory.EnumerateFiles could throw on .NET 10 content shares).
+            RunInTemporaryFunctionApp(includeProfile: false, profileFileName: null,
+                (functionLoadRequest, appRoot) =>
+                {
+                    var exception = Record.Exception(
+                        () => FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath: null));
+
+                    Assert.Null(exception);
+                    Assert.Null(FunctionLoader.FunctionAppProfilePath);
+                });
+        }
+
+        [Fact]
+        public void SetupWellKnownPathsResolvesProfileCaseInsensitively()
+        {
+            RunInTemporaryFunctionApp(includeProfile: true, profileFileName: "Profile.PS1",
+                (functionLoadRequest, appRoot) =>
+                {
+                    FunctionLoader.SetupWellKnownPaths(functionLoadRequest, managedDependenciesPath: null);
+
+                    Assert.NotNull(FunctionLoader.FunctionAppProfilePath);
+                    Assert.Equal(
+                        "Profile.PS1",
+                        Path.GetFileName(FunctionLoader.FunctionAppProfilePath),
+                        ignoreCase: true);
+                });
+        }
+
+        private void RunInTemporaryFunctionApp(bool includeProfile, string profileFileName, Action<FunctionLoadRequest, string> test)
+        {
+            var appRoot = Path.Combine(Path.GetTempPath(), "PSWorkerFuncLoaderTests", Guid.NewGuid().ToString("N"));
+            var functionDir = Path.Combine(appRoot, "MyHttpTrigger");
+            Directory.CreateDirectory(functionDir);
+
+            try
+            {
+                if (includeProfile)
+                {
+                    File.WriteAllText(Path.Combine(appRoot, profileFileName), "# test profile");
+                }
+
+                var scriptFileToUse = Path.Join(functionDir, "BasicFuncScript.ps1");
+                var functionLoadRequest = GetFuncLoadRequest(scriptFileToUse, entryPoint: string.Empty);
+                functionLoadRequest.Metadata.Directory = functionDir;
+
+                test(functionLoadRequest, appRoot);
+            }
+            finally
+            {
+                Directory.Delete(appRoot, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Makes `FunctionLoader.SetupWellKnownPaths` resilient so a missing `profile.ps1` can no longer terminate the PowerShell 7.6 (.NET 10) worker. Fixes #1146 (root cause tracked in #1147).

Previously the profile path was resolved with a filtered directory enumeration:

```csharp
var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
var profiles = Directory.EnumerateFiles(FunctionAppRootPath, "profile.ps1", options);
FunctionAppProfilePath = profiles.FirstOrDefault();
```

On .NET 10 (10.0.9 / 10.0.10), `Directory.EnumerateFiles` passes the search pattern to `NtQueryDirectoryFile` as an OS-level filter. On some Azure Files / content-share file system drivers, a **zero-match** filtered query is reported as `STATUS_OBJECT_NAME_NOT_FOUND (0xC0000034)`, which maps to `ERROR_FILE_NOT_FOUND` and throws `FileNotFoundException: "Could not find file 'C:\home\site\wwwroot'."` mid-enumeration. Because the enumeration is lazy, this lands when `FirstOrDefault()` pulls the first entry. `ProcessFunctionLoadRequest` caches it as `_initTerminatingError`, so the worker is terminated for apps that simply don't have a `profile.ps1`.

## Change

- Resolve the fixed, known `profile.ps1` name with a direct `File.Exists(Path.Combine(root, "profile.ps1"))` check, which does not go through the filtered `FileSystemEnumerator` path and returns `false` (not throw) when the file is absent.
- Keep case-insensitive matching on case-sensitive file systems via a guarded, unfiltered fallback enumeration wrapped in `try/catch` (`IOException` / `UnauthorizedAccessException`).
- Guard the root with `Directory.Exists` so a missing/unreadable root yields "no profile" rather than an opaque enumeration exception.

This gives us a **worker-side fix that works on the affected .NET 10 runtimes today**, independent of the platform runtime update tracked in #1147 — so it can ship without waiting on the platform.

## Tests

Added `FunctionLoaderTests` cases:
- resolves `profile.ps1` when present,
- **returns null and does not throw when `profile.ps1` is missing** (regression test for #1146 / #1147),
- resolves case-insensitively (`Profile.PS1`).

All FunctionLoader (21) and PowerShellManager (20) unit tests pass locally; the "no profile" trace path is unchanged.

## Related

- #1146 — resiliency (this PR)
- #1147 — .NET 10 `Directory.EnumerateFiles` root cause (regression in 10.0.9, fixed in 10.0.11) and platform runtime update