### PR TITLE
Route NuGet restores through Central Feed Service

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines-e2e-integration-tests.yml
+++ b/azure-pipelines-e2e-integration-tests.yml
@@ -19,6 +19,9 @@ pool:
       - ImageOverride -equals $(imageName)
 
 steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
+
 - task: AzureKeyVault@2
   inputs:
     azureSubscription: 'Simple Batch(0b894477-1614-4c8d-8a9b-a697a24596b8)'

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -8,6 +8,9 @@ jobs:
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -1,6 +1,9 @@
 jobs:
   - job: UnitTests
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 


### PR DESCRIPTION
## Summary
- add a repository-root `NuGet.config` that clears inherited sources and routes NuGet dependencies through the Azure Functions `upstream-public` CFS feed
- authenticate NuGet before restore-capable build and test paths in the shared Azure Pipelines templates
- authenticate the E2E integration pipeline before Functions extension installation and test restore activity
- leave PowerShell Gallery module acquisition and package publishing behavior unchanged

## Validation
- restored all 7 checked-in projects from an isolated empty global package cache using automatic root-config discovery
- confirmed generated assets reference only the CFS NuGet endpoint and no direct NuGet.org/MyGet sources
- ran the repository Release build, publish, pack, and unit tests: 402 passed, 0 failed, 0 skipped
- inspected the generated NuGet package and confirmed feed configuration and credentials are not included