### PR TITLE
Update PS SDK to 7.4.18

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,13 +21,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.17" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
-    <PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.17" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -17,8 +17,8 @@ $DotnetSDKVersionRequirements = @{
     }
 
     '8.0' = @{
-        MinimalPatch = '422'
-        DefaultPatch = '422'
+        MinimalPatch = '423'
+        DefaultPatch = '423'
     }
 }
 


### PR DESCRIPTION
## Summary
- update Microsoft.PowerShell.SDK from 7.4.17 to 7.4.18
- require .NET SDK 8.0.423 for builds
- remove redundant System.IO.Packaging and System.Runtime.Caching pins now supplied by the SDK

## Validation
- `./build.ps1 -Clean -Test` (400 tests passed)
- `./Check-CsprojVulnerabilities.ps1 -PrintReport` (no vulnerabilities found)