### PR TITLE
Extend release approval gate to one day

### DIFF
--- a/eng/ci/official.yml
+++ b/eng/ci/official.yml
@@ -75,9 +75,11 @@ extends:
         jobs:
           - job: ApprovePublish
             pool: server
+            timeoutInMinutes: 1441
             steps:
               - task: ManualValidation@1
                 displayName: "Approve NuGet publish"
+                timeoutInMinutes: 1440
                 inputs:
                   notifyUsers: ""
                   instructions: "Approve to publish the NuGet package to the public/infra feed."


### PR DESCRIPTION
### Issue describing the changes in this PR

N/A

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Extends the NuGet publish approval gate from the Azure Pipelines one-hour defaults to 24 hours. The agentless job gets a one-minute buffer beyond the manual validation timeout so the job cannot expire before the gate.