### PR TITLE
Update PowerShell SDK to 7.4.19

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines-e2e-integration-tests.yml
+++ b/azure-pipelines-e2e-integration-tests.yml
@@ -19,6 +19,9 @@ pool:
       - ImageOverride -equals $(imageName)
 
 steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
+
 - task: AzureKeyVault@2
   inputs:
     azureSubscription: 'Simple Batch(0b894477-1614-4c8d-8a9b-a697a24596b8)'

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -8,6 +8,9 @@ jobs:
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -1,6 +1,9 @@
 jobs:
   - job: UnitTests
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.19" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,7 +1,7 @@
 @{
     # Modules bundled with the PowerShell Language Worker
     'Microsoft.PowerShell.Archive' = @{
-        Version = '1.2.5'
+        Version = '1.2.6'
         Target = 'src/Modules'
     }
     'ThreadJob' = @{

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.19" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -17,8 +17,8 @@ $DotnetSDKVersionRequirements = @{
     }
 
     '8.0' = @{
-        MinimalPatch = '423'
-        DefaultPatch = '423'
+        MinimalPatch = '424'
+        DefaultPatch = '424'
     }
 }
 


### PR DESCRIPTION
## Summary
- update `Microsoft.PowerShell.SDK` to 7.4.19
- require .NET SDK 8.0.424
- bundle `Microsoft.PowerShell.Archive` 1.2.6

## Validation
- `pwsh -c "./build.ps1 -Clean -Test"` (400 tests passed)
- `pwsh -c "./Check-CsprojVulnerabilities.ps1 -PrintReport"` (no vulnerabilities found)