### PR TITLE
Merge dev into v4.x/ps7.6 for PowerShell 7.6 release

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines-e2e-integration-tests.yml
+++ b/azure-pipelines-e2e-integration-tests.yml
@@ -19,6 +19,9 @@ pool:
       - ImageOverride -equals $(imageName)
 
 steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
+
 - task: AzureKeyVault@2
   inputs:
     azureSubscription: 'Simple Batch(0b894477-1614-4c8d-8a9b-a697a24596b8)'

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -8,6 +8,9 @@ jobs:
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -1,6 +1,9 @@
 jobs:
   - job: UnitTests
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
+++ b/src/Microsoft.Azure.Functions.PowerShellWorker.csproj
@@ -21,12 +21,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <ItemGroup>
         <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.5" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Google.Protobuf" Version="3.30.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/requirements.psd1
+++ b/src/requirements.psd1
@@ -1,7 +1,7 @@
 @{
     # Modules bundled with the PowerShell Language Worker
     'Microsoft.PowerShell.Archive' = @{
-        Version = '1.2.5'
+        Version = '1.2.6'
         Target = 'src/Modules'
     }
     'Microsoft.PowerShell.ThreadJob' = @{

--- a/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
+++ b/test/Unit/Microsoft.Azure.Functions.PowerShellWorker.Test.csproj
@@ -10,9 +10,8 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Issue describing the changes in this PR

N/A - release branch synchronization.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Fast-forward `v4.x/ps7.6` to the latest `dev` commit for the PowerShell 7.6 worker release. This includes only the two commits currently ahead on `dev`:

* Route NuGet restores through CFS (#1150)
* Update PS SDK to 7.6.5 (#1158)