### PR TITLE
ci: route NuGet restores through CFS feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines-e2e-integration-tests.yml
+++ b/azure-pipelines-e2e-integration-tests.yml
@@ -19,6 +19,9 @@ pool:
       - ImageOverride -equals $(imageName)
 
 steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet feeds'
+
 - task: AzureKeyVault@2
   inputs:
     azureSubscription: 'Simple Batch(0b894477-1614-4c8d-8a9b-a697a24596b8)'

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -8,6 +8,9 @@ jobs:
           sbomPackageName: "Azure Functions PowerShell Worker"
           sbomBuildComponentPath: "$(Build.SourcesDirectory)"
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -1,6 +1,9 @@
 jobs:
   - job: UnitTests
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: "Authenticate NuGet feeds"
+
       - pwsh: ./build.ps1 -NoBuild -Bootstrap
         displayName: "Running ./build.ps1 -NoBuild -Bootstrap"
 


### PR DESCRIPTION
## Summary

Back-ports the CFS NuGet restore fix from `dev` commit `552dfd7` to `v4.x/ps7.6`.

- adds a root `NuGet.config` that clears inherited sources and uses only the `upstream-public` NuGet v3 feed
- adds `NuGetAuthenticate@1` to the build, test, and E2E pipeline templates

## Validation

An authenticated `dotnet restore` of the solution succeeded through the new `NuGet.config` and its sole CFS source.

Pipeline execution and the resulting `PermissiveCFSClean` telemetry cannot be verified until this change runs in Azure DevOps.

## Scope

This change deliberately addresses NuGet only. It does not change PowerShell Gallery restores because `PermissiveCFSClean` does not gate that traffic: build-correlated telemetry for definition 580 found 17 builds passing while emitting 3,284 PowerShell Gallery requests, while zero builds passed after emitting any NuGet request.

Commit `b981583` (`Route PowerShell restores through CFS`) was evaluated and deliberately not ported. The `upstream-public` feed has upstreams for npmjs, NuGet.org, PyPI, and Maven, but not PowerShell Gallery. Authenticated probes confirmed that the required PowerShell module graph is unavailable, including no result for `PSDepend`. Porting that change would therefore make builds fail deterministically during module restore rather than make them compliant. PowerShell Gallery isolation is tracked separately and requires a feed-side change first.