### PR TITLE
Route PowerShell restores through CFS

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -115,6 +115,28 @@ function Set-CfsRepository {
     }
 }
 
+function Install-CfsModule {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    $maximumAttempts = 4
+    for ($attempt = 1; $attempt -le $maximumAttempts; $attempt++) {
+        try {
+            Install-Module -Name $Name -Repository $CfsRepositoryName -Scope CurrentUser -Force -ErrorAction Stop
+            return
+        } catch {
+            if ($_.FullyQualifiedErrorId -notlike 'NoMatchFoundForCriteria,*' -or $attempt -eq $maximumAttempts) {
+                throw
+            }
+
+            Write-Log -Warning "Module '$Name' is not yet available from CFS. Retrying in 15 seconds..."
+            Start-Sleep -Seconds 15
+        }
+    }
+}
+
 # Bootstrap step
 if ($Bootstrap.IsPresent) {
     Write-Log "Validate and install missing prerequisits for building ..."
@@ -123,11 +145,11 @@ if ($Bootstrap.IsPresent) {
 
     if (-not (Get-Module -Name PSDepend -ListAvailable)) {
         Write-Log -Warning "Module 'PSDepend' is missing. Installing 'PSDepend' ..."
-        Install-Module -Name PSDepend -Repository $CfsRepositoryName -Scope CurrentUser -Force
+        Install-CfsModule -Name PSDepend
     }
     if (-not (Get-Module -Name platyPS -ListAvailable)) {
         Write-Log -Warning "Module 'platyPS' is missing. Installing 'platyPS' ..."
-        Install-Module -Name platyPS -Repository $CfsRepositoryName -Scope CurrentUser -Force
+        Install-CfsModule -Name platyPS
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -37,6 +37,7 @@ Import-Module "$PSScriptRoot/tools/helper.psm1" -Force
 
 $TargetFramework = 'net10.0'
 $PowerShellVersion = '7.6'
+# PowerShellGet requires the NuGet v2 endpoint; CFS proxies PowerShell Gallery through this feed.
 $CfsRepositoryName = 'upstream-public'
 $CfsFeedUri = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v2'
 

--- a/build.ps1
+++ b/build.ps1
@@ -37,6 +37,8 @@ Import-Module "$PSScriptRoot/tools/helper.psm1" -Force
 
 $TargetFramework = 'net10.0'
 $PowerShellVersion = '7.6'
+$CfsRepositoryName = 'upstream-public'
+$CfsFeedUri = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v2'
 
 Write-Log "Build worker version: $PowerShellVersion"
 Write-Log "Target framework: $TargetFramework"
@@ -91,18 +93,40 @@ function Deploy-PowerShellWorker {
     Write-Log "Deployed worker to $powerShellWorkerDir"
 }
 
+function Set-CfsRepository {
+    $repositoryParameters = @{
+        Name = $CfsRepositoryName
+        SourceLocation = $CfsFeedUri
+        InstallationPolicy = 'Trusted'
+    }
+
+    if ($env:SYSTEM_ACCESSTOKEN) {
+        $secureToken = ConvertTo-SecureString $env:SYSTEM_ACCESSTOKEN -AsPlainText -Force
+        $repositoryParameters.Credential = [System.Management.Automation.PSCredential]::new(
+            'AzurePipelines',
+            $secureToken)
+    }
+
+    if (Get-PSRepository -Name $CfsRepositoryName -ErrorAction SilentlyContinue) {
+        Set-PSRepository @repositoryParameters
+    } else {
+        Register-PSRepository @repositoryParameters
+    }
+}
+
 # Bootstrap step
 if ($Bootstrap.IsPresent) {
     Write-Log "Validate and install missing prerequisits for building ..."
     Install-Dotnet
+    Set-CfsRepository
 
     if (-not (Get-Module -Name PSDepend -ListAvailable)) {
         Write-Log -Warning "Module 'PSDepend' is missing. Installing 'PSDepend' ..."
-        Install-Module -Name PSDepend -Scope CurrentUser -Force
+        Install-Module -Name PSDepend -Repository $CfsRepositoryName -Scope CurrentUser -Force
     }
     if (-not (Get-Module -Name platyPS -ListAvailable)) {
         Write-Log -Warning "Module 'platyPS' is missing. Installing 'platyPS' ..."
-        Install-Module -Name platyPS -Scope CurrentUser -Force
+        Install-Module -Name platyPS -Repository $CfsRepositoryName -Scope CurrentUser -Force
     }
 }
 
@@ -136,6 +160,7 @@ if (!$NoBuild.IsPresent) {
         Write-Log -Indent "$($entry.Name) $($entry.Value.Version)"
     }
 
+    Set-CfsRepository
     Invoke-PSDepend -Path $requirements -Force
 
     Write-Log "Deleting fullclr folder from PackageManagement module if the folder exists ..."

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -13,12 +13,16 @@ jobs:
 
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - pwsh: |
           $ErrorActionPreference = "Stop"
 
           ./build.ps1 -Clean -Configuration Release -BuildNumber "$(buildNumber)"
         displayName: "Build worker code"
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - task: CopyFiles@2
         inputs:

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -6,6 +6,8 @@ jobs:
 
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - pwsh: ./Check-CsprojVulnerabilities.ps1
         displayName: "Check for security vulnerabilities"
@@ -15,9 +17,13 @@ jobs:
 
           ./build.ps1 -Clean -Configuration Release
         displayName: "Build worker code"
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - pwsh: ./build.ps1 -NoBuild -Test
         displayName: "Running UnitTest"
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       # - pwsh: ./test/E2E/Start-E2ETest.ps1
       #   env:

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -3,17 +3,29 @@
     'Microsoft.PowerShell.Archive' = @{
         Version = '1.2.5'
         Target = 'src/Modules'
+        Parameters = @{
+            Repository = 'upstream-public'
+        }
     }
     'Microsoft.PowerShell.ThreadJob' = @{
         Version = '2.2.0'
         Target = 'src/Modules'
+        Parameters = @{
+            Repository = 'upstream-public'
+        }
     }
     'PowerShellGet' = @{
         Version = '2.2.5'
         Target = 'src/Modules'
+        Parameters = @{
+            Repository = 'upstream-public'
+        }
     }
     'PackageManagement' = @{
         Version = '1.4.8.1'
         Target = 'src/Modules'
+        Parameters = @{
+            Repository = 'upstream-public'
+        }
     }
 }


### PR DESCRIPTION
## Summary
- register the Azure Functions CFS feed as a PowerShell repository during bootstrap and module restore
- route bootstrap and PSDepend module downloads through the CFS feed
- provide the pipeline access token to every build invocation that accesses the feed

## Validation
- parsed build.ps1 and requirements.psd1 with PowerShell