### PR TITLE
Update PS SDK to 7.6.4

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,11 +21,12 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ItemGroup>
         <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.3" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Google.Protobuf" Version="3.30.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,8 +10,9 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -17,8 +17,8 @@ $DotnetSDKVersionRequirements = @{
     }
 
     '10.0' = @{
-        MinimalPatch = '301'
-        DefaultPatch = '301'
+        MinimalPatch = '302'
+        DefaultPatch = '302'
     }
 }
 


### PR DESCRIPTION
### Issue describing the changes in this PR

N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

* Updates `Microsoft.PowerShell.SDK` from 7.6.3 to 7.6.4.
* Updates the required .NET SDK patch to 10.0.302, matching PowerShell 7.6.4.
* Pins `System.Security.Cryptography.Xml` 10.0.10 to avoid high-severity vulnerabilities in the 10.0.6 transitive dependency.
* Clean build and all 402 unit tests pass.
* The vulnerability report finds no vulnerable packages.