### PR TITLE
Update PS SDK to 7.6.5

### DIFF
--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,12 +21,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ItemGroup>
         <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.5" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Google.Protobuf" Version="3.30.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,7 +1,7 @@
 @{
     # Modules bundled with the PowerShell Language Worker
     'Microsoft.PowerShell.Archive' = @{
-        Version = '1.2.5'
+        Version = '1.2.6'
         Target = 'src/Modules'
     }
     'Microsoft.PowerShell.ThreadJob' = @{

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,9 +10,8 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update `Microsoft.PowerShell.SDK` to 7.6.5
- bundle `Microsoft.PowerShell.Archive` 1.2.6 to match the PowerShell release
- remove the obsolete direct `System.Security.Cryptography.Xml` pin now supplied by the SDK

## Validation
- `pwsh -c "./build.ps1 -Clean -Test"` (405 tests passed)
- `pwsh -c "./Check-CsprojVulnerabilities.ps1 -PrintReport"` (no vulnerabilities found)